### PR TITLE
Enhance the time averaging plugin.

### DIFF
--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -17,17 +17,19 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
     def __init__(self, intg, cfgsect, suffix=None):
         super().__init__(intg, cfgsect, suffix)
 
+        # Averaging mode
+        self.mode = self.cfg.get(cfgsect, 'mode', 'windowed')
+        if self.mode not in {'continuous', 'windowed'}:
+            raise ValueError('Invalid averaging mode')
+
         # Underlying elements class
         self.elementscls = intg.system.elementscls
 
-        # Expressions to time average
-        c = self.cfg.items_as('constants', float)
-        self.exprs = [(k, self.cfg.getexpr(cfgsect, k, subs=c))
-                      for k in self.cfg.items(cfgsect)
-                      if k.startswith('avg-')]
+        # Expressions pre-processing
+        self._prepare_exprs()
 
         # Construct the file writer
-        self._writer = self._init_writer_for_region(intg, len(self.exprs),
+        self._writer = self._init_writer_for_region(intg, len(self.outfields),
                                                     'tavg')
         # Gradient pre-processing
         self._init_gradients(intg)
@@ -37,22 +39,39 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
                       for i, rgn in self._ele_regions]
 
         # Time averaging parameters
+        self.tstart = self.cfg.getfloat(cfgsect, 'tstart', 0.0)
         self.dtout = self.cfg.getfloat(cfgsect, 'dt-out')
         self.nsteps = self.cfg.getint(cfgsect, 'nsteps')
-        self.tout_last = intg.tcurr
 
         # Register our output times with the integrator
         intg.call_plugin_dt(self.dtout)
 
-        # Time averaging state
-        self.prevt = intg.tcurr
-        self.prevex = self._eval_exprs(intg)
-        self.accmex = [np.zeros_like(p) for p in self.prevex]
+        # Mark ourselves as not currently averaging
+        self._started = False
+
+    def _prepare_exprs(self):
+        cfg, cfgsect = self.cfg, self.cfgsect
+        c = self.cfg.items_as('constants', float)
+        self.anames, self.aexprs = [], []
+        self.outfields, self.fexprs = [], []
+
+        # Iterate over accumulation expressions first
+        for k in cfg.items(cfgsect):
+            if k.startswith('avg-'):
+                self.anames.append(f'avg_{k[4:]}')
+                self.aexprs.append(cfg.getexpr(cfgsect, k, subs=c))
+                self.outfields.append(k)
+
+        # Followed by any functional expressions
+        for k in cfg.items(cfgsect):
+            if k.startswith('fun-avg-'):
+                self.fexprs.append(cfg.getexpr(cfgsect, k, subs=c))
+                self.outfields.append(k)
 
     def _init_gradients(self, intg):
         # Determine what gradients, if any, are required
         self._gradpnames = gradpnames = set()
-        for k, ex in self.exprs:
+        for ex in self.aexprs:
             gradpnames.update(re.findall(r'\bgrad_(.+?)_[xyz]\b', ex))
 
         # If gradients are required then form the relevant operators
@@ -73,7 +92,17 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
                 # Product to give J^-T at the solution points
                 self._rcpjact.append(smat[..., rgn]*rcpdjac[..., rgn])
 
-    def _eval_exprs(self, intg):
+    def _init_accumex(self, intg):
+        self.prevt = self.tout_last = intg.tcurr
+        self.prevex = self._eval_acc_exprs(intg)
+        self.accex = [np.zeros_like(p) for p in self.prevex]
+
+        # Extra state for continuous accumulation
+        if self.mode == 'continuous':
+            self.caccex = [np.zeros_like(p) for p in self.prevex]
+            self.tstart_actual = intg.tcurr
+
+    def _eval_acc_exprs(self, intg):
         exprs = []
 
         # Get the primitive variable names
@@ -110,25 +139,48 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
                     gradpn = gradpn.reshape(self.ndims, nupts, -1)
 
                     for dim, grad in zip('xyz', gradpn):
-                        subs['grad_{0}_{1}'.format(pname, dim)] = grad
+                        subs[f'grad_{pname}_{dim}'] = grad
 
             # Evaluate the expressions
