### PR TITLE
Add operator accuracy testing in arbitrary meshes

### DIFF
--- a/pyfr/tests/defaultpts.cfg
+++ b/pyfr/tests/defaultpts.cfg
@@ -1,0 +1,49 @@
+[solver]
+system = navier-stokes
+order = 1
+
+[solver-interfaces-line]
+flux-pts = gauss-legendre
+quad-deg = 10
+quad-pts = gauss-legendre
+
+[solver-interfaces-tri]
+flux-pts = williams-shunn
+quad-deg = 10
+quad-pts = williams-shunn
+
+[solver-interfaces-quad]
+flux-pts = gauss-legendre
+quad-deg = 10
+quad-pts = gauss-legendre
+
+[solver-elements-tri]
+soln-pts = williams-shunn
+quad-deg = 10
+quad-pts = williams-shunn
+
+[solver-elements-quad]
+soln-pts = gauss-legendre
+quad-deg = 10
+quad-pts = gauss-legendre
+
+
+[solver-elements-hex]
+soln-pts = gauss-legendre
+quad-deg = 10
+quad-pts = gauss-legendre
+
+[solver-elements-tet]
+soln-pts = shunn-ham
+quad-deg = 10
+quad-pts = shunn-ham
+
+[solver-elements-pri]
+soln-pts = williams-shunn~gauss-legendre
+quad-deg = 10
+quad-pts = williams-shunn~gauss-legendre
+
+[solver-elements-pyr]
+soln-pts = gauss-legendre
+quad-deg = 10
+quad-pts = witherden-vincent

