### PR TITLE
integrate: use corrected velocity grads with Navier-Stokes

### DIFF
--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -134,12 +134,7 @@ class BaseIntegrator(object):
         else:
             return {'config': cfg, 'config-0': cfg}
 
-    def grad_pvars(self, pnames):
-        pnames = pnames if isinstance(pnames, Iterable) else [pnames]
-        for pname in pnames:
-            if pname not in self.system.elementscls.privarmap[self.system.ndims]:
-                raise ValueError(f'Gradient of non-primitive variable {pname} can not be computed')
-
+    def grad_pvars(self):
         try:
             # Fetch the corrected gradients only if needed
             grad_soln = self.grad_soln
@@ -161,9 +156,8 @@ class BaseIntegrator(object):
             pgrads = self.system.elementscls.grad_con_to_pri(soln, grad_soln, self.cfg)
 
             # Store the gradients
-            for pname in pnames:
-                idx = self.system.elementscls.privarmap[self.system.ndims].index(pname)
-                grads_ele.append(pgrads[idx])
+            for grad in pgrads:
+                grads_ele.append(grad)
             grads_eles.append(grads_ele)
         return grads_eles
 

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -135,13 +135,8 @@ class BaseIntegrator(object):
             return {'config': cfg, 'config-0': cfg}
 
     def grad_pvars(self):
-        try:
-            # Fetch the corrected gradients only if needed
-            grad_soln = self.grad_soln
-        except NotImplementedError:
-            # If the considered solver does not explictly compute gradients
-            # of primitive variables, then raise error
-            raise RuntimeError(f'Solver {self.system.name} not compatible with corrected gradients computation')
+        # Fetch the corrected gradients
+        grad_soln = self.grad_soln
 
         grads_eles = []
         for soln, grad_soln in zip(self.soln, self.grad_soln):
@@ -149,16 +144,15 @@ class BaseIntegrator(object):
             # Subset and transpose the solution
             soln = soln.swapaxes(0, 1)
 
-            # Subset and transpose the solution gradients
-            grad_soln = grad_soln.swapaxes(0, 2).swapaxes(1, 2)
+            # Rearrange gradient data
+            grad_soln = np.rollaxis(grad_soln, 2)
 
             # Transform from conservative to primitive gradients
             pgrads = self.system.elementscls.grad_con_to_pri(soln, grad_soln, self.cfg)
 
             # Store the gradients
-            for grad in pgrads:
-                grads_ele.append(grad)
-            grads_eles.append(grads_ele)
+            grads_eles.append(pgrads)
+
         return grads_eles
 
 class BaseCommon(object):

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -54,6 +54,9 @@ class BaseIntegrator(object):
         # Solution cache
         self._curr_soln = None
 
+        # Solution gradients cache
+        self._curr_grad_soln = None
+
         # Record the starting wall clock time
         self._wstart = time.time()
 

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from collections import deque
-from collections import Iterable
 import itertools as it
 import re
 import time
@@ -134,26 +133,6 @@ class BaseIntegrator(object):
         else:
             return {'config': cfg, 'config-0': cfg}
 
-    def grad_pvars(self):
-        # Fetch the corrected gradients
-        grad_soln = self.grad_soln
-
-        grads_eles = []
-        for soln, grad_soln in zip(self.soln, self.grad_soln):
-            grads_ele = []
-            # Subset and transpose the solution
-            soln = soln.swapaxes(0, 1)
-
-            # Rearrange gradient data
-            grad_soln = np.rollaxis(grad_soln, 2)
-
-            # Transform from conservative to primitive gradients
-            pgrads = self.system.elementscls.grad_con_to_pri(soln, grad_soln, self.cfg)
-
-            # Store the gradients
-            grads_eles.append(pgrads)
-
-        return grads_eles
 
 class BaseCommon(object):
     def _init_reg_banks(self):

--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -52,7 +52,7 @@ class BaseDualIntegrator(BaseIntegrator):
         # If we do not have the solution gradients cached then compute and fetch them
         if not self._curr_grad_soln:
             self.system.compute_grads(self.tcurr, self.pseudointegrator._idxcurr)
-            self._curr_grad_soln = self.system.eles_vect_upts_inb.get()
+            self._curr_grad_soln = self.system.eles_vect_upts.get()
 
         return self._curr_grad_soln
 

