### PR TITLE
Remove the dependency on PyCUDA in lieu of our own wrappers.

### DIFF
--- a/pyfr/backends/cuda/blasext.py
+++ b/pyfr/backends/cuda/blasext.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pycuda.driver as cuda
 
 from pyfr.backends.cuda.provider import CUDAKernelProvider, get_grid_for_block
 from pyfr.backends.base import ComputeKernel
@@ -31,21 +30,20 @@ class CUDABlasExtKernels(CUDAKernelProvider):
 
         class AxnpbyKernel(ComputeKernel):
             def run(self, queue, *consts):
-                args = list(arr) + list(consts)
-
-                kern.prepared_async_call(grid, block, queue.cuda_stream_comp,
-                                         nrow, ncolb, ldim, *args)
+                kern.exec_async(grid, block, queue.cuda_stream_comp,
+                                nrow, ncolb, ldim, *arr, *consts)
 
         return AxnpbyKernel()
 
     def copy(self, dst, src):
+        cuda = self.backend.cuda
+
         if dst.traits != src.traits:
             raise ValueError('Incompatible matrix types')
 
         class CopyKernel(ComputeKernel):
             def run(self, queue):
-                cuda.memcpy_dtod_async(dst.data, src.data, dst.nbytes,
-                                       stream=queue.cuda_stream_comp)
+                cuda.memcpy_async(dst, src, dst.nbytes, queue.cuda_stream_comp)
 
         return CopyKernel()
 
@@ -53,6 +51,7 @@ class CUDABlasExtKernels(CUDAKernelProvider):
         if x.traits != y.traits != z.traits:
             raise ValueError('Incompatible matrix types')
 
+        cuda = self.backend.cuda
         nrow, ncol, ldim, dtype = x.traits
         ncola, ncolb = x.ioshape[1:]
 
@@ -62,11 +61,11 @@ class CUDABlasExtKernels(CUDAKernelProvider):
         # Determine the grid size
         grid = get_grid_for_block(block, ncolb, ncola)
 
-        # Empty result buffer on host with shape (nvars, nblocks)
-        err_host = cuda.pagelocked_empty((ncola, grid[0]), dtype, 'C')
+        # Empty result buffer on the device
+        err_dev = cuda.mem_alloc(ncola*grid[0]*x.itemsize)
 
