### PR TITLE
Bug fix in linearisation of elements.

### DIFF
--- a/pyfr/readers/base.py
+++ b/pyfr/readers/base.py
@@ -249,7 +249,7 @@ class NodalMeshAssembler(object):
             # Use this to determine which elements are linear
             num = np.max(np.abs(eles - leles), axis=0)
             den = np.max(eles, axis=0) - np.min(eles, axis=0)
-            lin = lidx[petype] = np.any(num / den < lintol, axis=1)
+            lin = lidx[petype] = np.all(num / den < lintol, axis=1)
 
             for ix in np.nonzero(lin)[0]:
                 self._nodepts[elesix[ix], :ndim] = leles[ptoi, ix]


### PR DESCRIPTION
Define an element as linear when max deltas in all directions (not just any of them) are less than the given tolerance. 