### PR TITLE
Improve strong scaling by enabling additional overlap

### DIFF
--- a/pyfr/backends/base/__init__.py
+++ b/pyfr/backends/base/__init__.py
@@ -8,5 +8,5 @@ from pyfr.backends.base.kernels import (BaseKernelProvider,
                                         NotSuitableError, NullComputeKernel,
                                         NullMPIKernel)
 from pyfr.backends.base.types import (ConstMatrix, Matrix, MatrixBank,
-                                      MatrixBase, MatrixRSlice, Queue, View,
+                                      MatrixBase, MatrixSlice, Queue, View,
                                       XchgMatrix, XchgView)

--- a/pyfr/backends/base/backend.py
+++ b/pyfr/backends/base/backend.py
@@ -130,8 +130,8 @@ class BaseBackend(object):
         return self.matrix_cls(self, ioshape, initval, extent, aliases, tags)
 
     @recordmat
-    def matrix_rslice(self, mat, p, q):
-        return self.matrix_rslice_cls(self, mat, p, q)
+    def matrix_slice(self, mat, ra, rb, ca, cb):
+        return self.matrix_slice_cls(self, mat, ra, rb, ca, cb)
 
     def matrix_bank(self, mats, initbank=0, tags=set()):
         return self.matrix_bank_cls(self, mats, initbank, tags)

--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -96,7 +96,7 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
         # Possible matrix types
         mattypes = (
             self.backend.const_matrix_cls, self.backend.matrix_cls,
-            self.backend.matrix_bank_cls, self.backend.matrix_rslice_cls,
+            self.backend.matrix_bank_cls, self.backend.matrix_slice_cls,
             self.backend.xchg_matrix_cls
         )
 

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -99,6 +99,12 @@ class MatrixBase(object):
 
         return ary
 
+    def slice(self, ra=None, rb=None, ca=None, cb=None):
+        ra, rb = ra or 0, rb or self.nrow
+        ca, cb = ca or 0, cb or self.ncol
+
+        return self.backend.matrix_slice(self, ra, rb, ca, cb)
+
 
 class Matrix(MatrixBase):
     _base_tags = {'dense'}
@@ -121,35 +127,60 @@ class Matrix(MatrixBase):
     def _set(self, ary):
         pass
 
-    def rslice(self, p, q):
-        return self.backend.matrix_rslice(self, p, q)
 
-
-class MatrixRSlice(object):
-    def __init__(self, backend, mat, p, q):
+class MatrixSlice(object):
+    def __init__(self, backend, mat, ra, rb, ca, cb):
         self.backend = backend
         self.parent = mat
+        self.datamap = {}
 
-        if p < 0 or q > mat.nrow or q < p:
+        # Parameter validation
+        if ra < 0 or rb > mat.nrow or rb < ra:
             raise ValueError('Invalid row slice')
+        if ca < 0 or cb > mat.ncol or cb < ca:
+            raise ValueError('Invalid column slice')
+        if ca*mat.itemsize % backend.alignb != 0:
+            raise ValueError('Starting column must conform to backend '
+                             'alignment requirements')
+        if isinstance(mat, MatrixBank) and any('bank' in m.tags for m in mat):
+            raise TypeError('Nested MatrixBank objects can not be sliced')
 
-        self.p, self.q = int(p), int(q)
-        self.nrow, self.ncol = self.q - self.p, mat.ncol
+        self.ra, self.rb = int(ra), int(rb)
+        self.ca, self.cb = int(ca), int(cb)
+        self.nrow, self.ncol = self.rb - self.ra, self.cb - self.ca
         self.dtype, self.itemsize = mat.dtype, mat.itemsize
         self.leaddim, self.pitch = mat.leaddim, mat.pitch
 
-        self.nbytes = self.nrow*self.pitch
         self.traits = (self.nrow, self.ncol, self.leaddim, self.dtype)
-
         self.tags = mat.tags | {'slice'}
+
+        # Only set nbytes for slices which are safe to memcpy
+        if ca == 0 and cb == mat.ncol:
+            self.nbytes = self.nrow*self.pitch
 
     @property
     def basedata(self):
+        if 'bank' in self.tags:
+            raise AttributeError('basedata undefined for banked slices')
+
         return self.parent.basedata
 
     @property
     def offset(self):
