### PR TITLE
Partition: lower tolerance to select non-linear cells

### DIFF
--- a/pyfr/partitioners/base.py
+++ b/pyfr/partitioners/base.py
@@ -14,7 +14,7 @@ from pyfr.util import subclass_where
 Graph = namedtuple('Graph', ['vtab', 'etab', 'vwts', 'ewts'])
 
 
-def _find_curved_eles(etype, eles, tol=1e-5):
+def _find_curved_eles(etype, eles, tol=1e-15):
     nspts, neles, ndims = eles.shape
 
     shape = subclass_where(BaseShape, name=etype)


### PR DESCRIPTION
## Short description

I was having issues with a SD7003 simulation in which the pressure coefficient was not consistent with reference values obtained with PyFR. To understand these issues I have tried to assess if the free-stream condition was assessed in this case. After some tests, I observed free-stream preservation issues after partitioning a mesh with non-linear cells. 

With some debugging I have found that this issue disappears if the `tol` parameter in `_find_curved_eles` is set to `0`. In that case all non-linear elements are tagged as non-linear cells. Moreover, in my tests a value of `tol=1e-15` ensures that non-linear cells with straight edges are tagged as linear cells, but I'm not sure if there exists an appropriate value of `tol` which allows to select non-linear cells with linear shapes.

## More details

I’m simulating the SD7003 test case provided by

B.C. Vermeire, F.D. Witherden, P.E. Vincent,
On the utility of GPU accelerated high-order methods for unsteady flow simulations: A comparison with industry-standard tools,
Journal of Computational Physics, Volume 334, 2017,
https://doi.org/10.1016/j.jcp.2016.12.049.

whose mesh consists of approximately 1.5E5 degree 2 hexahedrons (hex27) and p=4 (therefore there should not be any free-stream preservation issues theoretically even when using the true metrics). I’m having some issues when trying to replicate the results provided in the aforementioned study so I’ve tried to study if there could be an issue with non-linear cells.
I have changed the BCs definition so that they all behave as inlet conditions equal to the initial condition and I have modified the initial condition to ensure that it is constant over all the domain (see the attached ini)

With such test case definition, one expects the solution to remain constant over time (free-stream preservation condition). However, I have simulated this test case (after partitioning it with 2 ranks) using the current develop branch of PyFR and as one can observe in the attached figure, there exists generation of spurious velocities in cells close to the walls and at the interface between mesh blocks (zones where non-linear Jacobians are important I suppose). These regions are also located close to zones in which my simulations do not show the same results as those in the aforementioned article.

![image](https://user-images.githubusercontent.com/11050889/108513118-7067ba00-72c2-11eb-9613-ee7e3b011e0d.png)
`sd7003.ini`
```ini
[backend]
precision = double

[backend-openmp]
cc = gcc
gimmik-max-nnz = 200000000

[backend-cuda]
device-id = local-rank
gimmik-max-nnz = 512000000
mpi-type = standard

[constants]
gamma = 1.4
mu    = 3.94405318873308E-6
Pr    = 0.72
M     = 0.2

[solver-time-integrator]
scheme = rk45
controller = pi
t0 = 0.0
dt = 0.0001
tend = 200
atol = 0.00001
rtol = 0.00001
safety-fact = 0.9
min-fact = 0.3
max-fact = 1.15

[solver]
system = navier-stokes
order  = 4

[solver-interfaces]
riemann-solver = rusanov
ldg-beta = 0.0
ldg-tau = 0.0

[solver-interfaces-line]
flux-pts = gauss-legendre

[solver-interfaces-quad]
flux-pts = gauss-legendre

[solver-elements-hex]
soln-pts = gauss-legendre

[soln-bcs-outlet]
type = char-riem-inv
rho = 1.0
u   = 0.2366431913
v   = 0.0
w   = 0.0
p   = 1.0

[soln-bcs-inlet]
type = char-riem-inv
rho = 1.0
u   = 0.2366431913
v   = 0.0
w   = 0.0
p   = 1.0

[soln-bcs-wall]
type = char-riem-inv
rho = 1.0
u   = 0.2366431913
v   = 0.0
w   = 0.0
p   = 1.0

[soln-ics]
rho  = 1.0
u    = 0.2366431913
v    = 0.0
w    = 0.0
p    = 1.0

[soln-plugin-writer]
dt-out = 0.001
basedir = ./
basename = slice_sd7003_{t:.3f}
region = [(-3, -3, -0.9), (3, 3, 1.1)]
post-action = echo "Wrote slice file {soln} at time {t} for mesh {mesh}."
post-action-mode = non-blocking

; [soln-plugin-integrate]
; nsteps = 1
; file = integrate
; int-rho = rho - 1.0
; int-u = u - 0.2366431913

```


