### PR TITLE
 Separate out linear elements from curved elements. 

### DIFF
--- a/pyfr/backends/base/generator.py
+++ b/pyfr/backends/base/generator.py
@@ -11,15 +11,17 @@ class Arg(object):
     def __init__(self, name, spec, body):
         self.name = name
 
-        specptn = (r'(?:(in|inout|out)\s+)?'                # Intent
-                   r'(?:(broadcast|mpi|scalar|view)\s+)?'   # Attrs
-                   r'([A-Za-z_]\w*)'                        # Data type
-                   r'((?:\[\d+\]){0,2})$')                  # Dimensions
+        specptn = r'''
+            (?:(in|inout|out)\s+)?                            # Intent
+            (?:(broadcast(?:-row|-col)?|mpi|scalar|view)\s+)? # Attrs
+            ([A-Za-z_]\w*)                                    # Data type
+            ((?:\[\d+\]){0,2})$                               # Dimensions
+        '''
         dimsptn = r'(?<=\[)\d+(?=\])'
         usedptn = r'(?:[^A-Za-z]|^){0}[^A-Za-z0-9]'.format(name)
 
         # Parse our specification
-        m = re.match(specptn, spec)
+        m = re.match(specptn, spec, re.X)
         if not m:
             raise ValueError('Invalid argument specification')
 
@@ -35,16 +37,22 @@ class Arg(object):
         self.ncdim = len(self.cdims)
 
         # Attributes
-        self.isbroadcast = 'broadcast' in self.attrs
-        self.ismpi = 'mpi' in self.attrs
+        self.isbroadcast = self.attrs == 'broadcast'
+        self.isbroadcastr = self.attrs == 'broadcast-row'
+        self.isbroadcastc = self.attrs == 'broadcast-col'
+        self.ismpi = self.attrs == 'mpi'
         self.isused = bool(re.search(usedptn, body))
-        self.isview = 'view' in self.attrs
-        self.isscalar = 'scalar' in self.attrs
-        self.isvector = 'scalar' not in self.attrs
+        self.isview = self.attrs == 'view'
+        self.isscalar = self.attrs == 'scalar'
+        self.isvector = not self.isscalar
 
         # Validation
-        if self.isbroadcast and self.intent != 'in':
-            raise ValueError('Broadcast arguments must be of intent in')
+        if self.attrs.startswith('broadcast') and self.intent != 'in':
+             raise ValueError('Broadcast arguments must be of intent in')
+        if self.isbroadcastr and self.ncdim != 1:
+            raise ValueError('Row broadcasts must have one dimension')
+        if self.isbroadcastc and self.ncdim != 2:
+            raise ValueError('Column broadcasts must have two dimensions')
         if self.isscalar and self.dtype != 'fpdtype_t':
             raise ValueError('Scalar arguments must be of type fpdtype_t')
 
@@ -167,19 +175,26 @@ class BaseKernelGenerator(object):
         # Matrix:
         #   name => name_v[ldim*_y + X_IDX]
         elif arg.ncdim == 0:
-            ix = 'ld{0}*_y + X_IDX'.format(arg.name)
+            ix = f'ld{arg.name}*_y + X_IDX'
+        # Row broacast matrix
+        #   name[\1] => name_v[ldim*_y + \1]
+        elif arg.isbroadcastr:
+            ix = fr'ld{arg.name}*_y + \1'
         # Stacked matrix:
         #   name[\1] => name_v[ldim*_y + X_IDX_AOSOA(\1, nv)]
         elif arg.ncdim == 1:
-            ix = (r'ld{0}*_y + X_IDX_AOSOA(\1, {1})'
-                   .format(arg.name, arg.cdims[0]))
+            ix = fr'ld{arg.name}*_y + X_IDX_AOSOA(\1, {arg.cdims[0]})'
+        # Column broadcast matrix
+        #   name[\1][\2] => name_v[ldim*\1 + X_IDX_AOSOA(\2, nv)]
+        elif arg.isbroadcastc:
+            ix = fr'ld{arg.name}*\1 + X_IDX_AOSOA(\2, {arg.cdims[1]})'
         # Doubly stacked matrix:
         #   name[\1][\2] => name_v[((\1)*ny + _y)*ldim + X_IDX_AOSOA(\2, nv)]
         else:
-            ix = (r'((\1)*_ny + _y)*ld{0} + X_IDX_AOSOA(\2, {1})'
-                   .format(arg.name, arg.cdims[1]))
+            ix = (fr'((\1)*_ny + _y)*ld{arg.name} + '
+                  fr'X_IDX_AOSOA(\2, {arg.cdims[1]})')
 
-        return '{0}_v[{1}]'.format(arg.name, ix)
+        return f'{arg.name}_v[{ix}]'
 
     def _render_body(self, body):
         bmch = r'\[({0})\]'.format(match_paired_paren('[]'))

--- a/pyfr/backends/cuda/generator.py
+++ b/pyfr/backends/cuda/generator.py
@@ -12,9 +12,8 @@ class CUDAKernelGenerator(BaseKernelGenerator):
             self._ix = 'int _x = blockIdx.x*blockDim.x + threadIdx.x;'
             self._limits = 'if (_x < _nx)'
         else:
-            self._ix = ('int _x = blockIdx.x*blockDim.x + threadIdx.x;'
-                        'int _y = blockIdx.y*blockDim.y + threadIdx.y;')
-            self._limits = 'if (_x < _nx && _y < _ny)'
+            self._ix = 'int _x = blockIdx.x*blockDim.x + threadIdx.x;'
+            self._limits = 'for (int _y = 0; _x < _nx && _y < _ny; _y++)'
 
     def render(self):
         # Kernel spec

--- a/pyfr/backends/cuda/generator.py
+++ b/pyfr/backends/cuda/generator.py
@@ -9,32 +9,25 @@ class CUDAKernelGenerator(BaseKernelGenerator):
 
         # Specialise
         if self.ndim == 1:
-            self._ix = 'int _x = blockIdx.x*blockDim.x + threadIdx.x;'
             self._limits = 'if (_x < _nx)'
         else:
-            self._ix = 'int _x = blockIdx.x*blockDim.x + threadIdx.x;'
             self._limits = 'for (int _y = 0; _x < _nx && _y < _ny; _y++)'
 
     def render(self):
-        # Kernel spec
         spec = self._render_spec()
 
-        # Iteration indicies and limits
-        ix, limits = self._ix, self._limits
-
-        # Combine
-        return '''{spec}
+        return f'''{spec}
                {{
-                   {ix}
+                   int _x = blockIdx.x*blockDim.x + threadIdx.x;
                    #define X_IDX (_x)
                    #define X_IDX_AOSOA(v, nv) SOA_IX(X_IDX, v, nv)
-                   {limits}
+                   {self._limits}
                    {{
-                       {body}
+                       {self.body}
                    }}
                    #undef X_IDX
                    #undef X_IDX_AOSOA
-               }}'''.format(spec=spec, ix=ix, limits=limits, body=self.body)
+               }}'''
 
     def _render_spec(self):
         # We first need the argument list; starting with the dimensions

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -31,8 +31,7 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
         if len(dims) == 1:
             block = (cfg.getint('backend-cuda', 'block-1d', '64'), 1, 1)
         else:
-            block = cfg.getliteral('backend-cuda', 'block-2d', '128, 1')
-            block += (1,)
+            block = (cfg.getint('backend-cuda', 'block-2d', '128'), 1, 1)
 
         # Use this to compute the grid size
         grid = get_grid_for_block(block, *dims[::-1])

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -34,7 +34,7 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
             block = (cfg.getint('backend-cuda', 'block-2d', '128'), 1, 1)
 
         # Use this to compute the grid size
-        grid = get_grid_for_block(block, *dims[::-1])
+        grid = get_grid_for_block(block, dims[-1])
 
         class PointwiseKernel(ComputeKernel):
             if any(isinstance(arg, str) for arg in arglst):

--- a/pyfr/backends/hip/generator.py
+++ b/pyfr/backends/hip/generator.py
@@ -16,24 +16,18 @@ class HIPKernelGenerator(BaseKernelGenerator):
         else:
             self._ix = (
                 'int _x = hipBlockIdx_x*hipBlockDim_x + hipThreadIdx_x;'
-                'int _y = hipBlockIdx_y*hipBlockDim_y + hipThreadIdx_y;'
             )
-            self._limits = 'if (_x < _nx && _y < _ny)'
+            self._limits = 'for (int _y = 0; _x < _nx && _y < _ny; _y++)'
 
     def render(self):
-        # Kernel spec
         spec = self._render_spec()
 