--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -52,7 +52,7 @@ class BaseDualIntegrator(BaseIntegrator):
         # If we do not have the solution gradients cached then compute and fetch them
         if not self._curr_grad_soln:
             self.system.compute_grads(self.tcurr, self.pseudointegrator._idxcurr)
-            self._curr_grad_soln = self.system.ele_vect_upts()
+            self._curr_grad_soln = self.system.eles_vect_upts_inb.get()
 
         return self._curr_grad_soln
 

--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -47,6 +47,15 @@ class BaseDualIntegrator(BaseIntegrator):
 
         return self._curr_soln
 
+    @property
+    def grad_soln(self):
+        # If we do not have the solution gradients cached then compute and fetch them
+        if not self._curr_grad_soln:
+            self.system.compute_grads(self.tcurr, self.pseudointegrator._idxcurr)
+            self._curr_grad_soln = self.system.ele_vect_upts()
+
+        return self._curr_grad_soln
+
     def call_plugin_dt(self, dt):
         rem = math.fmod(dt, self._dt)
         tol = 5.0*self.dtmin

--- a/pyfr/integrators/dual/phys/controllers.py
+++ b/pyfr/integrators/dual/phys/controllers.py
@@ -22,6 +22,9 @@ class BaseDualController(BaseDualIntegrator):
         # Invalidate the solution cache
         self._curr_soln = None
 
+        # Invalidate the solution gradients cache
+        self._curr_grad_soln = None
+
         # Fire off any event handlers
         self.completed_step_handlers(self)
 

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -52,7 +52,7 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
         # If we do not have the solution gradients cached then compute and fetch them
         if not self._curr_grad_soln:
             self.system.compute_grads(self.tcurr, self._idxcurr)
-            self._curr_grad_soln = self.system.eles_vect_upts_inb.get()
+            self._curr_grad_soln = self.system.eles_vect_upts.get()
 
         return self._curr_grad_soln
 

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -52,7 +52,7 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
         # If we do not have the solution gradients cached then compute and fetch them
         if not self._curr_grad_soln:
             self.system.compute_grads(self.tcurr, self._idxcurr)
-            self._curr_grad_soln = self.system.ele_vect_upts()
+            self._curr_grad_soln = self.system.eles_vect_upts_inb.get()
 
         return self._curr_grad_soln
 

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -48,6 +48,15 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
         return self._curr_soln
 
     @property
+    def grad_soln(self):
+        # If we do not have the solution gradients cached then compute and fetch them
+        if not self._curr_grad_soln:
+            self.system.compute_grads(self.tcurr, self._idxcurr)
+            self._curr_grad_soln = self.system.ele_vect_upts()
+
+        return self._curr_grad_soln
+
+    @property
     def _controller_needs_errest(self):
         pass
 

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -34,6 +34,9 @@ class BaseStdController(BaseStdIntegrator):
         # Invalidate the solution cache
         self._curr_soln = None
 
+        # Invalidate the solution gradients cache
+        self._curr_grad_soln = None
+
         # Fire off any event handlers
         self.completed_step_handlers(self)
 

--- a/pyfr/plugins/integrate.py
+++ b/pyfr/plugins/integrate.py
@@ -130,9 +130,10 @@ class IntegratePlugin(BasePlugin):
         # Get the primitive variable names
         pnames = self.elementscls.privarmap[self.ndims]
 
-        # Compute any required gradients
+        # Compute primitive gradients if required
         if self._gradpnames:
             grads_eles = intg.grad_pvars()
+
         # Iterate over each element type in the simulation
         for i, (soln, eleinfo) in enumerate(zip(intg.soln, self.eleinfo)):
             plocs, wts, eset, emask = eleinfo
@@ -147,7 +148,7 @@ class IntegratePlugin(BasePlugin):
             subs = dict(zip(pnames, psolns))
             subs.update(zip('xyz', plocs))
 
-            # Compute any required gradients
+            # Prepare any required gradient
             if self._gradpnames:
                 gradps = grads_eles[i]
                 for pname in self._gradpnames:

--- a/pyfr/plugins/integrate.py
+++ b/pyfr/plugins/integrate.py
@@ -132,7 +132,7 @@ class IntegratePlugin(BasePlugin):
 
         # Compute any required gradients
         if self._gradpnames:
-            grads_eles = intg.grad_pvars(self._gradpnames)
+            grads_eles = intg.grad_pvars()
         # Iterate over each element type in the simulation
         for i, (soln, eleinfo) in enumerate(zip(intg.soln, self.eleinfo)):
             plocs, wts, eset, emask = eleinfo