-        return self.parent.offset + self.p*self.pitch
+        if 'bank' in self.tags:
+            raise AttributeError('offset undefined for banked slices')
+
+        return self.parent.offset + self.ra*self.pitch + self.ca*self.itemsize
+
+    @property
+    def data(self):
+        try:
+            return self.datamap[self.parent.mid]
+        except KeyError:
+            data = self._init_data(self.parent)
+            self.datamap[self.parent.mid] = data
+
+            return data
 
 
 class ConstMatrix(MatrixBase):
@@ -177,7 +208,7 @@ class MatrixBank(Sequence):
             raise ValueError('Matrices in a bank must share tags')
 
         self.backend = backend
-        self.tags = tags | mats[0].tags
+        self.tags = tags | mats[0].tags | {'bank'}
 
         self._mats = mats
         self._curr_idx = initbank
@@ -192,8 +223,7 @@ class MatrixBank(Sequence):
     def __getattr__(self, attr):
         return getattr(self._curr_mat, attr)
 
-    def rslice(self, p, q):
-        raise RuntimeError('Matrix banks can not be sliced')
+    slice = MatrixBase.slice
 
     @property
     def active(self):
@@ -220,10 +250,11 @@ class View(object):
         self.refdtype = self._mats[0].dtype
 
         # Valid matrix types
-        mattypes = (backend.matrix_cls, backend.matrix_rslice_cls)
+        mattypes = (backend.matrix_cls, backend.matrix_slice_cls)
 
         # Validate the matrices
-        if any(not isinstance(m, mattypes) for m in self._mats):
+        if any(not isinstance(m, mattypes) or 'bank' in m.tags
+               for m in self._mats):
             raise TypeError('Incompatible matrix type for view')
 
         if any(m.basedata != self.basedata for m in self._mats):

--- a/pyfr/backends/cuda/base.py
+++ b/pyfr/backends/cuda/base.py
@@ -59,7 +59,7 @@ class CUDABackend(BaseBackend):
         self.const_matrix_cls = types.CUDAConstMatrix
         self.matrix_cls = types.CUDAMatrix
         self.matrix_bank_cls = types.CUDAMatrixBank
-        self.matrix_rslice_cls = types.CUDAMatrixRSlice
+        self.matrix_slice_cls = types.CUDAMatrixSlice
         self.queue_cls = types.CUDAQueue
         self.view_cls = types.CUDAView
         self.xchg_matrix_cls = types.CUDAXchgMatrix

--- a/pyfr/backends/opencl/base.py
+++ b/pyfr/backends/opencl/base.py
@@ -64,7 +64,7 @@ class OpenCLBackend(BaseBackend):
         self.const_matrix_cls = types.OpenCLConstMatrix
         self.matrix_cls = types.OpenCLMatrix
         self.matrix_bank_cls = types.OpenCLMatrixBank
-        self.matrix_rslice_cls = types.OpenCLMatrixRSlice
+        self.matrix_slice_cls = types.OpenCLMatrixSlice
         self.queue_cls = types.OpenCLQueue
         self.view_cls = types.OpenCLView
         self.xchg_matrix_cls = types.OpenCLXchgMatrix

--- a/pyfr/backends/opencl/types.py
+++ b/pyfr/backends/opencl/types.py
@@ -4,10 +4,15 @@ import numpy as np
 import pyopencl as cl
 
 import pyfr.backends.base as base
-from pyfr.util import lazyprop
 
 
-class OpenCLMatrixBase(base.MatrixBase):
+class _OpenCLMatrixCommon(object):
+    @property
+    def _as_parameter_(self):
+        return self.data.int_ptr
+
+
+class OpenCLMatrixBase(_OpenCLMatrixCommon, base.MatrixBase):
     def onalloc(self, basedata, offset):
         self.basedata = basedata
         self.data = basedata.get_sub_region(offset, self.nbytes)
@@ -38,24 +43,17 @@ class OpenCLMatrixBase(base.MatrixBase):
         # Copy
         cl.enqueue_copy(self.backend.qdflt, self.data, buf)
 
-    @property
-    def _as_parameter_(self):
-        return self.data.int_ptr
-
 
 class OpenCLMatrix(OpenCLMatrixBase, base.Matrix):
     pass
 
 
