### PR TITLE
Add support for __launch_bounds__ in the HIP backend.

### DIFF
--- a/pyfr/backends/hip/generator.py
+++ b/pyfr/backends/hip/generator.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from math import prod
+
 from pyfr.backends.base.generator import BaseKernelGenerator
 
 
 class HIPKernelGenerator(BaseKernelGenerator):
+    block1d = None
+    block2d = None
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -59,4 +64,8 @@ class HIPKernelGenerator(BaseKernelGenerator):
                 if self.needs_ldim(va):
                     kargs.append(f'int ld{va.name}')
 
-        return '__global__ void {0}({1})'.format(self.name, ', '.join(kargs))
+        # Determine the launch bounds for the kernel
+        nthrds = prod(self.block1d if self.ndim == 1 else self.block2d)
+        kattrs = f'__global__ __launch_bounds__({nthrds})'
+
+        return '{0} void {1}({2})'.format(kattrs, self.name, ', '.join(kargs))

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -28,19 +28,20 @@ class HIPGiMMiKKernels(HIPKernelProvider):
         if nuq > 28 and nnz / arr.size > 0.15:
             raise NotSuitableError('Matrix inappropriate GiMMiK')
 
+        # Determine the grid/block
+        block = (128, 1, 1)
+        grid = get_grid_for_block(block, b.ncol)
+
         # Generate
         src = generate_mm(a.get(), dtype=a.dtype, platform='cuda',
                           alpha=alpha, beta=beta)
+        src = src.replace('void', f'__launch_bounds__({block[0]}) void')
         src = src.replace('blockDim.x*blockIdx.x + threadIdx.x',
                           'hipBlockDim_x*hipBlockIdx_x + hipThreadIdx_x')
 
         # Build
         fun = self._build_kernel('gimmik_mm', src,
                                  [np.int32, np.intp]*2 + [np.int32])
-
-        # Determine the grid/block
-        block = (128, 1, 1)
-        grid = get_grid_for_block(block, b.ncol)
 
         class MulKernel(ComputeKernel):
             def run(self, queue):

--- a/pyfr/backends/hip/kernels/axnpby.mako
+++ b/pyfr/backends/hip/kernels/axnpby.mako
@@ -2,7 +2,7 @@
 <%inherit file='base'/>
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-__global__ void
+__global__ __launch_bounds__(${block[0]*block[1]}) void
 axnpby(int nrow, int ncolb, int ldim, fpdtype_t* __restrict__ x0,
        ${', '.join(f'const fpdtype_t* __restrict__ x{i}'
                    for i in range(1, nv))},

--- a/pyfr/backends/hip/kernels/pack.mako
+++ b/pyfr/backends/hip/kernels/pack.mako
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 <%inherit file='base'/>
 
-__global__ void
+__global__ __launch_bounds__(${blocksz}) void
 pack_view(int n, int nrv, int ncv,
           const fpdtype_t* __restrict__ v,
           const int* __restrict__ vix,

--- a/pyfr/backends/hip/packing.py
+++ b/pyfr/backends/hip/packing.py
@@ -14,15 +14,15 @@ class HIPPackingKernels(HIPKernelProvider, BasePackingKernels):
         # An exchange view is simply a regular view plus an exchange matrix
         m, v = mv.xchgmat, mv.view
 
-        # Render the kernel template
-        src = self.backend.lookup.get_template('pack').render()
-
-        # Build
-        kern = self._build_kernel('pack_view', src, [np.int32]*3 + [np.intp]*4)
-
         # Compute the grid and thread-block size
         block = (128, 1, 1)
         grid = get_grid_for_block(block, v.n)
+
+        # Render the kernel template
+        src = self.backend.lookup.get_template('pack').render(blocksz=block[0])
+
+        # Build
+        kern = self._build_kernel('pack_view', src, [np.int32]*3 + [np.intp]*4)
 
         # If MPI is HIP aware then we just need to pack the buffer
         if self.backend.mpitype == 'hip-aware':


### PR DESCRIPTION
This fixes a performance regression with recent versions of HIP.