@@ -150,8 +150,9 @@ class IntegratePlugin(BasePlugin):
             # Compute any required gradients
             if self._gradpnames:
                 gradps = grads_eles[i]
-                for gradpn, pname in zip(gradps, self._gradpnames):
-                    gradpn = gradpn[..., eset]
+                for pname in self._gradpnames:
+                    idx = self.elementscls.privarmap[self.ndims].index(pname)
+                    gradpn = gradps[idx][..., eset]
                     for dim, grad in zip('xyz', gradpn):
                         subs[f'grad_{pname}_{dim}'] = grad
 

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -69,9 +69,13 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
 
     def _init_gradients(self, intg):
         # Determine what gradients, if any, are required
-        self._gradpnames = gradpnames = set()
+        gradpnames = set()
         for ex in self.aexprs:
             gradpnames.update(re.findall(r'\bgrad_(.+?)_[xyz]\b', ex))
+
+        privarmap = self.elementscls.privarmap[self.ndims]
+        self._gradpinfo = [(pname, privarmap.index(pname)) 
+                            for pname in gradpnames]
 
         # If gradients are required then form the relevant operators
         if gradpnames:
@@ -108,8 +112,8 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
         pnames = self.elementscls.privarmap[self.ndims]
 
         # Compute primitive gradients if required
-        if self._gradpnames:
-            grads_eles = intg.grad_pvars()
+        if self._gradpinfo:
+            grads_eles = self._grad_pvars(intg)
 
         # Iterate over each element type in the simulation
         for i, (j, rgn) in enumerate(self._ele_regions):
@@ -122,14 +126,10 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
             # Prepare the substitutions dictionary
             subs = dict(zip(pnames, psolns))
 
-            # Prepare any required gradient
-            if self._gradpnames:
-                gradps = grads_eles[j]
-                for pname in self._gradpnames:
-                    idx = self.elementscls.privarmap[self.ndims].index(pname)
-                    gradpn = gradps[idx][..., rgn]
-                    for dim, grad in zip('xyz', gradpn):
-                        subs[f'grad_{pname}_{dim}'] = grad
+            # Prepare any required gradients
+            for pname, idx in self._gradpinfo:
+                for dim, grad in zip('xyz', grads_eles[i][idx]):
+                    subs[f'grad_{pname}_{dim}'] = grad
 
             # Evaluate the expressions
             exprs.append([npeval(v, subs) for v in self.aexprs])
@@ -149,6 +149,25 @@ class TavgPlugin(PostactionMixin, RegionMixin, BasePlugin):
 
         # Stack up the expressions for each element type and return
         return [np.dstack(exs).swapaxes(1, 2) for exs in exprs]
+
+    def _grad_pvars(self, intg):
+        grads_eles = []
+
+        # Iterate over each element type in the simulation
+        for i, (j, rgn) in enumerate(self._ele_regions):
+            # Subset and transpose the solution
+            soln = intg.soln[j][..., rgn].swapaxes(0, 1)
+            
+            # Rearrange and subset gradient data
+            grad_soln = np.rollaxis(intg.grad_soln[j], 2)[..., rgn]
+
+            # Transform from conservative to primitive gradients
+            pgrads = self.elementscls.grad_con_to_pri(soln, grad_soln, self.cfg)
+
+            # Store the gradients
+            grads_eles.append(pgrads)
+
+        return grads_eles
 
     def __call__(self, intg):
         # If we are not supposed to be averaging yet then return

--- a/pyfr/solvers/acnavstokes/elements.py
+++ b/pyfr/solvers/acnavstokes/elements.py
@@ -8,7 +8,7 @@ class ACNavierStokesElements(BaseACFluidElements,
                              BaseAdvectionDiffusionElements):
     @staticmethod
     def grad_con_to_pri(cons, grad_cons, cfg):
-        return [grad for grad in grad_cons]
+        return grad_cons
 
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)

--- a/pyfr/solvers/acnavstokes/elements.py
+++ b/pyfr/solvers/acnavstokes/elements.py
@@ -6,9 +6,6 @@ from pyfr.solvers.baseadvecdiff import BaseAdvectionDiffusionElements
 
 class ACNavierStokesElements(BaseACFluidElements,
                              BaseAdvectionDiffusionElements):