-class OpenCLMatrixRSlice(base.MatrixRSlice):
-    @lazyprop
-    def data(self):
-        return self.parent.basedata.get_sub_region(self.offset,
-                                                   self.nrow*self.pitch)
+class OpenCLMatrixSlice(_OpenCLMatrixCommon, base.MatrixSlice):
+    def _init_data(self, mat):
+        start = self.ra*self.pitch + self.ca*self.itemsize
+        nbytes = (self.nrow - 1)*self.pitch + self.ncol*self.itemsize
 
-    @property
-    def _as_parameter_(self):
-        return self.data.int_ptr
+        return mat.basedata.get_sub_region(mat.offset + start, nbytes)
 
 
 class OpenCLMatrixBank(base.MatrixBank):

--- a/pyfr/backends/openmp/base.py
+++ b/pyfr/backends/openmp/base.py
@@ -28,7 +28,7 @@ class OpenMPBackend(BaseBackend):
         self.const_matrix_cls = types.OpenMPConstMatrix
         self.matrix_cls = types.OpenMPMatrix
         self.matrix_bank_cls = types.OpenMPMatrixBank
-        self.matrix_rslice_cls = types.OpenMPMatrixRSlice
+        self.matrix_slice_cls = types.OpenMPMatrixSlice
         self.queue_cls = types.OpenMPQueue
         self.view_cls = types.OpenMPView
         self.xchg_matrix_cls = types.OpenMPXchgMatrix

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -37,12 +37,11 @@ class OpenMPMatrix(OpenMPMatrixBase, base.Matrix):
         return self.data
 
 
-class OpenMPMatrixRSlice(base.MatrixRSlice):
-    @lazyprop
-    def data(self):
-        return self.parent.data[self.p:self.q]
+class OpenMPMatrixSlice(base.MatrixSlice):
+    def _init_data(self, mat):
+        return mat.data[self.ra:self.rb, self.ca:self.cb]
 
-    @lazyprop
+    @property
     def _as_parameter_(self):
         return self.data.ctypes.data
 

--- a/pyfr/solvers/aceuler/elements.py
+++ b/pyfr/solvers/aceuler/elements.py
@@ -32,24 +32,24 @@ class BaseACFluidElements(object):
 
 
 class ACEulerElements(BaseACFluidElements, BaseAdvectionElements):
-    def set_backend(self, backend, nscalupts, nonce):
-        super().set_backend(backend, nscalupts, nonce)
+    def set_backend(self, *args, **kwargs):
+        super().set_backend(*args, **kwargs)
 
         # Register our flux kernel
-        backend.pointwise.register('pyfr.solvers.aceuler.kernels.tflux')
+        self._be.pointwise.register('pyfr.solvers.aceuler.kernels.tflux')
 
         # Template parameters for the flux kernel
         tplargs = dict(ndims=self.ndims, nvars=self.nvars,
                        c=self.cfg.items_as('constants', float))
 
         if 'flux' in self.antialias:
-            self.kernels['tdisf'] = lambda: backend.kernel(
+            self.kernels['tdisf'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nqpts, self.neles],
                 u=self._scal_qpts, smats=self.smat_at('qpts'),
                 f=self._vect_qpts
             )
         else:
-            self.kernels['tdisf'] = lambda: backend.kernel(
+            self.kernels['tdisf'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nupts, self.neles],
                 u=self.scal_upts_inb, smats=self.smat_at('upts'),
                 f=self._vect_upts

--- a/pyfr/solvers/acnavstokes/elements.py
+++ b/pyfr/solvers/acnavstokes/elements.py
@@ -6,24 +6,24 @@ from pyfr.solvers.baseadvecdiff import BaseAdvectionDiffusionElements
 
 class ACNavierStokesElements(BaseACFluidElements,
                              BaseAdvectionDiffusionElements):
-    def set_backend(self, backend, nscalupts, nonce):
-        super().set_backend(backend, nscalupts, nonce)
+    def set_backend(self, *args, **kwargs):
+        super().set_backend(*args, **kwargs)
 
         # Register our flux kernel
-        backend.pointwise.register('pyfr.solvers.acnavstokes.kernels.tflux')
+        self._be.pointwise.register('pyfr.solvers.acnavstokes.kernels.tflux')
 
         # Template parameters for the flux kernel
         tplargs = dict(ndims=self.ndims, nvars=self.nvars,
                        c=self.cfg.items_as('constants', float))
 
         if 'flux' in self.antialias:
-            self.kernels['tdisf'] = lambda: backend.kernel(
+            self.kernels['tdisf'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nqpts, self.neles],
                 u=self._scal_qpts, smats=self.smat_at('qpts'),
                 f=self._vect_qpts
             )
         else:
-            self.kernels['tdisf'] = lambda: backend.kernel(
+            self.kernels['tdisf'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nupts, self.neles],
                 u=self.scal_upts_inb, smats=self.smat_at('upts'),
                 f=self._vect_upts

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -112,6 +112,34 @@ class BaseElements(object):
     def _scratch_bufs(self):
         pass
 
+    @property
+    def _ext_int_sides(self):
+        # No elements on a partition boundary
+        if self._intoff == 0:
+            return [('int', self.neles)]
+        # All elements on a partition boundary
+        elif self._intoff >= self.neles:
+            return [('ext', self.neles)]
+        # Mix of elements
+        else:
+            return [('ext', self._intoff), ('int', self.neles - self._intoff)]
+
+    def _slice_mat(self, mat, side, ra=None, rb=None):
+        ix = self._intoff
+
+        # Handle stacked matrices
+        if len(mat.ioshape) >= 3:
+            ix *= mat.ioshape[-2]
+        else:
+            ix = min(ix, mat.ncol)
+
+        if side == 'ext':
+            return mat.slice(ra, rb, 0, ix)
+        elif side == 'int':
+            return mat.slice(ra, rb, ix, mat.ncol)
+        else:
+            raise ValueError('Invalid slice side')
+
     @lazyprop
     def _src_exprs(self):
         convars = self.convarmap[self.ndims]
@@ -133,8 +161,9 @@ class BaseElements(object):
     def _soln_in_src_exprs(self):
         return any(re.search(r'\bu\b', ex) for ex in self._src_exprs)
 
-    def set_backend(self, backend, nscalupts, nonce):
+    def set_backend(self, backend, nscalupts, nonce, intoff):
         self._be = backend
+        self._intoff = intoff - intoff % -backend.soasz
 
         # Sizes
         ndims, nvars, neles = self.ndims, self.nvars, self.neles
@@ -151,8 +180,8 @@ class BaseElements(object):
         # Allocate required scalar scratch space
         if 'scal_fpts' in sbufs and 'scal_qpts' in sbufs:
             self._scal_fqpts = salloc('_scal_fqpts', nfpts + nqpts)
-            self._scal_fpts = self._scal_fqpts.rslice(0, nfpts)
-            self._scal_qpts = self._scal_fqpts.rslice(nfpts, nfpts + nqpts)
+            self._scal_fpts = self._scal_fqpts.slice(0, nfpts)
+            self._scal_qpts = self._scal_fqpts.slice(nfpts, nfpts + nqpts)
         elif 'scal_fpts' in sbufs:
             self._scal_fpts = salloc('scal_fpts', nfpts)
         elif 'scal_qpts' in sbufs:
@@ -190,6 +219,18 @@ class BaseElements(object):
         return self._be.const_matrix(self.basis.opmat(expr),
                                      tags={expr, 'align'})
 
+    def sliceat(fn):
+        @memoize
+        def newfn(self, name, side=None):
+            mat = fn(self, name)
+
+            if side is not None:
+                return self._slice_mat(mat, side)
+            else:
+                return mat
+
+        return newfn
+
     @memoize
     def smat_at_np(self, name):
         smats_mpts, _ = self._smats_djacs_mpts
@@ -201,6 +242,7 @@ class BaseElements(object):
         smats = np.array([m0 @ smat for smat in smats_mpts])
         return smats.reshape(self.ndims, -1, self.ndims, self.neles)
 
+    @sliceat
     @memoize
     def smat_at(self, name):
         return self._be.const_matrix(self.smat_at_np(name), tags={'align'})
@@ -220,6 +262,7 @@ class BaseElements(object):
 
         return 1.0 / djac
 
+    @sliceat
     @memoize
     def rcpdjac_at(self, name):
         return self._be.const_matrix(self.rcpdjac_at_np(name), tags={'align'})
@@ -233,6 +276,7 @@ class BaseElements(object):
 
         return ploc
 
+    @sliceat
     @memoize
     def ploc_at(self, name):
         return self._be.const_matrix(self.ploc_at_np(name), tags={'align'})

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -68,6 +68,19 @@ class BaseSystem(object):
         self._bc_inters = bc_inters
         del bc_inters.elemap
 
+    def _compute_int_offsets(self, rallocs, mesh):
+        lhsprank = rallocs.prank
+        intoffs = defaultdict(lambda: 0)
+
+        for rhsprank in rallocs.prankconn[lhsprank]:
+            interarr = mesh['con_p{0}p{1}'.format(lhsprank, rhsprank)]
+            interarr = interarr[['f0', 'f1']].astype('U4,i4').tolist()
+
+            for etype, eidx in interarr:
+                intoffs[etype] = max(eidx + 1, intoffs[etype])
+
+        return intoffs
+
     def _load_eles(self, rallocs, mesh, initsoln, nregs, nonce):
         basismap = {b.name: b for b in subclasses(BaseShape, just_leaf=True)}
 
@@ -105,8 +118,12 @@ class BaseSystem(object):
         else:
             eles.set_ics_from_cfg()
 
+        # Compute the index of first strictly interior element
+        intoffs = self._compute_int_offsets(rallocs, mesh)
+
         # Allocate these elements on the backend
-        eles.set_backend(self.backend, nregs, nonce)
+        for etype, ele in elemap.items():
+            ele.set_backend(self.backend, nregs, nonce, intoffs[etype])
 
         return eles, elemap
 

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -16,10 +16,11 @@ class BaseAdvectionSystem(BaseSystem):
         self.eles_scal_upts_inb.active = uinbank
         self.eles_scal_upts_outb.active = foutbank
 
-        q1 << kernels['eles', 'disu']()
+        q1 << kernels['eles', 'disu_ext']()
         q1 << kernels['mpiint', 'scal_fpts_pack']()
         runall([q1])
 
+        q1 << kernels['eles', 'disu_int']()
         if ('eles', 'copy_soln') in kernels:
             q1 << kernels['eles', 'copy_soln']()
         q1 << kernels['eles', 'tdisf']()

--- a/pyfr/solvers/baseadvecdiff/elements.py
+++ b/pyfr/solvers/baseadvecdiff/elements.py
@@ -22,44 +22,53 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
 
         return bufs
 
-    def set_backend(self, backend, nscalupts, nonce):
-        super().set_backend(backend, nscalupts, nonce)
+    def set_backend(self, *args, **kwargs):
+        super().set_backend(*args, **kwargs)
+
+        slicem = self._slice_mat
+        kernel = self._be.kernel
+        kernels = self.kernels
 
         # Register pointwise kernels
-        backend.pointwise.register(
+        self._be.pointwise.register(
             'pyfr.solvers.baseadvecdiff.kernels.gradcoru'
         )
 
-        self.kernels['_copy_fpts'] = lambda: backend.kernel(
-            'copy', self._vect_fpts.rslice(0, self.nfpts), self._scal_fpts
+        kernels['_copy_fpts'] = lambda: kernel(
+            'copy', self._vect_fpts.slice(0, self.nfpts), self._scal_fpts
         )
-        self.kernels['tgradpcoru_upts'] = lambda: backend.kernel(
+        kernels['tgradpcoru_upts'] = lambda: kernel(
             'mul', self.opmat('M4 - M6*M0'), self.scal_upts_inb,
             out=self._vect_upts
         )
-        self.kernels['tgradcoru_upts'] = lambda: backend.kernel(
-            'mul', self.opmat('M6'), self._vect_fpts.rslice(0, self.nfpts),
-             out=self._vect_upts, beta=1.0
-        )
-        self.kernels['gradcoru_upts'] = lambda: backend.kernel(
-            'gradcoru', tplargs=dict(ndims=self.ndims, nvars=self.nvars),
-             dims=[self.nupts, self.neles], smats=self.smat_at('upts'),
-             rcpdjac=self.rcpdjac_at('upts'), gradu=self._vect_upts
-        )
 
-        def gradcoru_fpts():
-            nupts, nfpts = self.nupts, self.nfpts
-            vupts, vfpts = self._vect_upts, self._vect_fpts
+        for s, neles in self._ext_int_sides:
+            kernels['tgradcoru_upts_' + s] = lambda s=s: kernel(
+                'mul', self.opmat('M6'),
+                slicem(self._vect_fpts, s, 0, self.nfpts),
+                out=slicem(self._vect_upts, s), beta=1.0
+            )
+            kernels['gradcoru_upts_' + s] = lambda s=s, neles=neles: kernel(
+                'gradcoru', tplargs=dict(ndims=self.ndims, nvars=self.nvars),
+                 dims=[self.nupts, neles],
+                 smats=self.smat_at('upts', s),
+                 rcpdjac=self.rcpdjac_at('upts', s),
+                 gradu=slicem(self._vect_upts, s)
+            )
 
-            # Exploit the block-diagonal form of the operator
-            muls = [backend.kernel('mul', self.opmat('M0'),
-                                   vupts.rslice(i*nupts, (i + 1)*nupts),
-                                   vfpts.rslice(i*nfpts, (i + 1)*nfpts))
-                    for i in range(self.ndims)]
+            def gradcoru_fpts(s=s):
+                nupts, nfpts = self.nupts, self.nfpts
+                vupts, vfpts = self._vect_upts, self._vect_fpts
 
-            return ComputeMetaKernel(muls)
+                # Exploit the block-diagonal form of the operator
+                muls = [kernel('mul', self.opmat('M0'),
+                               slicem(vupts, s, i*nupts, (i + 1)*nupts),
+                               slicem(vfpts, s, i*nfpts, (i + 1)*nfpts))
+                        for i in range(self.ndims)]
 
-        self.kernels['gradcoru_fpts'] = gradcoru_fpts
+                return ComputeMetaKernel(muls)
+
+            kernels['gradcoru_fpts_' + s] = gradcoru_fpts
 
         if 'flux' in self.antialias:
             def gradcoru_qpts():
@@ -67,14 +76,14 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
                 vupts, vqpts = self._vect_upts, self._vect_qpts
 
                 # Exploit the block-diagonal form of the operator
-                muls = [backend.kernel('mul', self.opmat('M7'),
-                                       vupts.rslice(i*nupts, (i + 1)*nupts),
-                                       vqpts.rslice(i*nqpts, (i + 1)*nqpts))
+                muls = [self._be.kernel('mul', self.opmat('M7'),
+                                        vupts.slice(i*nupts, (i + 1)*nupts),
+                                        vqpts.slice(i*nqpts, (i + 1)*nqpts))
                         for i in range(self.ndims)]
 
                 return ComputeMetaKernel(muls)
 
-            self.kernels['gradcoru_qpts'] = gradcoru_qpts
+            kernels['gradcoru_qpts'] = gradcoru_qpts
 
         # Shock capturing
         shock_capturing = self.cfg.get('solver', 'shock-capturing', 'none')
@@ -82,7 +91,7 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
             tags = {'align'}
 
             # Register the kernels
-            backend.pointwise.register(
+            self._be.pointwise.register(
                 'pyfr.solvers.baseadvecdiff.kernels.shocksensor'
             )
 
@@ -101,11 +110,11 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
             )
 
             # Allocate space for the artificial viscosity vector
-            self.artvisc = backend.matrix((1, self.neles),
-                                          extent=nonce + 'artvisc', tags=tags)
+            self.artvisc = self._be.matrix((1, self.neles),
+                                           extent=nonce + 'artvisc', tags=tags)
 
             # Apply the sensor to estimate the required artificial viscosity
-            self.kernels['shocksensor'] = lambda: backend.kernel(
+            kernels['shocksensor'] = lambda: self._be.kernel(
                 'shocksensor', tplargs=tplargs, dims=[self.neles],
                 u=self.scal_upts_inb, artvisc=self.artvisc
             )

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -14,10 +14,11 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         self.eles_scal_upts_inb.active = uinbank
         self.eles_scal_upts_outb.active = foutbank
 
-        q1 << kernels['eles', 'disu']()
+        q1 << kernels['eles', 'disu_ext']()
         q1 << kernels['mpiint', 'scal_fpts_pack']()
         runall([q1])
 
+        q1 << kernels['eles', 'disu_int']()
         if ('eles', 'copy_soln') in kernels:
             q1 << kernels['eles', 'copy_soln']()
         if ('iint', 'copy_fpts') in kernels:
@@ -35,9 +36,9 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         runall([q1, q2])
 
         q1 << kernels['mpiint', 'con_u']()
-        q1 << kernels['eles', 'tgradcoru_upts']()
-        q1 << kernels['eles', 'gradcoru_upts']()
-        q1 << kernels['eles', 'gradcoru_fpts']()
+        q1 << kernels['eles', 'tgradcoru_upts_ext']()
+        q1 << kernels['eles', 'gradcoru_upts_ext']()
+        q1 << kernels['eles', 'gradcoru_fpts_ext']()
         q1 << kernels['mpiint', 'vect_fpts_pack']()
         if ('eles', 'shockvar') in kernels:
             q2 << kernels['mpiint', 'artvisc_fpts_send']()
@@ -46,6 +47,9 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
 
         runall([q1, q2])
 
+        q1 << kernels['eles', 'tgradcoru_upts_int']()
+        q1 << kernels['eles', 'gradcoru_upts_int']()
+        q1 << kernels['eles', 'gradcoru_fpts_int']()
         if ('eles', 'gradcoru_qpts') in kernels:
             q1 << kernels['eles', 'gradcoru_qpts']()
         q1 << kernels['eles', 'tdisf']()

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -51,24 +51,24 @@ class BaseFluidElements(object):
 
 
 class EulerElements(BaseFluidElements, BaseAdvectionElements):
-    def set_backend(self, backend, nscalupts, nonce):
-        super().set_backend(backend, nscalupts, nonce)
+    def set_backend(self, *args, **kwargs):
+        super().set_backend(*args, **kwargs)
 
         # Register our flux kernel
-        backend.pointwise.register('pyfr.solvers.euler.kernels.tflux')
+        self._be.pointwise.register('pyfr.solvers.euler.kernels.tflux')
 
         # Template parameters for the flux kernel
         tplargs = dict(ndims=self.ndims, nvars=self.nvars,
                        c=self.cfg.items_as('constants', float))
 
         if 'flux' in self.antialias:
-            self.kernels['tdisf'] = lambda: backend.kernel(
+            self.kernels['tdisf'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nqpts, self.neles],
                 u=self._scal_qpts, smats=self.smat_at('qpts'),
                 f=self._vect_qpts
             )
         else:
-            self.kernels['tdisf'] = lambda: backend.kernel(
+            self.kernels['tdisf'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nupts, self.neles],
                 u=self.scal_upts_inb, smats=self.smat_at('upts'),
                 f=self._vect_upts

--- a/pyfr/solvers/navstokes/elements.py
+++ b/pyfr/solvers/navstokes/elements.py
@@ -8,9 +8,9 @@ class NavierStokesElements(BaseFluidElements, BaseAdvectionDiffusionElements):
     # Use the density field for shock sensing
     shockvar = 'rho'
 
-    def set_backend(self, backend, nscalupts, nonce):
-        super().set_backend(backend, nscalupts, nonce)
-        backend.pointwise.register('pyfr.solvers.navstokes.kernels.tflux')
+    def set_backend(self, *args, **kwargs):
+        super().set_backend(*args, **kwargs)
+        self._be.pointwise.register('pyfr.solvers.navstokes.kernels.tflux')
 
         shock_capturing = self.cfg.get('solver', 'shock-capturing')
         visc_corr = self.cfg.get('solver', 'viscosity-correction', 'none')
@@ -22,13 +22,13 @@ class NavierStokesElements(BaseFluidElements, BaseAdvectionDiffusionElements):
                        c=self.cfg.items_as('constants', float))
 
         if 'flux' in self.antialias:
-            self.kernels['tdisf'] = lambda: backend.kernel(
+            self.kernels['tdisf'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nqpts, self.neles],
                 u=self._scal_qpts, smats=self.smat_at('qpts'),
                 f=self._vect_qpts, artvisc=self.artvisc
             )
         else:
-            self.kernels['tdisf'] = lambda: backend.kernel(
+            self.kernels['tdisf'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nupts, self.neles],
                 u=self.scal_upts_inb, smats=self.smat_at('upts'),
                 f=self._vect_upts, artvisc=self.artvisc


### PR DESCRIPTION
This PR aims to improve the strong scaling of PyFR.  Specifically, it should improve performance in instances where network bandwidth is a limiting factor.  It accomplishes this by splitting elements into two groups: those whose who have faces which are on the exterior of a partition and everything else.  The elements in the first group are then subject to priority processing which enables us to start MPI send/recv operations sooner.  This allows more time for them to complete.