-        # Device memory allocation
-        err_dev = cuda.mem_alloc(err_host.nbytes)
+        # Empty result buffer on the host
+        err_host = cuda.pagelocked_empty((ncola, grid[0]), dtype)
 
         # Get the kernel template
         src = self.backend.lookup.get_template('errest').render(
@@ -87,10 +86,9 @@ class CUDABlasExtKernels(CUDAKernelProvider):
                 return reducer(err_host, axis=1)
 
             def run(self, queue, atol, rtol):
-                rkern.prepared_async_call(grid, block, queue.cuda_stream_comp,
-                                          nrow, ncolb, ldim, err_dev, x, y, z,
-                                          atol, rtol)
-                cuda.memcpy_dtoh_async(err_host, err_dev,
-                                       queue.cuda_stream_comp)
+                rkern.exec_async(grid, block, queue.cuda_stream_comp, nrow,
+                                 ncolb, ldim, err_dev, x, y, z, atol, rtol)
+                cuda.memcpy_async(err_host, err_dev, err_dev.nbytes,
+                                  queue.cuda_stream_comp)
 
         return ErrestKernel()

--- a/pyfr/backends/cuda/compiler.py
+++ b/pyfr/backends/cuda/compiler.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+from ctypes import (POINTER, create_string_buffer, c_char_p, c_int, c_size_t,
+                    c_void_p)
+
+from pyfr.ctypesutil import LibWrapper
+from pyfr.nputil import npdtype_to_ctypestype
+
+
+# Possible NVRTC exception types
+NVRTCError = type('NVRTCError', (Exception,), {})
+NVRTCOutOfMemory = type('NVRTCOutOfMemory', (NVRTCError,), {})
+NVRTCProgCreationFailure = type('NVRTCProgCreationFailure', (NVRTCError,), {})
+NVRTCInvalidInput = type('NVRTCInvalidInput', (NVRTCError,), {})
+NVRTCInvalidProgram = type('NVRTCInvalidProgram', (NVRTCError,), {})
+NVRTCInvalidOption = type('NVRTCInvalidOption', (NVRTCError,), {})
+NVRTCCompilationError = type('NVRTCCompilationError', (NVRTCError,), {})
+NVRTCInternalError = type('NVRTCInternalError', (NVRTCError,), {})
+
+
+class NVRTCWrappers(LibWrapper):
+    _libname = 'nvrtc'
+
+    # Error codes
+    _statuses = {
+        1: NVRTCOutOfMemory,
+        2: NVRTCProgCreationFailure,
+        3: NVRTCInvalidInput,
+        4: NVRTCInvalidProgram,
+        5: NVRTCInvalidOption,
+        6: NVRTCCompilationError,
+        11: NVRTCInternalError,
+        '*': NVRTCError
+    }
+
+    # Functions
+    _functions = [
+        (c_int, 'nvrtcCreateProgram',  POINTER(c_void_p), c_char_p, c_char_p,
+         c_int, POINTER(c_char_p), POINTER(c_char_p)),
+        (c_int, 'nvrtcDestroyProgram', POINTER(c_void_p)),
+        (c_int, 'nvrtcCompileProgram', c_void_p, c_int, POINTER(c_char_p)),
+        (c_int, 'nvrtcGetPTXSize', c_void_p, POINTER(c_size_t)),
+        (c_int, 'nvrtcGetPTX', c_void_p, c_char_p),
+        (c_int, 'nvrtcGetProgramLogSize', c_void_p, POINTER(c_size_t)),
+        (c_int, 'nvrtcGetProgramLog', c_void_p, c_char_p)
+    ]
+
+
+class NVRTC(object):
+    def __init__(self):
+        self.lib = NVRTCWrappers()
+
+    def compile(self, name, src, flags=[]):
+        # Create the program
+        prog = c_void_p()
+        self.lib.nvrtcCreateProgram(prog, src.encode(), f'{name}.cu'.encode(),
+                                    0, None, None)
+
+        # Try to compile it
+        try:
+            if flags:
+                bflags = [f.encode() for f in flags]
+                aflags = (c_char_p * len(flags))(*bflags)
+            else:
+                aflags = None
+
+            try:
+                # Perform the compilation
+                self.lib.nvrtcCompileProgram(prog, len(flags), aflags)
+            except NVRTCError:
+                # Fetch the log size
+                logsz = c_size_t()
+                self.lib.nvrtcGetProgramLogSize(prog, logsz)
+
+                # Fetch the log itself
+                log = create_string_buffer(logsz.value)
+                self.lib.nvrtcGetProgramLog(prog, log)
+
+                raise RuntimeError(log.value.decode())
+
+            # Fetch the program size
+            ptxsz = c_size_t()
+            self.lib.nvrtcGetPTXSize(prog, ptxsz)
+
+            # Fetch the program itself
+            ptx = create_string_buffer(ptxsz.value)
+            self.lib.nvrtcGetPTX(prog, ptx)
+        finally:
+            # Destroy the program
+            self.lib.nvrtcDestroyProgram(prog)
+
+        return ptx.raw
+
+
+class SourceModule(object):
+    def __init__(self, backend, src):
+        # Prepare the source code
+        src = f'extern "C"\n{{\n{src}\n}}'
+
+        # Obtain the compute capability for our device
+        cmajor, cminor = backend.cuda.compute_capability()
+
+        # Compiler flags
+        flags = [
+            f'--gpu-architecture=compute_{cmajor}{cminor}',
+            '--ftz=true',
+            '--fmad=true'
+        ]
+
+        # Compile to PTX
+        ptx = backend.nvrtc.compile('kernel', src, flags)
+
+        # Load it as a module
+        self.mod = backend.cuda.load_module(ptx)
+
+    def get_function(self, name, argtypes, *, prefer_l1=None,
+                     prefer_shared=None):
+        argtypes = [npdtype_to_ctypestype(arg) for arg in argtypes]
+
+        fun = self.mod.get_function(name, argtypes)
+        fun.set_cache_pref(prefer_l1=prefer_l1, prefer_shared=prefer_shared)
+
+        return fun

--- a/pyfr/backends/cuda/driver.py
+++ b/pyfr/backends/cuda/driver.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+
+from ctypes import (POINTER, cast, c_char, c_char_p, c_int, c_size_t, c_uint,
+                    c_void_p, pointer)
+
+import numpy as np
+
+from pyfr.ctypesutil import LibWrapper
+
+
+# Possible CUDA exception types
+CUDAError = type('CUDAError', (Exception,), {})
+CUDAInvalidValue = type('CUDAInvalidValue', (CUDAError,), {})
+CUDAOutofMemory = type('CUDAOutofMemory', (CUDAError,), {})
+CUDANotInitalized = type('CUDANotInitalized', (CUDAError,), {})
+CUDAInvalidDevice = type('CUDAInvalidDevice', (CUDAError,), {})
+CUDAECCUncorrectable = type('CUDAECCUncorrectable', (CUDAError,), {})
+CUDAOSError = type('CUDAOSError', (CUDAError, OSError), {})
+CUDAInvalidHandle = type('CUDAInvalidHandle', (CUDAError,), {})
+CUDAIllegalAddress = type('CUDAIllegalAddress', (CUDAError,), {})
+CUDALaunchOutOfResources = type('CUDALaunchOutOfResources', (CUDAError,), {})
+CUDALaunchFailed = type('CUDALaunchFailed', (CUDAError,), {})
+CUDASystemDriverMismatch = type('CUDASystemDriverMismatch', (CUDAError,), {})
+
+
+class CUDAWrappers(LibWrapper):
+    _libname = 'cuda'
+
+    # Error codes
+    _statuses = {
+        1: CUDAInvalidValue,
+        2: CUDAOutofMemory,
+        3: CUDANotInitalized,
+        101: CUDAInvalidDevice,
+        214: CUDAECCUncorrectable,
+        304: CUDAOSError,
+        400: CUDAInvalidHandle,
+        700: CUDAIllegalAddress,
+        701: CUDALaunchOutOfResources,
+        719: CUDALaunchFailed,
+        803: CUDASystemDriverMismatch,
+        '*': CUDAError
+    }
+
+    # Constants
+    COMPUTE_CAPABILITY_MAJOR = 75
+    COMPUTE_CAPABILITY_MINOR = 76
+    EVENT_DISABLE_TIMING = 2
+    FUNC_CACHE_PREFER_NONE = 0
+    FUNC_CACHE_PREFER_SHARED = 1
+    FUNC_CACHE_PREFER_L1 = 2
+    FUNC_CACHE_PREFER_EQUAL = 3
+
+    # Functions
+    _functions = [
+        (c_int, 'cuInit', c_int),
+        (c_int, 'cuDeviceGet', POINTER(c_int), c_int),
+        (c_int, 'cuDeviceGetCount',  POINTER(c_int)),
+        (c_int, 'cuDeviceGetAttribute', POINTER(c_int), c_int, c_int),
+        (c_int, 'cuDevicePrimaryCtxRetain', POINTER(c_void_p), c_int),
+        (c_int, 'cuDevicePrimaryCtxRelease', c_int),
+        (c_int, 'cuCtxSetCurrent', c_void_p),
+        (c_int, 'cuCtxSetCacheConfig', c_int),
+        (c_int, 'cuMemAlloc_v2', POINTER(c_void_p), c_size_t),
+        (c_int, 'cuMemFree_v2', c_void_p),
+        (c_int, 'cuMemAllocHost_v2', POINTER(c_void_p), c_size_t),
+        (c_int, 'cuMemFreeHost', c_void_p),
+        (c_int, 'cuMemcpy', c_void_p, c_void_p, c_size_t),
+        (c_int, 'cuMemcpyAsync', c_void_p, c_void_p, c_size_t, c_void_p),
+        (c_int, 'cuMemsetD8_v2', c_void_p, c_char, c_size_t),
+        (c_int, 'cuStreamCreate', POINTER(c_void_p), c_uint),
+        (c_int, 'cuStreamDestroy_v2', c_void_p),
+        (c_int, 'cuStreamSynchronize', c_void_p),
+        (c_int, 'cuStreamWaitEvent', c_void_p, c_void_p, c_uint),
+        (c_int, 'cuEventCreate', POINTER(c_void_p), c_uint),
+        (c_int, 'cuEventDestroy_v2', c_void_p),
+        (c_int, 'cuEventRecord', c_void_p, c_void_p),
+        (c_int, 'cuModuleLoadDataEx', POINTER(c_void_p), c_char_p, c_uint,
+         POINTER(c_int), POINTER(c_void_p)),
+        (c_int, 'cuModuleUnload', c_void_p),
+        (c_int, 'cuModuleGetFunction', POINTER(c_void_p), c_void_p, c_char_p),
+        (c_int, 'cuLaunchKernel', c_void_p, c_uint, c_uint, c_uint, c_uint,
+         c_uint, c_uint, c_uint, c_void_p, POINTER(c_void_p), c_void_p),
+        (c_int, 'cuFuncSetCacheConfig', c_void_p, c_int)
+    ]
+
+    def _transname(self, name):
+        return name[:-3] if name.endswith('_v2') else name
+
+
+class _CUDABase(object):
+    _destroyfn = None
+
+    def __init__(self, cuda, ptr):
+        self.cuda = cuda
+        self._as_parameter_ = ptr.value
+
+    def __del__(self):
+        if self._destroyfn:
+            try:
+                getattr(self.cuda.lib, self._destroyfn)(self)
+            except AttributeError:
+                pass
+
+    def __int__(self):
+        return self._as_parameter_
+
+
+class CUDADevAlloc(_CUDABase):
+    _destroyfn = 'cuMemFree'
+
+    def __init__(self, cuda, nbytes):
+        ptr = c_void_p()
+        cuda.lib.cuMemAlloc(ptr, nbytes)
+
+        super().__init__(cuda, ptr)
+        self.nbytes = nbytes
+
+
+class CUDAHostAlloc(_CUDABase):
+    _destroyfn = 'cuMemFreeHost'
+
+    def __init__(self, cuda, nbytes):
+        self.nbytes = nbytes
+
+        ptr = c_void_p()
+        cuda.lib.cuMemAllocHost(ptr, nbytes)
+
+        super().__init__(cuda, ptr)
+
+
+class CUDAStream(_CUDABase):
+    _destroyfn = 'cuStreamDestroy'
+
+    def __init__(self, cuda):
+        ptr = c_void_p()
+        cuda.lib.cuStreamCreate(ptr, 0)
+
+        super().__init__(cuda, ptr)
+
+    def synchronize(self):
+        self.cuda.lib.cuStreamSynchronize(self)
+
+    def wait_for_event(self, event):
+        self.cuda.lib.cuStreamWaitEvent(self, event, 0)
+
+
+class CUDAEvent(_CUDABase):
+    _destroyfn = 'cuEventDestroy'
+
+    def __init__(self, cuda):
+        ptr = c_void_p()
+        cuda.lib.cuEventCreate(ptr, cuda.lib.EVENT_DISABLE_TIMING)
+
+        super().__init__(cuda, ptr)
+
+    def record(self, stream):
+        self.cuda.lib.cuEventRecord(self, stream)
+
+
+class CUDAModule(_CUDABase):
+    _destroyfn = 'cuModuleUnload'
+
+    def __init__(self, cuda, ptx):
+        ptr = c_void_p()
+        cuda.lib.cuModuleLoadDataEx(ptr, ptx, 0, None, None)
+
+        super().__init__(cuda, ptr)
+
+    def get_function(self, name, argspec):
+        return CUDAFunction(self.cuda, self, name, argspec)
+
+
+class CUDAFunction(_CUDABase):
+    def __init__(self, cuda, module, name, argtypes):
+        ptr = c_void_p()
+        cuda.lib.cuModuleGetFunction(ptr, module, name.encode())
+
+        super().__init__(cuda, ptr)
+
+        # Save a reference to our underlying module
+        self.module = module
+
+        # For each argument type instantiate the corresponding ctypes type
+        self._args = args = [atype() for atype in argtypes]
+
+        # Obtain pointers to these arguments
+        self._arg_ptrs = [cast(pointer(arg), c_void_p) for arg in args]
+        self._arg_ptrs = (c_void_p * len(args))(*self._arg_ptrs)
+
+    def set_cache_pref(self, *, prefer_l1=None, prefer_shared=None):
+        pref = self.cuda._get_cache_pref(prefer_l1, prefer_shared)
+        self.cuda.lib.cuFuncSetCacheConfig(self, pref)
+
+    def exec_async(self, grid, block, stream, *args):
+        for src, dst in zip(args, self._args):
+            dst.value = getattr(src, '_as_parameter_', src)
+
+        self.cuda.lib.cuLaunchKernel(self, *grid, *block, 0, stream,
+                                     self._arg_ptrs, None)
+
+
+class CUDA(object):
+    def __init__(self):
+        self.lib = CUDAWrappers()
+        self.ctx = c_void_p()
+
+        self.lib.cuInit(0)
+
+    def __del__(self):
+        if getattr(self, 'ctx', None):
+            self.lib.cuDevicePrimaryCtxRelease(self.dev)
+
+    def _get_cache_pref(self, prefer_l1, prefer_shared):
+        if prefer_l1 is None and prefer_shared is None:
+            return self.lib.FUNC_CACHE_PREFER_NONE
+        elif prefer_l1 and not prefer_shared:
+            return self.lib.FUNC_CACHE_PREFER_L1
+        elif prefer_shared and not prefer_l1:
+            return self.lib.FUNC_CACHE_PREFER_SHARED
+        else:
+            return self.lib.FUNC_CACHE_PREFER_EQUAL
+
+    def device_count(self):
+        count = c_int()
+        self.lib.cuDeviceGetCount(count)
+
+        return count.value
+
+    def set_device(self, devid):
+        if self.ctx:
+            raise RuntimeError('Device has already been set')
+
+        dev = c_int()
+        self.lib.cuDeviceGet(dev, devid)
+        self.lib.cuDevicePrimaryCtxRetain(self.ctx, dev)
+        self.lib.cuCtxSetCurrent(self.ctx)
+        self.dev = dev.value
+
+    def set_cache_pref(self, *, prefer_l1=None, prefer_shared=None):
+        pref = self._get_cache_pref(prefer_l1, prefer_shared)
+        self.lib.cuCtxSetCacheConfig(pref)
+
+    def compute_capability(self):
+        dev, lib = self.dev, self.lib
+
+        major, minor = c_int(), c_int()
+        lib.cuDeviceGetAttribute(major, lib.COMPUTE_CAPABILITY_MAJOR, dev)
+        lib.cuDeviceGetAttribute(minor, lib.COMPUTE_CAPABILITY_MINOR, dev)
+
+        return major.value, minor.value
+
+    def mem_alloc(self, nbytes):
+        return CUDADevAlloc(self, nbytes)
+
+    def pagelocked_empty(self, shape, dtype):
+        nbytes = np.prod(shape)*np.dtype(dtype).itemsize
+
+        alloc = CUDAHostAlloc(self, nbytes)
+        alloc.__array_interface__ = {
+            'version': 3,
+            'typestr': np.dtype(dtype).str,
+            'data': (int(alloc), False),
+            'shape': tuple(shape)
+        }
+
+        return np.array(alloc, copy=False)
+
+    def memcpy(self, dst, src, nbytes):
+        if isinstance(dst, (np.ndarray, np.generic)):
+            dst = dst.ctypes.data
+
+        if isinstance(src, (np.ndarray, np.generic)):
+            src = src.ctypes.data
+
+        self.lib.cuMemcpy(dst, src, nbytes)
+
+    def memcpy_async(self, dst, src, nbytes, stream):
+        if isinstance(dst, (np.ndarray, np.generic)):
+            dst = dst.ctypes.data
+
+        if isinstance(src, (np.ndarray, np.generic)):
+            src = src.ctypes.data
+
+        self.lib.cuMemcpyAsync(dst, src, nbytes, stream)
+
+    def memset(self, dst, val, nbytes):
+        self.lib.cuMemsetD8(dst, val, nbytes)
+
+    def load_module(self, ptx):
+        return CUDAModule(self, ptx)
+
+    def create_stream(self):
+        return CUDAStream(self)
+
+    def create_event(self):
+        return CUDAEvent(self)

--- a/pyfr/backends/cuda/gimmik.py
+++ b/pyfr/backends/cuda/gimmik.py
@@ -33,7 +33,8 @@ class CUDAGiMMiKKernels(CUDAKernelProvider):
                           alpha=alpha, beta=beta)
 
         # Build
