### PR TITLE
Integrate plugin enhancements (quad-deg, quad-pts and access to tcurr)

### DIFF
--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -1513,8 +1513,13 @@ Integrate quantities over the compuational domain. Parameterised with:
 
     *boolean*
 
-4. ``int``-*name* --- expression to integrate, written as a function of
-   the primitive variables and gradients thereof; multiple expressions,
+4. ``quad-deg`` --- degree of quadrature rule (optional):
+
+5. ``quad-pts-{etype}`` --- name of quadrature rule (optional):
+
+6. ``int``-*name* --- expression to integrate, written as a function of
+   the primitive variables and gradients thereof, the physical coordinates
+   [x, y, [z]] and/or the physical time [t]; multiple expressions,
    each with their own *name*, may be specified:
 
     *string*
@@ -1525,6 +1530,7 @@ Example::
     nsteps = 50
     file = integral.csv
     header = true
+    quad-deg = 9
     vor1 = (grad_w_y - grad_v_z)
     vor2 = (grad_u_z - grad_w_x)
     vor3 = (grad_v_x - grad_u_y)

--- a/pyfr/plugins/integrate.py
+++ b/pyfr/plugins/integrate.py
@@ -129,6 +129,7 @@ class IntegratePlugin(BasePlugin):
             # Prepare the substitutions dictionary
             subs = dict(zip(pnames, psolns))
             subs.update(zip('xyz', plocs))
+            subs.update({'t': intg.tcurr})
 
             # Prepare any required gradients
             if self._gradpinfo:

--- a/pyfr/plugins/integrate.py
+++ b/pyfr/plugins/integrate.py
@@ -52,25 +52,36 @@ class IntegratePlugin(BasePlugin):
             # Open
             self.outf = init_csv(self.cfg, cfgsect, ','.join(header))
 
+        # Whether to use a quadrature different to that of the solution points
+        quad = self.cfg.hasopt(cfgsect, 'quad-deg')
+
         # Prepare the per element-type info list
         self.eleinfo = eleinfo = []
         for (ename, eles), (eset, emask) in zip(system.ele_map.items(), rinfo):
             # Obtain quadrature info
             rname = self.cfg.get(f'solver-elements-{ename}', 'soln-pts')
-            if self.cfg.hasopt(cfgsect, 'quad-deg'):
-                if self.cfg.hasopt(cfgsect, f'quad-pts-{ename}'):
-                    rname = self.cfg.get(cfgsect, f'quad-pts-{ename}')
 
-                # Quadrature rule
+            # Raise error with edge cases
+            if not quad and (self.cfg.hasopt(cfgsect, f'quad-pts-{ename}')
+                             or self.cfg.hasopt(cfgsect, f'quad-deg-{ename}')):
+                raise ValueError('Option "quad-deg" is not found')
+
+            if quad:
+                # Quadrature rule (default to that of the solution points)
+                qrule = self.cfg.get(cfgsect, f'quad-pts-{ename}', rname)
+
+                # Quadrature rule degree
                 qdeg = self.cfg.getint(cfgsect, 'quad-deg')
-                r = get_quadrule(ename, rname, qdeg=qdeg)
+                if self.cfg.hasopt(cfgsect, f'quad-deg-{ename}'):
+                    qdeg = self.cfg.getint(cfgsect, f'quad-deg-{ename}')
 
-                # Solution interpolation matrix to quadrature points
-                m0 = eles.basis.ubasis.nodal_basis_at(r.pts)
+                r = get_quadrule(ename, qrule, qdeg=qdeg)
             else:
                 # Default to the quadrature rule of the solution points
                 r = get_quadrule(ename, rname, eles.nupts)
-                m0 = None
+
+            # Interpolation to quadrature points matrix
+            m0 = eles.basis.ubasis.nodal_basis_at(r.pts) if quad else None
 
             # Locations of each quadrature point
             ploc = eles.ploc_at_np(r.pts).swapaxes(0, 1)[..., eset]

--- a/pyfr/plugins/integrate.py
+++ b/pyfr/plugins/integrate.py
@@ -53,11 +53,10 @@ class IntegratePlugin(BasePlugin):
             self.outf = init_csv(self.cfg, cfgsect, ','.join(header))
 
         # Prepare the per element-type info list
-        self.eleinfo = []
+        self.eleinfo = eleinfo = []
         for (ename, eles), (eset, emask) in zip(system.ele_map.items(), rinfo):
             # Obtain quadrature info
             rname = self.cfg.get(f'solver-elements-{ename}', 'soln-pts')
-            m0 = None
             if self.cfg.hasopt(cfgsect, 'quad-deg'):
                 if self.cfg.hasopt(cfgsect, f'quad-pts-{ename}'):
                     rname = self.cfg.get(cfgsect, f'quad-pts-{ename}')
@@ -71,6 +70,7 @@ class IntegratePlugin(BasePlugin):
             else:
                 # Default to the quadrature rule of the solution points
                 r = get_quadrule(ename, rname, eles.nupts)
+                m0 = None
 
             # Locations of each quadrature point
             ploc = eles.ploc_at_np(r.pts).swapaxes(0, 1)[..., eset]
@@ -79,8 +79,7 @@ class IntegratePlugin(BasePlugin):
             rcpdjacs = eles.rcpdjac_at_np(r.pts)[:, eset]
 
             # Save
-            self.eleinfo.append((ploc, r.wts[:, None] / rcpdjacs, m0, eset,
-                                 emask))
+            eleinfo.append((ploc, r.wts[:, None] / rcpdjacs, m0, eset, emask))
 
     def _prepare_region_info(self, intg):
         # All elements

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -256,7 +256,8 @@ class BaseElements(object):
         _, djacs_mpts = self._smats_djacs_mpts
 
         # Interpolation matrix to pts
-        m0 = self.basis.mbasis.nodal_basis_at(getattr(self.basis, name))
+        pt = getattr(self.basis, name) if isinstance(name, str) else name
+        m0 = self.basis.mbasis.nodal_basis_at(pt)
 
         # Interpolate the djacs
         djac = m0 @ djacs_mpts
@@ -273,7 +274,8 @@ class BaseElements(object):
 
     @memoize
     def ploc_at_np(self, name):
-        op = self.basis.sbasis.nodal_basis_at(getattr(self.basis, name))
+        pt = getattr(self.basis, name) if isinstance(name, str) else name
+        op = self.basis.sbasis.nodal_basis_at(pt)
 
         ploc = op @ self.eles.reshape(self.nspts, -1)
         ploc = ploc.reshape(-1, self.neles, self.ndims).swapaxes(1, 2)


### PR DESCRIPTION
1) Allow to access `tcurr` using `t` within the expressions of the integrate plugin (useful to compute errors with respect to analytical solutions)

2) Allow to choose the quadrature degree used to evaluate the expressions in the plugin integrate. To do so, the token `quad-deg` needs to be added to the input file in the integrate plugin section. The default quadrature type is taken from that used to set the solution points. If the user adds `quad-pts-{etype} = quad_name` to the integrate plugin section, then the the `quad_name quadrature will be used`.

Example:

```
[soln-plugin-integrate]
nsteps = 10
quad-deg = 10 ; quadrature degree
quad-pts-tet = witherden-vincent ; quadrature type
file = integrate
int-rho = rho
```