--- a/pyfr/tests/test_ele_operators.py
+++ b/pyfr/tests/test_ele_operators.py
@@ -1,0 +1,203 @@
+import numpy as np
+
+from pyfr.inifile import Inifile
+from pyfr.shapes import HexShape
+from pyfr.shapes import BaseShape
+from pyfr.util import subclass_where
+from pyfr.readers.native import NativeReader
+from pyfr.solvers.base import BaseSystem
+
+
+def test_operators(order, cfg, filename):
+    """
+    Tests the interpolation (M0), gradient (M4) and
+    and divergence (M1) operators in a mesh given by
+    filename
+    The parameter order should be integer and
+    it is used to assess the precision of the
+    operators using a polynomial of degree order
+    cfg should be an instance of Inifile which
+    holds the flux and solution points information
+    of the elements of the mesh given by filename
+    """
+
+    # System and elements classes
+    systemscls = subclass_where(
+        BaseSystem, name=cfg.get('solver', 'system')
+    )
+
+    # Read the mesh
+    meshin = NativeReader(filename)
+
+    # For each element type in the mesh
+    for eletype in meshin.keys():
+        # skip non-elements keys
+        eletypes = ['tri', 'quad', 'hex', 'tet', "pri", "pry"]
+        found = [ele in eletype for ele in eletypes]
+        if not any(found):
+            continue
+
+        # Obtain the nodes of the elements
+        mesh = meshin[eletype]
+
+        # Number of dimensions
+        ndim = mesh.shape[-1]
+
+        # Get the shape class
+        name_ele = eletype.split('_')[1]
+        basiscls = subclass_where(BaseShape, name=name_ele)
+
+        # Elements classes
+        elementscls = systemscls.elementscls
+        eles = elementscls(basiscls, mesh, cfg)
+
+        # Work in double precision
+        dtype = np.float64
+
+        # Position of the solution points
+        solptspos = eles.ploc_at_np('upts').astype(dtype).swapaxes(0, 1)
+
+        # Number of solution points
+        nupts = eles.nupts
+
+        # Define the error function used to test the operators
+        # In this case f = (x' + y' + z')^{exponent}
+        # Where exponent = order
+        # and x_i' = x_i + displacement_i
+        # WARNING: we might want to change the basis of
+        # the f function
+        # The displacement is added to avoid
+        # close-to-zero values of f as we are computing
+        # relative errors
+        exponent = order
+        # Compute the displacement to avoid (x, y, z) close to (0, 0, 0)
+        displacement = 1.0 - np.array([pts.min() for pts in solptspos])
+
+        def monomial(pos):
+            return np.sum(pos, axis=0)
+
+        def function(pos, exponent):
+            # Add the displacement
+            displ_pos = pos + displacement[:, np.newaxis, np.newaxis]
+            return monomial(displ_pos)**exponent
+
+        # Compute the error function at the solution points
+        f = function(solptspos, exponent)
+
+        # Test M0 matrix
+        # (interpolation to the flux points)
+
+        # Obtain the flux point positions
+        fptspos = eles.ploc_at_np('fpts').swapaxes(0, 1)
+
+        # Compute the analytical function value at the fpts
+        f_at_fpts = function(fptspos, exponent)
+
+        # Get the m0 operator
+        m0 = eles.basis.m0.astype(dtype)
+
+        # Interpolation from solution points to flux points
+        f_at_fptsnum = m0 @ f
+
+        # Compute the relative error
+        print(eletype, "maximum interpolation relative error",
+              np.max(np.abs(f_at_fpts - f_at_fptsnum)/np.abs(f_at_fpts)))
+
+        # Test the gradient operator M4
+        # \nabla u = J^{-T} \nabla_\xi u
+        # WARNING: we suppose that there is no jump of f
+        # at the flux points. Therefore, we neglect
+        # the influence of the M6 operator
+        # This is only true if all monomials of f
+        # are in the polynomial basis of the element
+
+        # smat represents |J|*J^{-T} at solution points
+        smat = eles.smat_at_np('upts').transpose(2, 0, 1, 3)
+
+        # rcpdjac is |J|^{-1} at solution points
+        rcpdjac = eles.rcpdjac_at_np('upts')
+
+        # Gradient operator M4
+        gradop = eles.basis.m4.astype(dtype)
+
+        # Compute the gradient at upts in the reference frame
+        gradsoln = gradop @ f
+        # gradsoln \in [ndof*3, nCells]
+        gradsoln = gradsoln.reshape(ndim, nupts, 1, -1)
+
+        # Multiply by J^{-T} = |J|^{-1}*|J|*J^{-T} = rcpdjac*smat
+        gradsolnum = np.einsum('ijkl,jkml->mikl', smat*rcpdjac, gradsoln,
+                               dtype=dtype, casting='same_kind')
+
+        # Compute the analytical gradient at the solution points
+        gradsol = exponent*function(solptspos, exponent - 1)
+        gradsol = np.array([gradsol for i in range(ndim)])
+
+        # Compute the error
+        print(eletype, "maximum gradient relative error ",
+              np.max(np.abs(gradsol - gradsolnum[0])/np.abs(gradsol)))
+
+        # Test the Divergence Operator M1
+        # \nabla \cdot \vec{f} = |J|^{-1} \nabla_\xi \cdot |J|*J^{-T} f
+        # WARNING: we suppose that there is no jump of \vec{f}
+        # at the flux points. Therefore, we neglect
+        # the influence of the M3 operator
+        # This is only true if all monomials of f
+        # are contained in the polynomial basis of the element
+
+        # compute the flux
+        # this flux is representative of the
+        # flux of the linear advection equation
+        flux = np.array([f for i in range(ndim)])
+
+        # M1 operator
+        m1 = eles.basis.m1.astype(dtype)
+
+        # compute analytical divergence
+        divflux = ndim*exponent*function(solptspos, exponent - 1)
+
+        # multiply the flux by |J|*J^{-1}
+        # watch out with the indices of the transpose
+        # if you want |J|*J^{-T} use 2, 0 instead of 0, 2
+        smat = eles.smat_at_np('upts').astype(dtype).transpose(0, 2, 1, 3)
+
+        # Evaluate the transformed flux of the solution
+        fluxtrans = np.einsum('ijkl,jkl->ikl', smat, flux,
+                              dtype=dtype, casting='same_kind')
+
+        # reshape the flux to apply m0 to it
+        fluxtrans = fluxtrans.reshape(ndim*nupts, -1)
+
+        # compute the divergence without taking into account
+        # the end points contribution, as the Riemann flux
+        # is equal to the extrapolated points flux value
+        # when using analytical interpolation
+        divfluxnum = m1 @ fluxtrans
+
+        # multiply by the inverse jacobian
+        divfluxnum *= rcpdjac
+
+        # Compute error
+        print(eletype, "maximum divergence operator relative error ",
+              np.max(np.abs(divfluxnum - divflux)/np.abs(divflux)))
+
+
+# Read cfg with default flux and solution points
+cfg = Inifile.load("defaultpts.cfg")
+
+# Mesh filename
+filename = "mesh.pyfrm"
+
+# Orders to be tested
+orders = range(2, 5)
+
+# For each order
+for order in orders:
+    # Update the order in the cfg file
+    cfg.set('solver', 'order', str(order))
+
+    # Test the operators in the mesh
+    print("Testing operators order ", order)
+    test_operators(order, cfg, filename)
+
+    print("\n")


