### PR TITLE
Python 3.10 support

### DIFF
--- a/pyfr/backends/base/makoutil.py
+++ b/pyfr/backends/base/makoutil.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from collections import Iterable
+from collections.abc import Iterable
 import itertools as it
 import re
 

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from collections import Sequence, deque
+from collections import deque
+from collections.abc import Sequence
 
 import numpy as np
 

--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from ast import literal_eval
-from configparser import SafeConfigParser, NoSectionError, NoOptionError
+from configparser import ConfigParser, NoSectionError, NoOptionError
 import io
 import os
 import re
@@ -17,7 +17,7 @@ _sentinel = object()
 
 class Inifile(object):
     def __init__(self, inistr=None):
-        self._cp = cp = SafeConfigParser(inline_comment_prefixes=[';'])
+        self._cp = cp = ConfigParser(inline_comment_prefixes=[';'])
 
         # Preserve case
         cp.optionxform = str

--- a/pyfr/polys.py
+++ b/pyfr/polys.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from collections import Iterable
+from collections.abc import Iterable
 from math import sqrt
 
 import numpy as np

--- a/pyfr/quadrules/__init__.py
+++ b/pyfr/quadrules/__init__.py
@@ -38,8 +38,8 @@ class BaseTabulatedQuadRule(object):
             pts = [p[0] for p in pts]
 
         # Cast
-        self.pts = np.array(pts, dtype=np.float)
-        self.wts = np.array(wts, dtype=np.float)
+        self.pts = np.array(pts)
+        self.wts = np.array(wts)
 
 
 class BaseStoredQuadRule(BaseTabulatedQuadRule):

--- a/pyfr/readers/native.py
+++ b/pyfr/readers/native.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from collections import Mapping
+from collections.abc import Mapping
 import os
 import re
 


### PR DESCRIPTION
This PR migrates away from various deprecated interfaces which are going away in Python 3.9 and future NumPy releases.