-        # Iteration indicies and limits
-        ix, limits = self._ix, self._limits
-
-        # Combine
         return f'''{spec}
                {{
-                   {ix}
+                   {self._ix}
                    #define X_IDX (_x)
                    #define X_IDX_AOSOA(v, nv) SOA_IX(X_IDX, v, nv)
-                   {limits}
+                   {self._limits}
                    {{
                        {self.body}
                    }}

--- a/pyfr/backends/hip/generator.py
+++ b/pyfr/backends/hip/generator.py
@@ -9,14 +9,8 @@ class HIPKernelGenerator(BaseKernelGenerator):
 
         # Specialise
         if self.ndim == 1:
-            self._ix = (
-                'int _x = hipBlockIdx_x*hipBlockDim_x + hipThreadIdx_x;'
-            )
             self._limits = 'if (_x < _nx)'
         else:
-            self._ix = (
-                'int _x = hipBlockIdx_x*hipBlockDim_x + hipThreadIdx_x;'
-            )
             self._limits = 'for (int _y = 0; _x < _nx && _y < _ny; _y++)'
 
     def render(self):
@@ -24,7 +18,7 @@ class HIPKernelGenerator(BaseKernelGenerator):
 
         return f'''{spec}
                {{
-                   {self._ix}
+                   int _x = hipBlockIdx_x*hipBlockDim_x + hipThreadIdx_x;
                    #define X_IDX (_x)
                    #define X_IDX_AOSOA(v, nv) SOA_IX(X_IDX, v, nv)
                    {self._limits}

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -30,11 +30,10 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
         if len(dims) == 1:
             block = (cfg.getint('backend-hip', 'block-1d', '64'), 1, 1)
         else:
-            block = cfg.getliteral('backend-hip', 'block-2d', '128, 1')
-            block += (1,)
+            block = (cfg.getint('backend-hip', 'block-2d', '128'), 1, 1)
 
         # Use this to compute the grid size
-        grid = get_grid_for_block(block, *dims[::-1])
+        grid = get_grid_for_block(block, dims[-1])
 
         class PointwiseKernel(ComputeKernel):
             if any(isinstance(arg, str) for arg in arglst):

--- a/pyfr/backends/opencl/generator.py
+++ b/pyfr/backends/opencl/generator.py
@@ -12,8 +12,8 @@ class OpenCLKernelGenerator(BaseKernelGenerator):
             self._ix = 'int _x = get_global_id(0);'
             self._limits = 'if (_x < _nx)'
         else:
-            self._ix = 'int _x = get_global_id(0), _y = get_global_id(1);'
-            self._limits = 'if (_x < _nx && _y < _ny)'
+            self._ix = 'int _x = get_global_id(0);'
+            self._limits = 'for (int _y = 0; _x < _nx && _y < _ny; _y++)'
 
     def render(self):
         # Kernel spec

--- a/pyfr/backends/opencl/generator.py
+++ b/pyfr/backends/opencl/generator.py
@@ -9,32 +9,25 @@ class OpenCLKernelGenerator(BaseKernelGenerator):
 
         # Specialise
         if self.ndim == 1:
-            self._ix = 'int _x = get_global_id(0);'
             self._limits = 'if (_x < _nx)'
         else:
-            self._ix = 'int _x = get_global_id(0);'
             self._limits = 'for (int _y = 0; _x < _nx && _y < _ny; _y++)'
 
     def render(self):
-        # Kernel spec
         spec = self._render_spec()
 
-        # Iteration indicies and limits
-        ix, limits = self._ix, self._limits
-
-        # Combine
-        return '''{spec}
+        return f'''{spec}
                {{
-                   {ix}
+                   int _x = get_global_id(0);
                    #define X_IDX (_x)
                    #define X_IDX_AOSOA(v, nv) SOA_IX(X_IDX, v, nv)
-                   {limits}
+                   {self._limits}
                    {{
-                       {body}
+                       {self.body}
                    }}
                    #undef X_IDX
                    #undef X_IDX_AOSOA
-               }}'''.format(spec=spec, ix=ix, limits=limits, body=self.body)
+               }}'''
 
     def _render_spec(self):
         # We first need the argument list; starting with the dimensions

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -37,7 +37,7 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
         if len(dims) == 1:
             ls = (cfg.getint('backend-opencl', 'local-size-1d', '64'),)
         else:
-            ls = (cfg.getint('backend-opencl', 'local-size-2d', '128'), 1)
+            ls = (cfg.getint('backend-opencl', 'local-size-2d', '128'),)
 
         # Global work size
         gs = tuple(gi - gi % -li for gi, li in zip(dims[::-1], ls))

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -37,7 +37,7 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
         if len(dims) == 1:
             ls = (cfg.getint('backend-opencl', 'local-size-1d', '64'),)
         else:
-            ls = cfg.getliteral('backend-opencl', 'local-size-2d', '128, 1')
+            ls = (cfg.getint('backend-opencl', 'local-size-2d', '128'), 1)
 
         # Global work size
         gs = tuple(gi - gi % -li for gi, li in zip(dims[::-1], ls))

--- a/pyfr/backends/openmp/generator.py
+++ b/pyfr/backends/openmp/generator.py
@@ -7,9 +7,6 @@ class OpenMPKernelGenerator(BaseKernelGenerator):
     def render(self):
         if self.ndim == 1:
             inner = '''
-                    int cb, ce;
-                    loop_sched_1d(_nx, align, &cb, &ce);
-                    int nci = ((ce - cb) / SOA_SZ)*SOA_SZ;
                     for (int _xi = cb; _xi < cb + nci; _xi += SOA_SZ)
                     {{
                         #pragma omp simd
@@ -24,12 +21,9 @@ class OpenMPKernelGenerator(BaseKernelGenerator):
                     }}'''.format(body=self.body)
         else:
             inner = '''
-                    int rb, re, cb, ce;
-                    loop_sched_2d(_ny, _nx, align, &rb, &re, &cb, &ce);
-                    int nci = ((ce - cb) / SOA_SZ)*SOA_SZ;
-                    for (int _y = rb; _y < re; _y++)
+                    for (int _xi = cb; _xi < cb + nci; _xi += SOA_SZ)
                     {{
-                        for (int _xi = cb; _xi < cb + nci; _xi += SOA_SZ)
+                        for (int _y = 0; _y < _ny; _y++)
                         {{
                             #pragma omp simd
                             for (int _xj = 0; _xj < SOA_SZ; _xj++)
@@ -37,8 +31,10 @@ class OpenMPKernelGenerator(BaseKernelGenerator):
                                 {body}
                             }}
                         }}
-                        for (int _xi = cb + nci, _xj = 0; _xj < ce - _xi;
-                             _xj++)
+                    }}
+                    for (int _xi = cb + nci, _xj = 0; _xj < ce - _xi; _xj++)
+                    {{
+                        for (int _y = 0; _y < _ny; _y++)
                         {{
                             {body}
                         }}
@@ -52,6 +48,9 @@ class OpenMPKernelGenerator(BaseKernelGenerator):
                    int align = PYFR_ALIGN_BYTES / sizeof(fpdtype_t);
                    #pragma omp parallel
                    {{
+                       int cb, ce;
+                       loop_sched_1d(_nx, align, &cb, &ce);
+                       int nci = ((ce - cb) / SOA_SZ)*SOA_SZ;
                        {inner}
                    }}
                    #undef X_IDX

--- a/pyfr/shapes.py
+++ b/pyfr/shapes.py
@@ -277,6 +277,10 @@ class BaseShape(object):
         return self.std_ele(self.nsptsord - 1)
 
     @lazyprop
+    def linspts(self):
+        return self.std_ele(1)
+
+    @lazyprop
     def facebases(self):
         fb = {}
 
@@ -340,6 +344,18 @@ class QuadShape(TensorProdShape, BaseShape):
         ('line', lambda s: (-1, s), (-1, 0)),
     ]
 
+    # Jacobian expressions for a linear element
+    jac_exprs = [
+        ['((1 - x[1])*V[1][0] - (x[1] + 1)*V[2][0] +'
+         ' (x[1] - 1)*V[0][0] + (x[1] + 1)*V[3][0])/4',
+         '((1 - x[1])*V[1][1] - (x[1] + 1)*V[2][1] +'
+         ' (x[1] - 1)*V[0][1] + (x[1] + 1)*V[3][1])/4'],
+        ['((1 - x[0])*V[2][0] - (x[0] + 1)*V[1][0] +'
+         ' (x[0] - 1)*V[0][0] + (x[0] + 1)*V[3][0])/4',
+         '((1 - x[0])*V[2][1] - (x[0] + 1)*V[1][1] +'
+         ' (x[0] - 1)*V[0][1] + (x[0] + 1)*V[3][1])/4']
+    ]
+
 
 class HexShape(TensorProdShape, BaseShape):
     name = 'hex'
@@ -359,6 +375,37 @@ class HexShape(TensorProdShape, BaseShape):
         ('quad', lambda s, t: (s, t, 1), (0, 0, 1)),
     ]
 
+    # Jacobian expressions for a linear element
+    jac_exprs = [
+        [f'((-x[1]*x[2] + x[1] + x[2] - 1)*V[0][{i}] +'
+         f' ( x[1]*x[2] - x[1] - x[2] + 1)*V[1][{i}] +'
+         f' ( x[1]*x[2] - x[1] + x[2] - 1)*V[2][{i}] +'
+         f' (-x[1]*x[2] + x[1] - x[2] + 1)*V[3][{i}] +'
+         f' ( x[1]*x[2] + x[1] - x[2] - 1)*V[4][{i}] +'
+         f' (-x[1]*x[2] - x[1] + x[2] + 1)*V[5][{i}] +'
+         f' (-x[1]*x[2] - x[1] - x[2] - 1)*V[6][{i}] +'
+         f' ( x[1]*x[2] + x[1] + x[2] + 1)*V[7][{i}])/8'
+         for i in range(3)],
+        [f'((-x[0]*x[2] + x[0] + x[2] - 1)*V[0][{i}] +'
+         f' ( x[0]*x[2] - x[0] + x[2] - 1)*V[1][{i}] +'
+         f' ( x[0]*x[2] - x[0] - x[2] + 1)*V[2][{i}] +'
+         f' (-x[0]*x[2] + x[0] - x[2] + 1)*V[3][{i}] +'
+         f' ( x[0]*x[2] + x[0] - x[2] - 1)*V[4][{i}] +'
+         f' (-x[0]*x[2] - x[0] - x[2] - 1)*V[5][{i}] +'
+         f' (-x[0]*x[2] - x[0] + x[2] + 1)*V[6][{i}] +'
+         f' ( x[0]*x[2] + x[0] + x[2] + 1)*V[7][{i}])/8'
+         for i in range(3)],
+        [f'((-x[0]*x[1] + x[0] + x[1] - 1)*V[0][{i}] +'
+         f' ( x[0]*x[1] - x[0] + x[1] - 1)*V[1][{i}] +'
+         f' ( x[0]*x[1] + x[0] - x[1] - 1)*V[2][{i}] +'
+         f' (-x[0]*x[1] - x[0] - x[1] - 1)*V[3][{i}] +'
+         f' ( x[0]*x[1] - x[0] - x[1] + 1)*V[4][{i}] +'
+         f' (-x[0]*x[1] + x[0] - x[1] + 1)*V[5][{i}] +'
+         f' (-x[0]*x[1] - x[0] + x[1] + 1)*V[6][{i}] +'
+         f' ( x[0]*x[1] + x[0] + x[1] + 1)*V[7][{i}])/8'
+         for i in range(3)]
+    ]
+
 
 class TriShape(BaseShape):
     name = 'tri'
@@ -373,6 +420,12 @@ class TriShape(BaseShape):
         ('line', lambda s: (s, -1), (0, -1)),
         ('line', lambda s: (-s, s), (1, 1)),
         ('line', lambda s: (-1, s), (-1, 0)),
+    ]
+
+    # Jacobian expressions for a linear element
+    jac_exprs = [
+        [f'(V[{i + 1}][{j}] - V[0][{j}])/2' for j in range(2)]
+        for i in range(2)
     ]
 
     @classmethod
@@ -398,6 +451,12 @@ class TetShape(BaseShape):
         ('tri', lambda s, t: (s, -1, t), (0, -1, 0)),
         ('tri', lambda s, t: (-1, t, s), (-1, 0, 0)),
         ('tri', lambda s, t: (s, t, -s - t - 1), (1, 1, 1)),
+    ]
+
+    # Jacobian expressions for a linear element
+    jac_exprs = [
+        [f'(V[{i + 1}][{j}] - V[0][{j}])/2' for j in range(3)]
+        for i in range(3)
     ]
 
     @classmethod
@@ -427,6 +486,20 @@ class PriShape(BaseShape):
         ('quad', lambda s, t: (-1, s, t), (-1, 0, 0)),
     ]
 
+    # Jacobian expressions for a linear element
+    _jac_exprs_xy = [
+        [f'((x[2] - 1)*V[0, {j}] + (1 - x[2])*V[{i + 1}, {j}] -'
+         f' (x[2] + 1)*V[3, {j}] + (x[2] + 1)*V[{i + 4}, {j}])/4'
+         for j in range(3)]
+        for i in range(2)
+    ]
+    _jac_exprs_z = [[f'((x[0] + 1)*V[4][{j}] + (x[0] + x[1])*V[0][{j}] -'
+                     f' (x[0] + 1)*V[1][{j}] - (x[0] + x[1])*V[3][{j}] -'
+                     f' (x[1] + 1)*V[2][{j}] + (x[1] +    1)*V[5][{j}])/4'
+                     for j in range(3)]]
+    jac_exprs = _jac_exprs_xy + _jac_exprs_z
+
+
     @classmethod
     def std_ele(cls, sptord):
         pts1d = np.linspace(-1, 1, sptord + 1)
@@ -452,6 +525,25 @@ class PyrShape(BaseShape):
         ('tri', lambda s, t: ((1 - t)/2, -s - (t + 1)/2, t), (1, 0, 0.5)),
         ('tri', lambda s, t: (-s - (t + 1)/2, (1 - t)/2, t), (0, 1, 0.5)),
         ('tri', lambda s, t: ((t - 1)/2, s + (t + 1)/2, t), (-1, 0, 0.5)),
+    ]
+
+    # Jacobian expressions for a linear element
+    jac_exprs = [
+        ['((1 - x[1])*V[1][0] + (-x[1] - 1)*V[2][0] +'
+         ' (x[1] - 1)*V[0][0] + (x[1] + 1)*V[3][0])/4',
+         '((1 - x[1])*V[1][1] + (-x[1] - 1)*V[2][1] +'
+         '(x[1] - 1)*V[0][1] + (x[1] + 1)*V[3][1])/4',
+         '((1 - x[1])*V[1][2] + (-x[1] - 1)*V[2][2] +'
+         ' (x[1] - 1)*V[0][2] + (x[1] + 1)*V[3][2])/4'],
+        ['((1 - x[0])*V[2][0] + (-x[0] - 1)*V[1][0] +'
+         ' (x[0] - 1)*V[0][0] + (x[0] + 1)*V[3][0])/4',
+         '((1 - x[0])*V[2][1] + (-x[0] - 1)*V[1][1] +'
+         ' (x[0] - 1)*V[0][1] + (x[0] + 1)*V[3][1])/4',
+         '((1 - x[0])*V[2][2] + (-x[0] - 1)*V[1][2] +'
+         '(x[0] - 1)*V[0][2] + (x[0] + 1)*V[3][2])/4'],
+        ['(-V[0][0] - V[1][0] - V[2][0] - V[3][0] + 4*V[4][0])/8',
+         '(-V[0][1] - V[1][1] - V[2][1] - V[3][1] + 4*V[4][1])/8',
+         '(-V[0][2] - V[1][2] - V[2][2] - V[3][2] + 4*V[4][2])/8']
     ]
 
     @classmethod

--- a/pyfr/shapes.py
+++ b/pyfr/shapes.py
@@ -488,8 +488,8 @@ class PriShape(BaseShape):
 
     # Jacobian expressions for a linear element
     _jac_exprs_xy = [
-        [f'((x[2] - 1)*V[0, {j}] + (1 - x[2])*V[{i + 1}, {j}] -'
-         f' (x[2] + 1)*V[3, {j}] + (x[2] + 1)*V[{i + 4}, {j}])/4'
+        [f'((x[2] - 1)*V[0][{j}] + (1 - x[2])*V[{i + 1}][{j}] -'
+         f' (x[2] + 1)*V[3][{j}] + (x[2] + 1)*V[{i + 4}][{j}])/4'
          for j in range(3)]
         for i in range(2)
     ]

--- a/pyfr/solvers/aceuler/elements.py
+++ b/pyfr/solvers/aceuler/elements.py
@@ -35,22 +35,43 @@ class ACEulerElements(BaseACFluidElements, BaseAdvectionElements):
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)
 
-        # Register our flux kernel
+        # Register our flux kernels
         self._be.pointwise.register('pyfr.solvers.aceuler.kernels.tflux')
+        self._be.pointwise.register('pyfr.solvers.aceuler.kernels.tfluxlin')
 
-        # Template parameters for the flux kernel
-        tplargs = dict(ndims=self.ndims, nvars=self.nvars,
-                       c=self.cfg.items_as('constants', float))
+        # Template parameters for the flux kernels
+        tplargs = {
+            'ndims': self.ndims,
+            'nvars': self.nvars,
+            'nverts': len(self.basis.linspts),
+            'c': self.cfg.items_as('constants', float),
+            'jac_exprs': self.basis.jac_exprs
+        }
 
+        # Common arguments
         if 'flux' in self.antialias:
-            self.kernels['tdisf'] = lambda: self._be.kernel(
-                'tflux', tplargs=tplargs, dims=[self.nqpts, self.neles],
-                u=self._scal_qpts, smats=self.smat_at('qpts'),
-                f=self._vect_qpts
-            )
+            u = lambda s: self._slice_mat(self._scal_fqpts, s, ra=self.nfpts)
+            f = lambda s: self._slice_mat(self._vect_qpts, s)
+            pts, npts = 'qpts', self.nqpts
         else:
-            self.kernels['tdisf'] = lambda: self._be.kernel(
-                'tflux', tplargs=tplargs, dims=[self.nupts, self.neles],
-                u=self.scal_upts_inb, smats=self.smat_at('upts'),
-                f=self._vect_upts
+            u = lambda s: self._slice_mat(self.scal_upts_inb, s)
+            f = lambda s: self._slice_mat(self._vect_upts, s)
+            pts, npts = 'upts', self.nupts
+
+        # Mesh regions
+        regions = self._mesh_regions
+
+        if 'curved' in regions:
+            self.kernels['tdisf_curved'] = lambda: self._be.kernel(
+                'tflux', tplargs=tplargs, dims=[npts, regions['curved']],
+                u=u('curved'), f=f('curved'),
+                smats=self.smat_at(pts, 'curved')
+            )
+
+        if 'linear' in regions:
+            upts = getattr(self, pts)
+            self.kernels['tdisf_linear'] = lambda: self._be.kernel(
+                'tfluxlin', tplargs=tplargs, dims=[npts, regions['linear']],
+                u=u('linear'), f=f('linear'),
+                verts=self.ploc_at('linspts', 'linear'), upts=upts
             )

--- a/pyfr/solvers/aceuler/kernels/tflux.mako
+++ b/pyfr/solvers/aceuler/kernels/tflux.mako
@@ -5,16 +5,15 @@
 
 <%pyfr:kernel name='tflux' ndim='2'
               u='in fpdtype_t[${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
-              f='out fpdtype_t[${str(ndims)}][${str(nvars)}]'>
+              f='out fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'>
     // Compute the flux
     fpdtype_t ftemp[${ndims}][${nvars}];
     ${pyfr.expand('inviscid_flux', 'u', 'ftemp')};
 
     // Transform the fluxes
 % for i, j in pyfr.ndrange(ndims, nvars):
-    f[${i}][${j}] = ${' + '.join('smats[{0}][{1}]*ftemp[{1}][{2}]'
-                                 .format(i, k, j)
+    f[${i}][${j}] = ${' + '.join(f'smats[{i}][{k}]*ftemp[{k}][{j}]'
                                  for k in range(ndims))};
 % endfor
 </%pyfr:kernel>

--- a/pyfr/solvers/aceuler/kernels/tfluxlin.mako
+++ b/pyfr/solvers/aceuler/kernels/tfluxlin.mako
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+<%include file='pyfr.solvers.baseadvec.kernels.smats'/>
+<%include file='pyfr.solvers.aceuler.kernels.flux'/>
+
+<%pyfr:kernel name='tfluxlin' ndim='2'
+              u='in fpdtype_t[${str(nvars)}]'
+              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+    // Compute the flux
+    fpdtype_t ftemp[${ndims}][${nvars}];
+    ${pyfr.expand('inviscid_flux', 'u', 'ftemp')};
+
+    // Compute the S matrices
+    fpdtype_t smats[${ndims}][${ndims}], djac;
+    ${pyfr.expand('calc_smats_detj', 'verts', 'upts', 'smats', 'djac')};
+
+    // Transform the fluxes
+% for i, j in pyfr.ndrange(ndims, nvars):
+    f[${i}][${j}] = ${' + '.join(f'smats[{i}][{k}]*ftemp[{k}][{j}]'
+                                 for k in range(ndims))};
+% endfor
+</%pyfr:kernel>

--- a/pyfr/solvers/acnavstokes/elements.py
+++ b/pyfr/solvers/acnavstokes/elements.py
@@ -9,22 +9,44 @@ class ACNavierStokesElements(BaseACFluidElements,
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)
 
-        # Register our flux kernel
-        self._be.pointwise.register('pyfr.solvers.acnavstokes.kernels.tflux')
+        # Register our flux kernels
+        kprefix = 'pyfr.solvers.acnavstokes.kernels'
+        self._be.pointwise.register(f'{kprefix}.tflux')
+        self._be.pointwise.register(f'{kprefix}.tfluxlin')
 
-        # Template parameters for the flux kernel
-        tplargs = dict(ndims=self.ndims, nvars=self.nvars,
-                       c=self.cfg.items_as('constants', float))
+        # Template parameters for the flux kernels
+        tplargs = {
+            'ndims': self.ndims,
+            'nvars': self.nvars,
+            'nverts': len(self.basis.linspts),
+            'c': self.cfg.items_as('constants', float),
+            'jac_exprs': self.basis.jac_exprs
+        }
 
+        # Common arguments
         if 'flux' in self.antialias:
-            self.kernels['tdisf'] = lambda: self._be.kernel(
-                'tflux', tplargs=tplargs, dims=[self.nqpts, self.neles],
-                u=self._scal_qpts, smats=self.smat_at('qpts'),
-                f=self._vect_qpts
-            )
+            u = lambda s: self._slice_mat(self._scal_fqpts, s, ra=self.nfpts)
+            f = lambda s: self._slice_mat(self._vect_qpts, s)
+            pts, npts = 'qpts', self.nqpts
         else:
-            self.kernels['tdisf'] = lambda: self._be.kernel(
-                'tflux', tplargs=tplargs, dims=[self.nupts, self.neles],
-                u=self.scal_upts_inb, smats=self.smat_at('upts'),
-                f=self._vect_upts
+            u = lambda s: self._slice_mat(self.scal_upts_inb, s)
+            f = lambda s: self._slice_mat(self._vect_upts, s)
+            pts, npts = 'upts', self.nupts
+
+        # Mesh regions
+        regions = self._mesh_regions
+
+        if 'curved' in regions:
+            self.kernels['tdisf_curved'] = lambda: self._be.kernel(
+                'tflux', tplargs=tplargs, dims=[npts, regions['curved']],
+                u=u('curved'), f=f('curved'),
+                smats=self.smat_at(pts, 'curved')
+            )
+
+        if 'linear' in regions:
+            upts = getattr(self, pts)
+            self.kernels['tdisf_linear'] = lambda: self._be.kernel(
+                'tfluxlin', tplargs=tplargs, dims=[npts, regions['linear']],
+                u=u('linear'), f=f('linear'),
+                verts=self.ploc_at('linspts', 'linear'), upts=upts
             )

--- a/pyfr/solvers/acnavstokes/kernels/tflux.mako
+++ b/pyfr/solvers/acnavstokes/kernels/tflux.mako
@@ -6,8 +6,8 @@
 
 <%pyfr:kernel name='tflux' ndim='2'
               u='in fpdtype_t[${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
-              f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'>
+              f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'>
     // Compute the flux (F = Fi + Fv)
     fpdtype_t ftemp[${ndims}][${nvars}];
     ${pyfr.expand('inviscid_flux', 'u', 'ftemp')};
@@ -15,8 +15,7 @@
 
     // Transform the fluxes
 % for i, j in pyfr.ndrange(ndims, nvars):
-    f[${i}][${j}] = ${' + '.join('smats[{0}][{1}]*ftemp[{1}][{2}]'
-                                 .format(i, k, j)
+    f[${i}][${j}] = ${' + '.join(f'smats[{i}][{k}]*ftemp[{k}][{j}]'
                                  for k in range(ndims))};
 % endfor
 </%pyfr:kernel>

--- a/pyfr/solvers/acnavstokes/kernels/tfluxlin.mako
+++ b/pyfr/solvers/acnavstokes/kernels/tfluxlin.mako
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+<%include file='pyfr.solvers.baseadvec.kernels.smats'/>
+<%include file='pyfr.solvers.aceuler.kernels.flux'/>
+<%include file='pyfr.solvers.acnavstokes.kernels.flux'/>
+
+<%pyfr:kernel name='tfluxlin' ndim='2'
+              u='in fpdtype_t[${str(nvars)}]'
+              f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+    // Compute the flux (F = Fi + Fv)
+    fpdtype_t ftemp[${ndims}][${nvars}];
+    ${pyfr.expand('inviscid_flux', 'u', 'ftemp')};
+    ${pyfr.expand('viscous_flux_add', 'u', 'f', 'ftemp')};
+
+    // Compute the S matrices
+    fpdtype_t smats[${ndims}][${ndims}], djac;
+    ${pyfr.expand('calc_smats_detj', 'verts', 'upts', 'smats', 'djac')};
+
+    // Transform the fluxes
+% for i, j in pyfr.ndrange(ndims, nvars):
+    f[${i}][${j}] = ${' + '.join(f'smats[{i}][{k}]*ftemp[{k}][{j}]'
+                                 for k in range(ndims))};
+% endfor
+</%pyfr:kernel>

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -112,6 +112,36 @@ class BaseElements(object):
     def _scratch_bufs(self):
         pass
 
+    @property
+    def _mesh_regions(self):
+        off = self._linoff
+
+        # No curved elements
+        if off == 0:
+            return {'linear': self.neles}
+        # All curved elements
+        elif off >= self.neles:
+            return {'curved': self.neles}
+        # Mix of curved and linear elements
+        else:
+            return {'curved': off, 'linear': self.neles - off}
+
+    def _slice_mat(self, mat, region, ra=None, rb=None):
+        off = self._linoff
+
+        # Handle stacked matrices
+        if len(mat.ioshape) >= 3:
+            off *= mat.ioshape[-2]
+        else:
+            off = min(off, mat.ncol)
+
+        if region == 'curved':
+            return mat.slice(ra, rb, 0, off)
+        elif region == 'linear':
+            return mat.slice(ra, rb, off, mat.ncol)
+        else:
+            raise ValueError('Invalid slice region')
+
     @lazyprop
     def _src_exprs(self):
         convars = self.convarmap[self.ndims]
@@ -133,8 +163,13 @@ class BaseElements(object):
     def _soln_in_src_exprs(self):
         return any(re.search(r'\bu\b', ex) for ex in self._src_exprs)
 
-    def set_backend(self, backend, nscalupts, nonce):
+    def set_backend(self, backend, nscalupts, nonce, linoff):
         self._be = backend
+
+        if self.basis.order >= 2:
+            self._linoff = linoff - linoff % -backend.soasz
+        else:
+            self._linoff = self.neles
 
         # Sizes
         ndims, nvars, neles = self.ndims, self.nvars, self.neles
@@ -188,6 +223,18 @@ class BaseElements(object):
         return self._be.const_matrix(self.basis.opmat(expr),
                                      tags={expr, 'align'})
 
+    def sliceat(fn):
+        @memoize
+        def newfn(self, name, side=None):
+            mat = fn(self, name)
+
+            if side is not None:
+                return self._slice_mat(mat, side)
+            else:
+                return mat
+
+        return newfn
+
     @memoize
     def smat_at_np(self, name):
         smats_mpts, _ = self._smats_djacs_mpts
@@ -199,6 +246,7 @@ class BaseElements(object):
         smats = np.array([m0 @ smat for smat in smats_mpts])
         return smats.reshape(self.ndims, -1, self.ndims, self.neles)
 
+    @sliceat
     @memoize
     def smat_at(self, name):
         return self._be.const_matrix(self.smat_at_np(name), tags={'align'})
@@ -218,6 +266,7 @@ class BaseElements(object):
 
         return 1.0 / djac
 
+    @sliceat
     @memoize
     def rcpdjac_at(self, name):
         return self._be.const_matrix(self.rcpdjac_at_np(name), tags={'align'})
@@ -231,9 +280,18 @@ class BaseElements(object):
 
         return ploc
 
+    @sliceat
     @memoize
     def ploc_at(self, name):
         return self._be.const_matrix(self.ploc_at_np(name), tags={'align'})
+
+    @lazyprop
+    def upts(self):
+        return self._be.const_matrix(self.basis.upts)
+
+    @lazyprop
+    def qpts(self):
+        return self._be.const_matrix(self.basis.qpts)
 
     def _gen_pnorm_fpts(self):
         smats = self.smat_at_np('fpts').transpose(1, 3, 0, 2)

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -107,7 +107,14 @@ class BaseSystem(object):
 
         # Allocate these elements on the backend
         for etype, ele in elemap.items():
-            ele.set_backend(self.backend, nregs, nonce)
+            k = f'spt_{etype}_p{rallocs.prank}'
+
+            try:
+                linoff = mesh[k, 'lin_off']
+            except KeyError:
+                linoff = ele.neles
+
+            ele.set_backend(self.backend, nregs, nonce, linoff)
 
         return eles, elemap
 

--- a/pyfr/solvers/baseadvec/kernels/smats.mako
+++ b/pyfr/solvers/baseadvec/kernels/smats.mako
@@ -8,6 +8,7 @@
     s[1][0] = -${jac_exprs[0][1]};
     s[1][1] =  ${jac_exprs[0][0]};
     d = s[0][0]*s[1][1] - s[0][1]*s[1][0];
+    (void) d;
 </%pyfr:macro>
 % else:
 <%pyfr:macro name='calc_smats_detj', params='V, x, s, d'>
@@ -21,5 +22,6 @@
     s[${i}][2] = j[${j}][0]*j[${k}][1] - j[${j}][1]*j[${k}][0];
 % endfor
     d = j[0][0]*s[0][0] + j[0][1]*s[0][1] + j[0][2]*s[0][2];
+    (void) d;
 </%pyfr:macro>
 % endif

--- a/pyfr/solvers/baseadvec/kernels/smats.mako
+++ b/pyfr/solvers/baseadvec/kernels/smats.mako
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+% if ndims == 2:
+<%pyfr:macro name='calc_smats_detj', params='V, x, s, d'>
+    s[0][0] =  ${jac_exprs[1][1]};
+    s[0][1] = -${jac_exprs[1][0]};
+    s[1][0] = -${jac_exprs[0][1]};
+    s[1][1] =  ${jac_exprs[0][0]};
+    d = s[0][0]*s[1][1] - s[0][1]*s[1][0];
+</%pyfr:macro>
+% else:
+<%pyfr:macro name='calc_smats_detj', params='V, x, s, d'>
+    fpdtype_t j[3][3];
+% for i, j in pyfr.ndrange(3, 3):
+    j[${i}][${j}] = ${jac_exprs[i][j]};
+% endfor
+% for i, (j, k) in enumerate([(1, 2), (2, 0), (0, 1)]):
+    s[${i}][0] = j[${j}][1]*j[${k}][2] - j[${j}][2]*j[${k}][1];
+    s[${i}][1] = j[${j}][2]*j[${k}][0] - j[${j}][0]*j[${k}][2];
+    s[${i}][2] = j[${j}][0]*j[${k}][1] - j[${j}][1]*j[${k}][0];
+% endfor
+    d = j[0][0]*s[0][0] + j[0][1]*s[0][1] + j[0][2]*s[0][2];
+</%pyfr:macro>
+% endif

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -22,7 +22,8 @@ class BaseAdvectionSystem(BaseSystem):
 
         if ('eles', 'copy_soln') in kernels:
             q1.enqueue(kernels['eles', 'copy_soln'])
-        q1.enqueue(kernels['eles', 'tdisf'])
+        q1.enqueue(kernels['eles', 'tdisf_curved'])
+        q1.enqueue(kernels['eles', 'tdisf_linear'])
         q1.enqueue(kernels['eles', 'tdivtpcorf'])
         q1.enqueue(kernels['iint', 'comm_flux'])
         q1.enqueue(kernels['bcint', 'comm_flux'], t=t)

--- a/pyfr/solvers/baseadvecdiff/elements.py
+++ b/pyfr/solvers/baseadvecdiff/elements.py
@@ -17,34 +17,56 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
 
         return bufs
 
-    def set_backend(self, backend, nscalupts, nonce):
-        super().set_backend(backend, nscalupts, nonce)
+    def set_backend(self, backend, nscalupts, nonce, linoff):
+        super().set_backend(backend, nscalupts, nonce, linoff)
 
         kernel = self._be.kernel
-        kernels = self.kernels
+        kprefix = 'pyfr.solvers.baseadvecdiff.kernels'
+        slicem = self._slice_mat
 
-        # Register pointwise kernels
-        self._be.pointwise.register(
-            'pyfr.solvers.baseadvecdiff.kernels.gradcoru'
-        )
+        # Register our pointwise kernels
+        self._be.pointwise.register(f'{kprefix}.gradcoru')
+        self._be.pointwise.register(f'{kprefix}.gradcorulin')
 
-        kernels['_copy_fpts'] = lambda: kernel(
+        # Mesh regions
+        regions = self._mesh_regions
+
+        self.kernels['_copy_fpts'] = lambda: kernel(
             'copy', self._vect_fpts.slice(0, self.nfpts), self._scal_fpts
         )
-        kernels['tgradpcoru_upts'] = lambda: kernel(
+        self.kernels['tgradpcoru_upts'] = lambda: kernel(
             'mul', self.opmat('M4 - M6*M0'), self.scal_upts_inb,
             out=self._vect_upts
         )
-
-        kernels['tgradcoru_upts'] = lambda: kernel(
+        self.kernels['tgradcoru_upts'] = lambda: kernel(
             'mul', self.opmat('M6'), self._vect_fpts.slice(0, self.nfpts),
             out=self._vect_upts, beta=1.0
         )
-        kernels['gradcoru_upts'] = lambda: kernel(
-            'gradcoru', tplargs=dict(ndims=self.ndims, nvars=self.nvars),
-            dims=[self.nupts, self.neles], smats=self.smat_at('upts'),
-            rcpdjac=self.rcpdjac_at('upts'), gradu=self._vect_upts
-        )
+
+        # Template arguments for the physical gradient kernel
+        tplargs = {
+            'ndims': self.ndims,
+            'nvars': self.nvars,
+            'nverts': len(self.basis.linspts),
+            'jac_exprs': self.basis.jac_exprs
+        }
+
+        if 'curved' in regions:
+            self.kernels['gradcoru_upts_curved'] = lambda: kernel(
+                'gradcoru', tplargs=tplargs,
+                dims=[self.nupts, regions['curved']],
+                gradu=slicem(self._vect_upts, 'curved'),
+                smats=self.smat_at('upts', 'curved'),
+                rcpdjac=self.rcpdjac_at('upts', 'curved')
+            )
+
+        if 'linear' in regions:
+            self.kernels['gradcoru_upts_linear'] = lambda: kernel(
+                'gradcorulin', tplargs=tplargs,
+                dims=[self.nupts, regions['linear']],
+                gradu=slicem(self._vect_upts, 'linear'),
+                upts=self.upts, verts=self.ploc_at('linspts', 'linear')
+            )
 
         def gradcoru_fpts():
             nupts, nfpts = self.nupts, self.nfpts
@@ -58,7 +80,7 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
 
             return ComputeMetaKernel(muls)
 
-        kernels['gradcoru_fpts'] = gradcoru_fpts
+        self.kernels['gradcoru_fpts'] = gradcoru_fpts
 
         if 'flux' in self.antialias:
             def gradcoru_qpts():
@@ -73,7 +95,7 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
 
                 return ComputeMetaKernel(muls)
 
-            kernels['gradcoru_qpts'] = gradcoru_qpts
+            self.kernels['gradcoru_qpts'] = gradcoru_qpts
 
         # Shock capturing
         shock_capturing = self.cfg.get('solver', 'shock-capturing', 'none')
@@ -104,7 +126,7 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
                                            extent=nonce + 'artvisc', tags=tags)
 
             # Apply the sensor to estimate the required artificial viscosity
-            kernels['shocksensor'] = lambda: self._be.kernel(
+            self.kernels['shocksensor'] = lambda: self._be.kernel(
                 'shocksensor', tplargs=tplargs, dims=[self.neles],
                 u=self.scal_upts_inb, artvisc=self.artvisc
             )

--- a/pyfr/solvers/baseadvecdiff/kernels/gradcoru.mako
+++ b/pyfr/solvers/baseadvecdiff/kernels/gradcoru.mako
@@ -3,9 +3,9 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
 <%pyfr:kernel name='gradcoru' ndim='2'
+              gradu='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
               smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
-              rcpdjac='in fpdtype_t'
-              gradu='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'>
+              rcpdjac='in fpdtype_t'>
     fpdtype_t tmpgradu[${ndims}];
 
 % for j in range(nvars):
@@ -13,8 +13,7 @@
     tmpgradu[${i}] = gradu[${i}][${j}];
 % endfor
 % for i in range(ndims):
-    gradu[${i}][${j}] = rcpdjac*(${' + '.join('smats[{k}][{i}]*tmpgradu[{k}]'
-                                              .format(i=i, k=k)
+    gradu[${i}][${j}] = rcpdjac*(${' + '.join(f'smats[{k}][{i}]*tmpgradu[{k}]'
                                               for k in range(ndims))});
 % endfor
 % endfor

--- a/pyfr/solvers/baseadvecdiff/kernels/gradcorulin.mako
+++ b/pyfr/solvers/baseadvecdiff/kernels/gradcorulin.mako
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%include file='pyfr.solvers.baseadvec.kernels.smats'/>
+
+<%pyfr:kernel name='gradcorulin' ndim='2'
+              gradu='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+    // Compute the S matrices
+    fpdtype_t smats[${ndims}][${ndims}], djac;
+    ${pyfr.expand('calc_smats_detj', 'verts', 'upts', 'smats', 'djac')};
+
+    fpdtype_t rcpdjac = 1 / djac;
+    fpdtype_t tmpgradu[${ndims}];
+
+% for j in range(nvars):
+% for i in range(ndims):
+    tmpgradu[${i}] = gradu[${i}][${j}];
+% endfor
+% for i in range(ndims):
+    gradu[${i}][${j}] = rcpdjac*(${' + '.join(f'smats[{k}][{i}]*tmpgradu[{k}]'
+                                              for k in range(ndims))});
+% endfor
+% endfor
+</%pyfr:kernel>

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -36,7 +36,8 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
 
         q1.enqueue(kernels['mpiint', 'con_u'])
         q1.enqueue(kernels['eles', 'tgradcoru_upts'])
-        q1.enqueue(kernels['eles', 'gradcoru_upts'])
+        q1.enqueue(kernels['eles', 'gradcoru_upts_curved'])
+        q1.enqueue(kernels['eles', 'gradcoru_upts_linear'])
         q1.enqueue(kernels['eles', 'gradcoru_fpts'])
         q1.enqueue(kernels['mpiint', 'vect_fpts_pack'])
         if ('eles', 'shockvar') in kernels:
@@ -48,7 +49,8 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
 
         if ('eles', 'gradcoru_qpts') in kernels:
             q1.enqueue(kernels['eles', 'gradcoru_qpts'])
-        q1.enqueue(kernels['eles', 'tdisf'])
+        q1.enqueue(kernels['eles', 'tdisf_curved'])
+        q1.enqueue(kernels['eles', 'tdisf_linear'])
         q1.enqueue(kernels['eles', 'tdivtpcorf'])
         q1.enqueue(kernels['iint', 'comm_flux'])
         q1.enqueue(kernels['bcint', 'comm_flux'], t=t)

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -54,22 +54,43 @@ class EulerElements(BaseFluidElements, BaseAdvectionElements):
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)
 
-        # Register our flux kernel
+        # Register our flux kernels
         self._be.pointwise.register('pyfr.solvers.euler.kernels.tflux')
+        self._be.pointwise.register('pyfr.solvers.euler.kernels.tfluxlin')
 
-        # Template parameters for the flux kernel
-        tplargs = dict(ndims=self.ndims, nvars=self.nvars,
-                       c=self.cfg.items_as('constants', float))
+        # Template parameters for the flux kernels
+        tplargs = {
+            'ndims': self.ndims,
+            'nvars': self.nvars,
+            'nverts': len(self.basis.linspts),
+            'c': self.cfg.items_as('constants', float),
+            'jac_exprs': self.basis.jac_exprs
+        }
 
+        # Common arguments
         if 'flux' in self.antialias:
-            self.kernels['tdisf'] = lambda: self._be.kernel(
-                'tflux', tplargs=tplargs, dims=[self.nqpts, self.neles],
-                u=self._scal_qpts, smats=self.smat_at('qpts'),
-                f=self._vect_qpts
-            )
+            u = lambda s: self._slice_mat(self._scal_fqpts, s, ra=self.nfpts)
+            f = lambda s: self._slice_mat(self._vect_qpts, s)
+            pts, npts = 'qpts', self.nqpts
         else:
-            self.kernels['tdisf'] = lambda: self._be.kernel(
-                'tflux', tplargs=tplargs, dims=[self.nupts, self.neles],
-                u=self.scal_upts_inb, smats=self.smat_at('upts'),
-                f=self._vect_upts
+            u = lambda s: self._slice_mat(self.scal_upts_inb, s)
+            f = lambda s: self._slice_mat(self._vect_upts, s)
+            pts, npts = 'upts', self.nupts
+
+        # Mesh regions
+        regions = self._mesh_regions
+
+        if 'curved' in regions:
+            self.kernels['tdisf_curved'] = lambda: self._be.kernel(
+                'tflux', tplargs=tplargs, dims=[npts, regions['curved']],
+                u=u('curved'), f=f('curved'),
+                smats=self.smat_at(pts, 'curved')
+            )
+
+        if 'linear' in regions:
+            upts = getattr(self, pts)
+            self.kernels['tdisf_linear'] = lambda: self._be.kernel(
+                'tfluxlin', tplargs=tplargs, dims=[npts, regions['linear']],
+                u=u('linear'), f=f('linear'),
+                verts=self.ploc_at('linspts', 'linear'), upts=upts
             )

--- a/pyfr/solvers/euler/kernels/tflux.mako
+++ b/pyfr/solvers/euler/kernels/tflux.mako
@@ -5,8 +5,8 @@
 
 <%pyfr:kernel name='tflux' ndim='2'
               u='in fpdtype_t[${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
-              f='out fpdtype_t[${str(ndims)}][${str(nvars)}]'>
+              f='out fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'>
     // Compute the flux
     fpdtype_t ftemp[${ndims}][${nvars}];
     fpdtype_t p, v[${ndims}];
@@ -14,8 +14,7 @@
 
     // Transform the fluxes
 % for i, j in pyfr.ndrange(ndims, nvars):
-    f[${i}][${j}] = ${' + '.join('smats[{0}][{1}]*ftemp[{1}][{2}]'
-                                 .format(i, k, j)
+    f[${i}][${j}] = ${' + '.join(f'smats[{i}][{k}]*ftemp[{k}][{j}]'
                                  for k in range(ndims))};
 % endfor
 </%pyfr:kernel>

--- a/pyfr/solvers/euler/kernels/tfluxlin.mako
+++ b/pyfr/solvers/euler/kernels/tfluxlin.mako
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+<%include file='pyfr.solvers.baseadvec.kernels.smats'/>
+<%include file='pyfr.solvers.euler.kernels.flux'/>
+
+<%pyfr:kernel name='tfluxlin' ndim='2'
+              u='in fpdtype_t[${str(nvars)}]'
+              f='out fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+    // Compute the flux
+    fpdtype_t ftemp[${ndims}][${nvars}];
+    fpdtype_t p, v[${ndims}];
+    ${pyfr.expand('inviscid_flux', 'u', 'ftemp', 'p', 'v')};
+
+    // Compute the S matrices
+    fpdtype_t smats[${ndims}][${ndims}], djac;
+    ${pyfr.expand('calc_smats_detj', 'verts', 'upts', 'smats', 'djac')};
+
+    // Transform the fluxes
+% for i, j in pyfr.ndrange(ndims, nvars):
+    f[${i}][${j}] = ${' + '.join(f'smats[{i}][{k}]*ftemp[{k}][{j}]'
+                                 for k in range(ndims))};
+% endfor
+</%pyfr:kernel>

--- a/pyfr/solvers/navstokes/kernels/tflux.mako
+++ b/pyfr/solvers/navstokes/kernels/tflux.mako
@@ -8,9 +8,9 @@
 
 <%pyfr:kernel name='tflux' ndim='2'
               u='in fpdtype_t[${str(nvars)}]'
-              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'
               artvisc='in broadcast fpdtype_t'
-              f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'>
+              f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              smats='in fpdtype_t[${str(ndims)}][${str(ndims)}]'>
     // Compute the flux (F = Fi + Fv)
     fpdtype_t ftemp[${ndims}][${nvars}];
     fpdtype_t p, v[${ndims}];
@@ -20,8 +20,7 @@
 
     // Transform the fluxes
 % for i, j in pyfr.ndrange(ndims, nvars):
-    f[${i}][${j}] = ${' + '.join('smats[{0}][{1}]*ftemp[{1}][{2}]'
-                                 .format(i, k, j)
+    f[${i}][${j}] = ${' + '.join(f'smats[{i}][{k}]*ftemp[{k}][{j}]'
                                  for k in range(ndims))};
 % endfor
 </%pyfr:kernel>

--- a/pyfr/solvers/navstokes/kernels/tfluxlin.mako
+++ b/pyfr/solvers/navstokes/kernels/tfluxlin.mako
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%include file='pyfr.solvers.baseadvec.kernels.smats'/>
+<%include file='pyfr.solvers.baseadvecdiff.kernels.artvisc'/>
+<%include file='pyfr.solvers.euler.kernels.flux'/>
+<%include file='pyfr.solvers.navstokes.kernels.flux'/>
+
+<%pyfr:kernel name='tfluxlin' ndim='2'
+              u='in fpdtype_t[${str(nvars)}]'
+              artvisc='in broadcast fpdtype_t'
+              f='inout fpdtype_t[${str(ndims)}][${str(nvars)}]'
+              verts='in broadcast-col fpdtype_t[${str(nverts)}][${str(ndims)}]'
+              upts='in broadcast-row fpdtype_t[${str(ndims)}]'>
+    // Compute the flux (F = Fi + Fv)
+    fpdtype_t ftemp[${ndims}][${nvars}];
+    fpdtype_t p, v[${ndims}];
+    ${pyfr.expand('inviscid_flux', 'u', 'ftemp', 'p', 'v')};
+    ${pyfr.expand('viscous_flux_add', 'u', 'f', 'ftemp')};
+    ${pyfr.expand('artificial_viscosity_add', 'f', 'ftemp', 'artvisc')};
+
+    // Compute the S matrices
+    fpdtype_t smats[${ndims}][${ndims}], djac;
+    ${pyfr.expand('calc_smats_detj', 'verts', 'upts', 'smats', 'djac')};
+
+    // Transform the fluxes
+% for i, j in pyfr.ndrange(ndims, nvars):
+    f[${i}][${j}] = ${' + '.join(f'smats[{i}][{k}]*ftemp[{k}][{j}]'
+                                 for k in range(ndims))};
+% endfor
+</%pyfr:kernel>


### PR DESCRIPTION
This enables us to reduce the amount of memory bandwidth required
for a step by computing Jacobian entries on the fly from the vertex
data.