-        fun = self._build_kernel('gimmik_mm', src, 'iPiPi')
+        fun = self._build_kernel('gimmik_mm', src,
+                                 [np.int32, np.intp]*2 + [np.int32])
 
         # Determine the grid/block
         block = (128, 1, 1)
@@ -41,8 +42,7 @@ class CUDAGiMMiKKernels(CUDAKernelProvider):
 
         class MulKernel(ComputeKernel):
             def run(self, queue):
-                fun.prepared_async_call(grid, block, queue.cuda_stream_comp,
-                                        b.ncol, b, b.leaddim, out,
-                                        out.leaddim)
+                fun.exec_async(grid, block, queue.cuda_stream_comp,
+                               b.ncol, b, b.leaddim, out, out.leaddim)
 
         return MulKernel()

--- a/pyfr/backends/cuda/packing.py
+++ b/pyfr/backends/cuda/packing.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import pycuda.driver as cuda
+import numpy as np
 
 from pyfr.backends.base import ComputeKernel, NullComputeKernel
 from pyfr.backends.base.packing import BasePackingKernels
@@ -9,6 +9,8 @@ from pyfr.backends.cuda.provider import CUDAKernelProvider, get_grid_for_block
 
 class CUDAPackingKernels(CUDAKernelProvider, BasePackingKernels):
     def pack(self, mv):