-            exprs.append([npeval(v, subs) for k, v in self.exprs])
+            exprs.append([npeval(v, subs) for v in self.aexprs])
+
+        # Stack up the expressions for each element type and return
+        return [np.dstack(exs).swapaxes(1, 2) for exs in exprs]
+
+    def _eval_fun_exprs(self, intg, accex):
+        exprs = []
+
+        # Iterate over each element type our averaging region
+        for plocs, avals, in zip(self.plocs, accex):
+            # Prepare the substitution dictionary
+            subs = dict(zip('xyz', plocs.swapaxes(0, 1)))
+            subs.update(zip(self.anames, avals.swapaxes(0, 1)))
+
+            exprs.append([npeval(v, subs) for v in self.fexprs])
 
         # Stack up the expressions for each element type and return
         return [np.dstack(exs).swapaxes(1, 2) for exs in exprs]
 
     def __call__(self, intg):
-        tdiff = intg.tcurr - self.tout_last
-        dowrite = tdiff >= self.dtout - self.tol
+        # If we are not supposed to be averaging yet then return
+        if intg.tcurr < self.tstart:
+            return
+
+        # If necessary, run the start-up routines
+        if not self._started:
+            self._init_accumex(intg)
+            self._started = True
+
+        # See if we are due to write and/or accumulate this step
+        dowrite = intg.tcurr - self.tout_last >= self.dtout - self.tol
         doaccum = intg.nacptsteps % self.nsteps == 0
 
         if dowrite or doaccum:
             # Evaluate the time averaging expressions
-            currex = self._eval_exprs(intg)
+            currex = self._eval_acc_exprs(intg)
 
             # Accumulate them; always do this even when just writing
-            for a, p, c in zip(self.accmex, self.prevex, currex):
+            for a, p, c in zip(self.accex, self.prevex, currex):
                 a += 0.5*(intg.tcurr - self.prevt)*(p + c)
 
             # Save the time and solution
@@ -136,28 +188,47 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
             self.prevex = currex
 
             if dowrite:
-                # Normalise
-                accmex = [a / tdiff for a in self.accmex]
+                if self.mode == 'windowed':
+                    accex = self.accex
+                    tstart = self.tout_last
+                else:
+                    for a, c in zip(self.accex, self.caccex):
+                        c += a
 
+                    accex = self.caccex
+                    tstart = self.tstart_actual
+
+                # Normalise the accumulated expressions
+                data = [a / (intg.tcurr - tstart) for a in accex]
+
+                # Evaluate any functional expressions
+                if self.fexprs:
+                    funex = self._eval_fun_exprs(intg, data)
+                    data = [np.hstack([a, f]) for a, f in zip(data, funex)]
+
+                # Prepare the stats record
                 stats = Inifile()
                 stats.set('data', 'prefix', 'tavg')
-                stats.set('data', 'fields',
-                          ','.join(k for k, v in self.exprs))
-                stats.set('tavg', 'tstart', self.tout_last)
+                stats.set('data', 'fields', ','.join(self.outfields))
+                stats.set('tavg', 'tstart', tstart)
                 stats.set('tavg', 'tend', intg.tcurr)
                 intg.collect_stats(stats)
 
+                # Prepare the metadata
                 metadata = dict(intg.cfgmeta,
                                 stats=stats.tostr(),
                                 mesh_uuid=intg.mesh_uuid)
 
                 # Add in any required region data and write to disk
-                data = self._add_region_data(accmex)
+                data = self._add_region_data(data)
                 solnfname = self._writer.write(data, metadata, intg.tcurr)
 
                 # If a post-action has been registered then invoke it
                 self._invoke_postaction(mesh=intg.system.mesh.fname,
                                         soln=solnfname, t=intg.tcurr)
 
+                # Reset the accumulators
+                for a in self.accex:
+                    a.fill(0)
+
                 self.tout_last = intg.tcurr
-                self.accmex = [np.zeros_like(a) for a in accmex]


### PR DESCRIPTION
This PR contains several changes to the time averaging plugin.  Specifically:
 - It is possible to delay averaging until a specific simulation time with the `tstart` key.  This defaults to 0. 
 - It introduces a new kind of average called a `fun-avg` which can reference other average terms (but not the solution).  These can be used to compute fluctuations and are evaluated when the average is being written out to disk.
 - It adds a new `mode` key which dictates how the averaging process proceeds.  In `windowed` mode, which is the default, each output file contains just the average data for its `dt-out` time window.  In `continuous` mode each output file contains the average data from `tstart` until the current time.