-    gradconvarmap = {k : [f'grad_{var}' for var in v] for k, v in BaseACFluidElements.convarmap.items()}
-    gradprivarmap = {k : [f'grad_{var}' for var in v] for k, v in BaseACFluidElements.privarmap.items()}
-
     @staticmethod
     def grad_con_to_pri(cons, grad_cons, cfg):
         return [grad for grad in grad_cons]

--- a/pyfr/solvers/acnavstokes/elements.py
+++ b/pyfr/solvers/acnavstokes/elements.py
@@ -6,6 +6,13 @@ from pyfr.solvers.baseadvecdiff import BaseAdvectionDiffusionElements
 
 class ACNavierStokesElements(BaseACFluidElements,
                              BaseAdvectionDiffusionElements):
+    gradconvarmap = {k : [f'grad_{var}' for var in v] for k, v in BaseACFluidElements.convarmap.items()}
+    gradprivarmap = {k : [f'grad_{var}' for var in v] for k, v in BaseACFluidElements.privarmap.items()}
+
+    @staticmethod
+    def grad_con_to_pri(cons, grad_cons, cfg):
+        return [grad for grad in grad_cons]
+
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)
 

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -212,10 +212,6 @@ class BaseElements(object):
         self.scal_upts_inb = inb = backend.matrix_bank(self._scal_upts)
         self.scal_upts_outb = backend.matrix_bank(self._scal_upts)
 
-        # Allocate and bank the storage required to store the solution grads
-        # which will be used by post-processing plugins
-        self.vect_upts_inb = self._vect_upts
-
         # Find/allocate space for a solution-sized scalar that is
         # allowed to alias other scratch space in the simulation
         aliases = next((m for m in abufs if m.nbytes >= inb.nbytes), None)

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -212,6 +212,10 @@ class BaseElements(object):
         self.scal_upts_inb = inb = backend.matrix_bank(self._scal_upts)
         self.scal_upts_outb = backend.matrix_bank(self._scal_upts)
 
+        # Allocate and bank the storage required to store the solution grads
+        # which will be used by post-processing plugins
+        self.vect_upts_inb = backend.matrix_bank([self._vect_upts])
+
         # Find/allocate space for a solution-sized scalar that is
         # allowed to alias other scratch space in the simulation
         aliases = next((m for m in abufs if m.nbytes >= inb.nbytes), None)

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -214,7 +214,7 @@ class BaseElements(object):
 
         # Allocate and bank the storage required to store the solution grads
         # which will be used by post-processing plugins
-        self.vect_upts_inb = backend.matrix_bank([self._vect_upts])
+        self.vect_upts_inb = self._vect_upts
 
         # Find/allocate space for a solution-sized scalar that is
         # allowed to alias other scratch space in the simulation

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -188,7 +188,7 @@ class BaseSystem(object):
         pass
 
     def compute_grads(self, t, uinbank):
-        pass
+        raise NotImplementedError()
 
     def filt(self, uinoutbank):
         self.eles_scal_upts_inb.active = uinoutbank

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -48,7 +48,7 @@ class BaseSystem(object):
         # I/O banks for the elements
         self.eles_scal_upts_inb = eles.scal_upts_inb
         self.eles_scal_upts_outb = eles.scal_upts_outb
-        self.eles_vect_upts_inb = eles.vect_upts_inb
+        self.eles_vect_upts = eles._vect_upts
 
         # Save the number of dimensions and field variables
         self.ndims = eles[0].ndims
@@ -188,7 +188,8 @@ class BaseSystem(object):
         pass
 
     def compute_grads(self, t, uinbank):
-        raise NotImplementedError()
+        raise NotImplementedError(f'Solver "{self.name}" does not compute '
+                                  'corrected gradients of the solution')
 
     def filt(self, uinoutbank):
         self.eles_scal_upts_inb.active = uinoutbank

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -42,15 +42,13 @@ class BaseSystem(object):
         self.ele_ndofs = [e.neles*e.nupts*e.nvars for e in eles]
         self.ele_shapes = [(e.nupts, e.nvars, e.neles) for e in eles]
 
-        # Get the gradient banks
-        self.ele_grad_banks = list(eles.vect_upts_inb)
-
         # Get all the solution point locations for the elements
         self.ele_ploc_upts = [e.ploc_at_np('upts') for e in eles]
 
         # I/O banks for the elements
         self.eles_scal_upts_inb = eles.scal_upts_inb
         self.eles_scal_upts_outb = eles.scal_upts_outb
+        self.eles_vect_upts_inb = eles.vect_upts_inb
 
         # Save the number of dimensions and field variables
         self.ndims = eles[0].ndims