+        cuda = self.backend.cuda
+
         # An exchange view is simply a regular view plus an exchange matrix
         m, v = mv.xchgmat, mv.view
 
@@ -16,7 +18,7 @@ class CUDAPackingKernels(CUDAKernelProvider, BasePackingKernels):
         src = self.backend.lookup.get_template('pack').render()
 
         # Build
-        kern = self._build_kernel('pack_view', src, 'iiiPPPP')
+        kern = self._build_kernel('pack_view', src, [np.int32]*3 + [np.intp]*4)
 
         # Compute the grid and thread-block size
         block = (128, 1, 1)
@@ -29,14 +31,14 @@ class CUDAPackingKernels(CUDAKernelProvider, BasePackingKernels):
                     scomp = queue.cuda_stream_comp
 
                     # Pack
-                    kern.prepared_async_call(
+                    kern.exec_async(
                         grid, block, scomp, v.n, v.nvrow, v.nvcol, v.basedata,
                         v.mapping, v.rstrides or 0, m
                     )
         # Otherwise, we need to both pack the buffer and copy it back
         else:
             # Create a CUDA event
-            event = cuda.Event(cuda.event_flags.DISABLE_TIMING)
+            event = cuda.create_event()
 
             class PackXchgViewKernel(ComputeKernel):
                 def run(self, queue):
@@ -44,7 +46,7 @@ class CUDAPackingKernels(CUDAKernelProvider, BasePackingKernels):
                     scopy = queue.cuda_stream_copy
 
                     # Pack
-                    kern.prepared_async_call(
+                    kern.exec_async(
                         grid, block, scomp, v.n, v.nvrow, v.nvcol, v.basedata,
                         v.mapping, v.rstrides or 0, m
                     )
@@ -52,17 +54,19 @@ class CUDAPackingKernels(CUDAKernelProvider, BasePackingKernels):
                     # Copy the packed buffer to the host
                     event.record(scomp)
                     scopy.wait_for_event(event)
-                    cuda.memcpy_dtoh_async(m.hdata, m.data, scopy)
+                    cuda.memcpy_async(m.hdata, m.data, m.nbytes, scopy)
 
         return PackXchgViewKernel()
 
     def unpack(self, mv):
+        cuda = self.backend.cuda
+
         if self.backend.mpitype == 'cuda-aware':
             return NullComputeKernel()
         else:
             class UnpackXchgMatrixKernel(ComputeKernel):
                 def run(self, queue):
-                    cuda.memcpy_htod_async(mv.data, mv.hdata,
-                                           queue.cuda_stream_comp)
+                    cuda.memcpy_async(mv.data, mv.hdata, mv.nbytes,
+                                      queue.cuda_stream_comp)
 
             return UnpackXchgMatrixKernel()

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from pycuda import compiler, driver
-
 from pyfr.backends.base import (BaseKernelProvider,
                                 BasePointwiseKernelProvider, ComputeKernel)
-import pyfr.backends.cuda.generator as generator
+from pyfr.backends.cuda.generator import CUDAKernelGenerator
+from pyfr.backends.cuda.compiler import SourceModule
 from pyfr.util import memoize
 
 
@@ -16,21 +15,14 @@ def get_grid_for_block(block, nrow, ncol=1):
 class CUDAKernelProvider(BaseKernelProvider):
     @memoize
     def _build_kernel(self, name, src, argtypes):
-        # Compile the source code and retrieve the kernel
-        fun = compiler.SourceModule(src).get_function(name)
-
-        # Prepare the kernel for execution
-        fun.prepare(argtypes)
-
-        # Declare a preference for L1 cache over shared memory
-        fun.set_cache_config(driver.func_cache.PREFER_L1)
-
-        return fun
+        # Compile the source code and retrieve the function
+        mod = SourceModule(self.backend, src)
+        return mod.get_function(name, argtypes, prefer_l1=True)
 
 
 class CUDAPointwiseKernelProvider(CUDAKernelProvider,
                                   BasePointwiseKernelProvider):
-    kernel_generator_cls = generator.CUDAKernelGenerator
+    kernel_generator_cls = CUDAKernelGenerator
 
     def _instantiate_kernel(self, dims, fun, arglst):
         cfg = self.backend.cfg
@@ -46,9 +38,13 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
         grid = get_grid_for_block(block, *dims[::-1])
 
         class PointwiseKernel(ComputeKernel):
-            def run(self, queue, **kwargs):
-                narglst = [kwargs.get(ka, ka) for ka in arglst]
-                fun.prepared_async_call(grid, block, queue.cuda_stream_comp,
-                                        *narglst)
+            if any(isinstance(arg, str) for arg in arglst):
+                def run(self, queue, **kwargs):
+                    fun.exec_async(grid, block, queue.cuda_stream_comp,
+                                   *[kwargs.get(ka, ka) for ka in arglst])
+            else:
+                def run(self, queue, **kwargs):
+                    fun.exec_async(grid, block, queue.cuda_stream_comp,
+                                   *arglst)
 
         return PointwiseKernel()

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,6 @@ install_requires = [
 
 # Soft dependencies
 extras_require = {
-    'cuda': ['pycuda >= 2015.1'],
     'opencl': ['pyopencl >= 2015.2.4']
 }
 


### PR DESCRIPTION
This simplifies building PyFR on clusters and also enables us to make use of NVRTC.