### PR DESCRIPTION
(Pull request related to https://groups.google.com/g/pyfrmailinglist/c/mSFn-Wihs9E/m/9DixJKUoBgAJ)

This commits adds a new test which assesses the accuracy of the `M0` (interpolation), `M1` (divergence) and `M4` (gradient) in arbitrary meshes.

The accuracy is tested by using a test error function 

`f(\vec{x}) = (\sum_i^{ndim} x_i + d_i)^p `

where `d_i `are mesh dependent constants added to ensure that the absolute value of `f` is large enough in every solution and face flux point and `p` is a given exponent equal to the `order` parameter of the input file of `PyFR`. The polynomial basis and the exponent value of `f` are arbitrary choices made by me. Nonetheless, this polynomial is a Taylor polynomial and it allows to analyse the truncation error of the `pth-order` numerical schemes. 

The test reads an arbitrary mesh (hardcoded to the filename `mesh.pyfrm`) and for each element type in the mesh and `p` values \in [2, 4]:

1. Computes the function `f` and `\nabla f` at every solution point and `f` at the flux points
2. Computes the numerical interpolation of `f` at the flux points using the `M0` operator and computes `L_{\infty}` estimator of the interpolation compared to the analytical value of f at the flux points.
3. Computes `\nabla f` at the solution points using the `M4` operator and computes another `L_{\infty}` error of the gradient reconstruction.
4. Computes a flux `\vec{g} = (f, f, .., f)` at the solution points and computes its divergence at the solution points as

`\nabla \cdot \vec{g} = \frac{1}{|J|} \nabla \cdot \left( |J| J^{-1} \vec{g} \right)`

using the `M1` operator and supposing that there is no jump between the Riemann flux and the interpolated flux at the flux points. Of course this hypothesis only holds true if the interpolation is exact. However, as I'm still not too familiar with the connectivity of the flux points of `PyFR` I decided to first present you this small piece of work before extending the tests to take into account the jump functions of the divergence and the gradient at flux points.

Anyway, the error between the analytical divergence and the numerical divergence is intrinsically linked with the truncation error. If the divergence error is close to machine precision, then the scheme truncation error is of order of at least `p + 1`. If the error is much bigger than machine-precision then the scheme is at most order `p` (in my opinion of course, this might be debatable)
Interpolation and gradient error estimation might allow to better debug implementation errors.

To be discussed:

- [ ] Polynomial basis of choice and value of `p` for `f`
- [ ] Flux points communication to take into account the correction functions `g`
- [ ] Which meshes to use? In my test cases I used my own unstructured hex grids and those found in the example files
- [ ] Error output to a vtu file?

Output example for the **euler_vortex_2d** case

```
Testing operators order  2
spt_quad_p0 maximum interpolation relative error 5.11178953453495e-15
spt_quad_p0 maximum gradient relative error  7.533767061294547e-14
spt_quad_p0 maximum divergence operator relative error  1.2301042178224855e-13


Testing operators order  3
spt_quad_p0 maximum interpolation relative error 1.1356189451917017e-14
spt_quad_p0 maximum gradient relative error  1.1656184606596116e-13
spt_quad_p0 maximum divergence operator relative error  3.674811610721228e-13


Testing operators order  4
spt_quad_p0 maximum interpolation relative error 1.716970697203502e-14
spt_quad_p0 maximum gradient relative error  2.3198213547740715e-13
spt_quad_p0 maximum divergence operator relative error  1.0016005709243168e-12
```


Output example for the **inc_cylinder_2d** case

```
Testing operators order  2
spt_quad_p0 maximum interpolation relative error 0.0001032457627141232
spt_quad_p0 maximum gradient relative error  0.0029017278477043384
spt_quad_p0 maximum divergence operator relative error  0.07670678831044128
spt_tri_p0 maximum interpolation relative error 3.957602354921139e-06
spt_tri_p0 maximum gradient relative error  0.0006800297101648604
spt_tri_p0 maximum divergence operator relative error  0.002641918633714025


Testing operators order  3
spt_quad_p0 maximum interpolation relative error 1.29947061211108e-05
spt_quad_p0 maximum gradient relative error  0.0003194182156228099
spt_quad_p0 maximum divergence operator relative error  0.004225914769437806
spt_tri_p0 maximum interpolation relative error 3.1607887415340905e-07
spt_tri_p0 maximum gradient relative error  8.484259861051753e-05
spt_tri_p0 maximum divergence operator relative error  5.943471317610819e-05


Testing operators order  4
spt_quad_p0 maximum interpolation relative error 8.321370534623623e-07
spt_quad_p0 maximum gradient relative error  2.6389933518268598e-05
spt_quad_p0 maximum divergence operator relative error  0.00031723288251600014
spt_tri_p0 maximum interpolation relative error 5.225156445014801e-09
spt_tri_p0 maximum gradient relative error  1.0125976968227576e-06
spt_tri_p0 maximum divergence operator relative error  2.57744044942845e-06
```

Output example for my **unstructured hex mesh**

```
Testing operators order  2
spt_hex_p0 maximum interpolation relative error 1.3142943320865548e-15
spt_hex_p0 maximum gradient relative error  6.267405249010482e-13
spt_hex_p0 maximum divergence operator relative error  0.0017013088639230714


Testing operators order  3
spt_hex_p0 maximum interpolation relative error 1.950635671055735e-15
spt_hex_p0 maximum gradient relative error  2.925722311599068e-12
spt_hex_p0 maximum divergence operator relative error  1.0813035486432548e-05


Testing operators order  4
spt_hex_p0 maximum interpolation relative error 3.1326661468742096e-15
spt_hex_p0 maximum gradient relative error  8.359706038353391e-12
spt_hex_p0 maximum divergence operator relative error  8.763873932640072e-08
```
PD: I linted the code using PEP8 as I have seen that this is the standard used in your code. Variables names might not be very consistent with those of your code base. If you wish to change them just let me know.