@@ -199,6 +197,3 @@ class BaseSystem(object):
 
     def ele_scal_upts(self, idx):
         return [eb[idx].get() for eb in self.ele_banks]
-
-    def ele_vect_upts(self):
-        return [eb[0].get() for eb in self.ele_grad_banks]

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -42,6 +42,9 @@ class BaseSystem(object):
         self.ele_ndofs = [e.neles*e.nupts*e.nvars for e in eles]
         self.ele_shapes = [(e.nupts, e.nvars, e.neles) for e in eles]
 
+        # Get the gradient banks
+        self.ele_grad_banks = list(eles.vect_upts_inb)
+
         # Get all the solution point locations for the elements
         self.ele_ploc_upts = [e.ploc_at_np('upts') for e in eles]
 
@@ -186,6 +189,9 @@ class BaseSystem(object):
     def rhs(self, t, uinbank, foutbank):
         pass
 
+    def compute_grads(self, t, uinbank):
+        pass
+
     def filt(self, uinoutbank):
         self.eles_scal_upts_inb.active = uinoutbank
 
@@ -193,3 +199,6 @@ class BaseSystem(object):
 
     def ele_scal_upts(self, idx):
         return [eb[idx].get() for eb in self.ele_banks]
+
+    def ele_vect_upts(self):
+        return [eb[0].get() for eb in self.ele_grad_banks]

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -65,3 +65,38 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         q1.enqueue(kernels['eles', 'tdivtconf'])
         q1.enqueue(kernels['eles', 'negdivconf'], t=t)
         runall([q1])
+
+    def compute_grads(self, t, uinbank, foutbank):
+        runall = self.backend.runall
+        q1, q2 = self._queues
+        kernels = self._kernels
+
+        self._bc_inters.prepare(t)
+
+        self.eles_scal_upts_inb.active = uinbank
+        self.eles_scal_upts_outb.active = foutbank
+
+        q1.enqueue(kernels['eles', 'disu'])
+        q1.enqueue(kernels['mpiint', 'scal_fpts_pack'])
+        runall([q1])
+        if ('eles', 'copy_soln') in kernels:
+            q1.enqueue(kernels['eles', 'copy_soln'])
+        if ('iint', 'copy_fpts') in kernels:
+            q1.enqueue(kernels['iint', 'copy_fpts'])
+        q1.enqueue(kernels['iint', 'con_u'])
+        q1.enqueue(kernels['bcint', 'con_u'], t=t)
+        if ('eles', 'shocksensor') in kernels:
+            q1.enqueue(kernels['eles', 'shocksensor'])
+            q1.enqueue(kernels['mpiint', 'artvisc_fpts_pack'])
+        q1.enqueue(kernels['eles', 'tgradpcoru_upts'])
+        q2.enqueue(kernels['mpiint', 'scal_fpts_send'])
+        q2.enqueue(kernels['mpiint', 'scal_fpts_recv'])
+        q2.enqueue(kernels['mpiint', 'scal_fpts_unpack'])
+
+        runall([q1, q2])
+
+        q1.enqueue(kernels['mpiint', 'con_u'])
+        q1.enqueue(kernels['eles', 'tgradcoru_upts'])
+        q1.enqueue(kernels['eles', 'gradcoru_upts'])
+
+        runall([q1])

--- a/pyfr/solvers/navstokes/elements.py
+++ b/pyfr/solvers/navstokes/elements.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
+
 from pyfr.solvers.baseadvecdiff import BaseAdvectionDiffusionElements
 from pyfr.solvers.euler.elements import BaseFluidElements
 
@@ -10,23 +12,25 @@ class NavierStokesElements(BaseFluidElements, BaseAdvectionDiffusionElements):
 
     @staticmethod
     def grad_con_to_pri(cons, grad_cons, cfg):
-        rho = cons[0]
-        grad_rho = grad_cons[0]
-        grad_E = grad_cons[-1]
-        # Divide momentum components by rho
-        vs = [rhov/rho for rhov in cons[1:-1]]
+        rho, *rhouvw = cons[:-1]
+        grad_rho, *grad_rhouvw, grad_E = grad_cons
+        
+        # Divide momentum components by ρ
+        uvw = [rhov/rho for rhov in rhouvw]
 
         # Velocity gradients
