### PR TITLE
Added support for acm-ns no-slp-wall bc with expressions for u,v,w.

### DIFF
--- a/pyfr/solvers/acnavstokes/inters.py
+++ b/pyfr/solvers/acnavstokes/inters.py
@@ -94,11 +94,13 @@ class ACNavierStokesNoSlpWallBCInters(ACNavierStokesBaseBCInters):
     type = 'no-slp-wall'
     cflux_state = 'ghost'
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, be, lhs, elemap, cfgsect, cfg):
+        super().__init__(be, lhs, elemap, cfgsect, cfg)
 
-        self.c['v'] = self._eval_opts('uvw'[:self.ndims], default='0')
-
+        self.c.update(
+            self._exp_opts('uvw'[:self.ndims], lhs,
+                           default={'u': 0, 'v': 0, 'w': 0})
+        )
 
 class ACNavierStokesSlpWallBCInters(ACNavierStokesBaseBCInters):
     type = 'slp-wall'

--- a/pyfr/solvers/acnavstokes/kernels/bcs/no-slp-wall.mako
+++ b/pyfr/solvers/acnavstokes/kernels/bcs/no-slp-wall.mako
@@ -4,15 +4,15 @@
 
 <%pyfr:macro name='bc_rsolve_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
-% for i, v in enumerate(c['v']):
-    ur[${i + 1}] = -ul[${i + 1}] + ${2*v};
+% for i, v in enumerate('uvw'[:ndims]):
+    ur[${i + 1}] = -ul[${i + 1}] + 2*${c[v]};
 % endfor
 </%pyfr:macro>
 
 <%pyfr:macro name='bc_ldg_state' params='ul, nl, ur' externs='ploc, t'>
     ur[0] = ul[0];
-% for i, v in enumerate(c['v']):
-    ur[${i + 1}] = ${v};
+% for i, v in enumerate('uvw'[:ndims]):
+    ur[${i + 1}] = ${c[v]};
 % endfor
 </%pyfr:macro>
 


### PR DESCRIPTION
I think this feature was missed off, should now be in line with `no-slp-isot-wall` for the Navier-Stokes solver.