-        grad_v = [(grad_rhov - v*grad_rho)/rho for grad_rhov, v in zip(grad_cons[1:-1], vs)]
+        # ∇(\vec{u}) = 1/ρ·[∇(ρ\vec{u}) - \vec{u} \otimes ∇ρ]
+        grad_uvw = [(grad_rhov - v*grad_rho)/rho 
+                    for grad_rhov, v in zip(grad_rhouvw, uvw)]
 
         # Pressure gradient
+        # ∇p = (gamma - 1)·[∇E - 1/2*(\vec{u}·∇(ρ\vec{u}) - ρ\vec{u}·∇(\vec{u}))]
         gamma = cfg.getfloat('constants', 'gamma')
-        grad_p = grad_E - 0.5*sum(v*v for v in vs)*grad_rho
-        for vel, grad_vel in zip(vs, grad_v):
-            grad_p -= rho*vel*grad_vel
+        grad_p = grad_E - 0.5*(np.einsum('ijk, iljk -> ljk', uvw, grad_rhouvw) +
+                               np.einsum('ijk, iljk -> ljk', rhouvw, grad_uvw))
         grad_p *= (gamma - 1)
 
-        return [grad_rho] + grad_v + [grad_p]
+        return [grad_rho] + grad_uvw + [grad_p]
 
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)

--- a/pyfr/solvers/navstokes/elements.py
+++ b/pyfr/solvers/navstokes/elements.py
@@ -20,15 +20,13 @@ class NavierStokesElements(BaseFluidElements, BaseAdvectionDiffusionElements):
         # Divide momentum components by rho
         vs = [rhov/rho for rhov in cons[1:-1]]
 
-        # velocity gradients
-        grad_v = [(grad_cons[i + 1] - vel*grad_rho)/rho for i, vel in enumerate(vs)]
+        # Velocity gradients
+        grad_v = [(grad_rhov - v*grad_rho)/rho for grad_rhov, v in zip(grad_cons[1:-1], vs)]
 
-        # pressure gradient
+        # Pressure gradient
         gamma = cfg.getfloat('constants', 'gamma')
-        vsqr = sum(v*v for v in vs)
-        grad_p = grad_E.copy()
-        grad_p -= 0.5*vsqr*grad_rho
-        for i, (vel, grad_vel) in enumerate(zip(vs, grad_v)):
+        grad_p = grad_E - 0.5*sum(v*v for v in vs)*grad_rho
+        for vel, grad_vel in zip(vs, grad_v):
             grad_p -= rho*vel*grad_vel
         grad_p *= (gamma - 1)
 

--- a/pyfr/solvers/navstokes/elements.py
+++ b/pyfr/solvers/navstokes/elements.py
@@ -8,10 +8,6 @@ class NavierStokesElements(BaseFluidElements, BaseAdvectionDiffusionElements):
     # Use the density field for shock sensing
     shockvar = 'rho'
 
-    gradconvarmap = {k : [f'grad_{var}' for var in v] for k, v in BaseFluidElements.convarmap.items()}
-
-    gradprivarmap = {k : [f'grad_{var}' for var in v] for k, v in BaseFluidElements.privarmap.items()}
-
     @staticmethod
     def grad_con_to_pri(cons, grad_cons, cfg):
         rho = cons[0]


### PR DESCRIPTION
Hi everyone,

It seems that when analyzing the pressure-dilatation terms  of the default TGV vortex [1] using the integrate plugin as

`int-dissipationPressure = p*(grad_u_x + grad_v_y + grad_w_z)`

, the results are very far from the expected ones (two-order of magnitudes higher), although other quantities such as kinetic energy dissipation are very close to those shown in the literature. I also observed these issues with my in-house code (which uses a similar approach to compute the gradients in the postprocessing stages). Therefore, I tried to fix the issue by relying on the corrected gradients of the velocity at solution points, instead of the gradients computed using the nodal solution basis. When using these corrected gradients, the results are much closer to those obtained in the literature. 

I suppose that this is not the cleanest implementation (only compatible with the `navier-stokes` solver) and it will harm the performance (extra copy operations) and also increase the spatial complexity of the implementation (due to the need of storing a copy of `_vect_upts`). Anyway, I'll leave this implementation in the PR in case anyone needs to postprocess this pressure dilation term with PyFR.

[1] DeBonis, J. (2013), “Solutions of the Taylor-Green vortex problem using high-resolution explicit finite
difference methods”, In 51st AIAA Aerospace Sciences Meeting including the New Horizons Forum and Aerospace Exposition, p. 382.