### PR TITLE
Add support for DIRK integrators.

### DIFF
--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -408,7 +408,7 @@ Parameterises the time-integration scheme used by the solver with
 
         - ``scheme`` --- time-integration scheme
 
-           ``backward-euler`` | ``bdf2`` | ``bdf3``
+           ``backward-euler`` | ``bdf2`` | ``bdf3`` | ``sdirk33`` | ``sdirk43``
 
         - ``pseudo-scheme`` --- pseudo time-integration scheme
 

--- a/examples/inc_cylinder_2d/inc_cylinder_2d.ini
+++ b/examples/inc_cylinder_2d/inc_cylinder_2d.ini
@@ -15,14 +15,14 @@ order = 3
 
 [solver-time-integrator]
 formulation = dual
-scheme = bdf2
-pseudo-scheme = rk34
+scheme = sdirk33
+pseudo-scheme = rk45
 controller = none
 pseudo-controller = local-pi
 tstart = 0.0
 tend = 75.0
-dt = 0.0125
-pseudo-dt = 0.0025
+dt = 0.05
+pseudo-dt = 0.005
 pseudo-niters-min = 3
 pseudo-niters-max = 3
 pseudo-resid-norm = l2

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -188,9 +188,12 @@ class BaseCommon(object):
 
         return kerns
 
-    def _add(self, *args, subdims=None):
+    def _addv(self, consts, regidxs, subdims=None):
         # Get a suitable set of axnpby kernels
-        axnpby = self._get_axnpby_kerns(*args[1::2], subdims=subdims)
+        axnpby = self._get_axnpby_kerns(*regidxs, subdims=subdims)
 
         # Bind and run the axnpby kernels
-        self._queue.enqueue_and_run(axnpby, *args[::2])
+        self._queue.enqueue_and_run(axnpby, *consts)
+
+    def _add(self, *args, subdims=None):
+        self._addv(args[::2], args[1::2], subdims=subdims)

--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -15,8 +15,8 @@ class BaseDualIntegrator(BaseIntegrator):
 
         # Get the pseudo-integrator
         self.pseudointegrator = get_pseudo_integrator(
-            backend, systemcls, rallocs, mesh,
-            initsoln, cfg, self.stepper_coeffs, self._dt
+            backend, systemcls, rallocs, mesh, initsoln, cfg,
+            self.stepper_nregs, self.stage_nregs, self._dt
         )
 
         # Event handlers for advance_to

--- a/pyfr/integrators/dual/phys/controllers.py
+++ b/pyfr/integrators/dual/phys/controllers.py
@@ -47,5 +47,8 @@ class DualNoneController(BaseDualController):
             raise ValueError('Advance time is in the past')
 
         while self.tcurr < t:
-            self.pseudointegrator.pseudo_advance(self.tcurr)
+            # Take the physical step
+            self.step(self.tcurr, self._dt)
+
+            # We are not adaptive, so accept every step
             self._accept_step(self.pseudointegrator._idxcurr)

--- a/pyfr/integrators/dual/phys/steppers.py
+++ b/pyfr/integrators/dual/phys/steppers.py
@@ -1,25 +1,124 @@
 # -*- coding: utf-8 -*-
 
+import math
+
 from pyfr.integrators.dual.phys.base import BaseDualIntegrator
 
 
 class BaseDualStepper(BaseDualIntegrator):
-    pass
+
+    def step(self, t, dt):
+        pass
+
+    def _finalize_step(self):
+        pass
 
 
-class DualBDF2Stepper(BaseDualStepper):
+class BaseBDFStepper(BaseDualStepper):
+    nstages = 1
+    stage_nregs = 0
+
+    def step(self, t, dt):
+        self.pseudointegrator.init_stage(0, self.stepper_coeffs(dt))
+        self.pseudointegrator.pseudo_advance(t + dt)
+
+        self._finalize_step()
+
+    @property
+    def stepper_nregs(self):
+        return len(self.stepper_static_coeffs) - 1
+
+    def _finalize_step(self):
+        self.pseudointegrator.discard_oldest_source()
+        self.pseudointegrator.store_current_soln()
+
+    def stepper_coeffs(self, dt):
+        return [1] + [sc/dt for sc in self.stepper_static_coeffs]
+
+
+class DualBDF2Stepper(BaseBDFStepper):
     stepper_name = 'bdf2'
     stepper_order = 2
-    stepper_coeffs = [-1.5, 2.0, -0.5]
+    stepper_static_coeffs = [-1.5, 2.0, -0.5]
 
 
-class DualBDF3Stepper(BaseDualStepper):
+class DualBDF3Stepper(BaseBDFStepper):
     stepper_name = 'bdf3'
     stepper_order = 3
-    stepper_coeffs = [-11.0/6.0, 3.0, -1.5, 1.0/3.0]
+    stepper_static_coeffs = [-11.0/6.0, 3.0, -1.5, 1.0/3.0]
 
 
-class DualBackwardEulerStepper(BaseDualStepper):
+class BaseDIRKStepper(BaseDualStepper):
+    stepper_nregs = 1
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if self.fsal:
+            self.b = self.a[-1]
+
+        self.c = [sum(row) for row in self.a]
+
+    @property
+    def stage_nregs(self):
+        return self.nstages
+
+    def step(self, t, dt):
+        scoeffs = [self.stepper_coeffs(s, dt)
+                   for s in range(self.nstages)]
+
+        for s, (sc, tc) in enumerate(zip(scoeffs, self.c)):
+            self.pseudointegrator.init_stage(s, sc)
+            self.pseudointegrator.pseudo_advance(t + dt*tc)
+
+        self._finalize_step()
+
+    def stepper_coeffs(self, s, dt):
+        return [self.a[s][s], -1/dt, 1/dt] + self.a[s][:s]
+
+    def _finalize_step(self):
+        if not self.fsal:
+            bcoeffs = [bt*self._dt for bt in self.b]
+            self.pseudointegrator.obtain_solution(bcoeffs)
+
+        self.pseudointegrator.store_current_soln()
+
+
+class DualBackwardEulerStepper(BaseDIRKStepper):
     stepper_name = 'backward-euler'
-    stepper_order = 1
-    stepper_coeffs = [-1.0, 1.0]
+    nstages = 1
+    fsal = True
+
+    a = [[1]]
+
+
+class SDIRK33Stepper(BaseDIRKStepper):
+    stepper_name = 'sdirk33'
+    nstages = 3
+    fsal = True
+
+    _at = math.atan(0.5**1.5)/3
+    _a_lam = (3**0.5*math.sin(_at) - math.cos(_at))/2**0.5 + 1
+
+    a = [
+        [_a_lam],
+        [0.5*(1 - _a_lam), _a_lam],
+        [(4 - 1.5*_a_lam)*_a_lam - 0.25, (1.5*_a_lam - 5)*_a_lam + 1.25, _a_lam]
+    ]
+
+
+class SDIRK43Stepper(BaseDIRKStepper):
+    stepper_name = 'sdirk43'
+    nstages = 3
+    fsal = False
+
+    _a_lam = (3 + 2*3**0.5*math.cos(math.pi/18))/6
+
+    a = [
+        [_a_lam],
+        [0.5 - _a_lam,  _a_lam],
+        [2*_a_lam, 1 - 4*_a_lam, _a_lam]
+    ]
+
+    _b_rlam = 1/(6*(1 - 2*_a_lam)*(1 - 2*_a_lam))
+    b = [_b_rlam, 1 - 2*_b_rlam, _b_rlam]

--- a/pyfr/integrators/dual/pseudo/__init__.py
+++ b/pyfr/integrators/dual/pseudo/__init__.py
@@ -50,13 +50,13 @@ def get_pseudo_stepper_cls(name, porder):
 
 
 def get_pseudo_integrator(backend, systemcls, rallocs, mesh,
-                          initsoln, cfg, tcoeffs, dt):
+                          initsoln, cfg, stepnregs, stagenregs, dt):
     register_tabulated_pseudo_steppers()
 
     # A new type of integrator allowing multip convergence acceleration
     if 'solver-dual-time-integrator-multip' in cfg.sections():
         return DualMultiPIntegrator(backend, systemcls, rallocs, mesh,
-                                    initsoln, cfg, tcoeffs, dt)
+                                    initsoln, cfg, stepnregs, stagenregs, dt)
     else:
         cn = cfg.get('solver-time-integrator', 'pseudo-controller')
         pn = cfg.get('solver-time-integrator', 'pseudo-scheme')
@@ -74,4 +74,4 @@ def get_pseudo_integrator(backend, systemcls, rallocs, mesh,
 
         # Construct and return an instance of this new integrator class
         return pseudointegrator(backend, systemcls, rallocs, mesh,
-                                initsoln, cfg, tcoeffs, dt)
+                                initsoln, cfg, stepnregs, stagenregs, dt)

--- a/pyfr/integrators/dual/pseudo/multip.py
+++ b/pyfr/integrators/dual/pseudo/multip.py
@@ -14,7 +14,7 @@ from pyfr.util import memoize, proxylist, subclass_where
 
 class DualMultiPIntegrator(BaseDualPseudoIntegrator):
     def __init__(self, backend, systemcls, rallocs, mesh, initsoln, cfg,
-                 tcoeffs, dt):
+                 stp_nregs, stg_nregs, dt):
         self.backend = backend
 
         sect = 'solver-time-integrator'
@@ -83,7 +83,8 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
             class lpsint(*bases):
                 name = 'MultiPPseudoIntegrator' + str(l)
                 aux_nregs = 2 if l != self._order else 0
-                stepper_nregs = len(tcoeffs) - 1 if l == self._order else 0
+                stepper_nregs = stp_nregs if l == self._order else 0
+                stage_nregs = stg_nregs if l == self._order else 0
 
                 @property
                 def _aux_regidx(iself):
@@ -97,26 +98,29 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
                 def convmon(iself, *args, **kwargs):
                     pass
 
-                def finalise_pseudo_advance(iself, *args, **kwargs):
-                    pass
-
-                def _rhs_with_dts(iself, t, uin, fout):
+                def _rhs_with_dts(iself, t, uin, fout, mg_add=True):
                     # Compute -∇·f
                     iself.system.rhs(t, uin, fout)
 
-                    # Coefficient for the current solution state
-                    scoeff = iself.stepper_coeffs[0]/iself._dt
+                    if iself.stage_nregs > 1:
+                        iself._add(0, self._stage_regidx[iself.currstg],
+                                   1, fout)
+
+                    # Registers
+                    vals = iself.stepper_coeffs[:2] + [1]
+                    regs = [fout, iself._idxcurr, iself._source_regidx]
 
                     # Physical stepper source addition -∇·f - dQ/dt
-                    iself._add(1, fout, scoeff, iself._idxcurr,
-                               1, iself._source_regidx, subdims=iself._subdims)
+                    iself._addv(vals, regs, subdims=iself._subdims)
 
                     # Multigrid r addition
-                    if iself._aux_regidx:
+                    if mg_add and iself._aux_regidx:
                         iself._add(1, fout, -1, iself._aux_regidx[0])
 
-            self.pintgs[l] = lpsint(backend, systemcls, rallocs, mesh,
-                                    initsoln, mcfg, tcoeffs, dt)
+            self.pintgs[l] = lpsint(
+                backend, systemcls, rallocs, mesh, initsoln, mcfg,
+                stp_nregs, stg_nregs, dt
+            )
 
         # Get the highest p system from plugins
         self.system = self.pintgs[self._order].system
@@ -130,22 +134,6 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         # Delete remaining elements maps from multigrid systems
         for l in self.levels[1:]:
             del self.pintgs[l].system.ele_map
-
-    def finalise_mg_advance(self, currsoln):
-        psnregs = self.pintg.pseudo_stepper_nregs
-        snregs = self.pintg.stepper_nregs
-
-        # Rotate the stepper registers to the right by one
-        self.pintg._regidx[psnregs:psnregs + snregs] = (
-            self.pintg._stepper_regidx[-1:] +
-            self.pintg._stepper_regidx[:-1]
-        )
-
-        # Copy the current soln into the first source register
-        self.pintg._add(0, self.pintg._regidx[psnregs], 1, currsoln)
-
-        # Physical stepper source term
-        self.pintg._accumulate_source()
 
     @property
     def _idxcurr(self):
@@ -162,6 +150,30 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
     @pseudostepinfo.setter
     def pseudostepinfo(self, y):
         self.pintg.pseudostepinfo = y
+
+    @property
+    def _queue(self):
+        return self.pintg._queue
+
+    @property
+    def _regidx(self):
+        return self.pintg._regidx
+
+    @property
+    def stage_nregs(self):
+        return self.pintg.stage_nregs
+
+    @property
+    def stepper_nregs(self):
+        return self.pintg.stepper_nregs
+
+    @property
+    def pseudo_stepper_nregs(self):
+        return self.pintg.pseudo_stepper_nregs
+
+    @property
+    def _subdims(self):
+        return self.pintg._subdims
 
     @property
     def pintg(self):
@@ -205,11 +217,20 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
 
         l1sys, l2sys = self.pintgs[l1].system, self.pintgs[l2].system
 
+        # Restrict the physical source term
+        l1sys.eles_scal_upts_inb.active = self.pintgs[l1]._source_regidx
+        l2sys.eles_scal_upts_inb.active = self.pintgs[l2]._source_regidx
+        self.pintg._queue.enqueue_and_run(self.mgproject(l1, l2))
+
+        # Project local dtau field to lower multigrid levels
+        if self.pintgs[self._order].pseudo_controller_needs_lerrest:
+            self.pintg._queue.enqueue_and_run(self.dtauproject(l1, l2))
+
         # Prevsoln is used as temporal storage at l1
         rtemp = 0 if l1idxcurr == 1 else 1
 
-        # rtemp = R = -∇·f
-        self.pintg.system.rhs(self.tcurr, l1idxcurr, rtemp)
+        # rtemp = R = -∇·f - dQ/dt
+        self.pintg._rhs_with_dts(self.tcurr, l1idxcurr, rtemp, mg_add=False)
 
         # rtemp = -d = R - r at lower levels
         if l1 != self._order:
@@ -229,25 +250,16 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         l2sys.eles_scal_upts_inb.active = mg1
         self.pintg._queue.enqueue_and_run(self.mgproject(l1, l2))
 
-        # mg0 = R = -∇·f
-        self.pintg.system.rhs(self.tcurr, l2idxcurr, self._mg_regidx[0])
+        # mg0 = R = -∇·f - dQ/dt
+        self.pintg._rhs_with_dts(self.tcurr, l2idxcurr, mg0, mg_add=False)
 
         # Compute the target residual r
         # mg0 = r = R + d
-        self.pintg._add(1, self._mg_regidx[0], -1, self._mg_regidx[1])
+        self.pintg._add(1, mg0, -1, mg1)
 
         # Need to store the non-smoothed solution Q^ns for the correction
         # mg1 = Q^ns
         self.pintg._add(0, mg1, 1, l2idxcurr)
-
-        # Restrict the physical source term
-        l1sys.eles_scal_upts_inb.active = self.pintgs[l1]._source_regidx
-        l2sys.eles_scal_upts_inb.active = self.pintgs[l2]._source_regidx
-        self.pintg._queue.enqueue_and_run(self.mgproject(l1, l2))
-
-        # Project local dtau field to lower multigrid levels
-        if self.pintgs[self._order].pseudo_controller_needs_lerrest:
-            self.pintg._queue.enqueue_and_run(self.dtauproject(l1, l2))
 
     def prolongate(self, l1, l2):
         l1idxcurr = self.pintgs[l1]._idxcurr
@@ -284,6 +296,11 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         # Multigrid levels and step counts
         cycle, csteps = self.cycle, self.csteps
 
+        # Set current stage number and stepper coefficients for all levels
+        for l in self.levels:
+            self.pintgs[l].currstg = self.currstg
+            self.pintgs[l].stepper_coeffs = self.stepper_coeffs
+
         self.tcurr = tcurr
 
         for i in range(self._maxniters):
@@ -306,9 +323,6 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
             # Convergence monitoring
             if self.mg_convmon(self.pintg, i, self._minniters):
                 break
-
-        # Update the dual-time stepping banks
-        self.finalise_mg_advance(self.pintg._idxcurr)
 
     def collect_stats(self, stats):
         # Collect the stats for each level

--- a/pyfr/integrators/dual/pseudo/pseudocontrollers.py
+++ b/pyfr/integrators/dual/pseudo/pseudocontrollers.py
@@ -70,9 +70,6 @@ class DualNonePseudoController(BaseDualPseudoController):
             if self.convmon(i, self.minniters, self._dtau):
                 break
 
-        # Update
-        self.finalise_pseudo_advance(self._idxcurr)
-
 
 class DualPIPseudoController(BaseDualPseudoController):
     pseudo_controller_name = 'local-pi'
@@ -151,5 +148,3 @@ class DualPIPseudoController(BaseDualPseudoController):
             if self.convmon(i, self.minniters):
                 break
 
-        # Update
-        self.finalise_pseudo_advance(self._idxcurr)


### PR DESCRIPTION
This PR adds support to use any integration scheme that falls under DIRK as long as the Butcher tableau is provided. For now I added ESDIRK3 coefficients into phys/steppers.py, but we may want to change this and add coefficents into text files like Niki did for Brian's schemes.

I tested bdf and dirk steppers with the inc_cylinder example and it works all fine with multip and local-pi, but the implementation is not final yet. I just wanted to discuss the structure and I'm open to suggestions related to this integrator in general.
@FreddieWitherden @pv101 @GiorgioGiangaspero @WillTrojak @GonzaloSaez  

Remaining work
- Freddie wants to remove bdf2 and bdf3 schemes. Any objections? My plan is to remove bdf2/3 support with a different commit in this PR, so that we have both dirk and bdf stuff coexist at one particular point in history. And also probably I'll remove bdf completely and implement backward-euler stepper through dirk. See the 'dirkbdf1' stepper in phys/steppers.py. I don't think there is any performance penalty and it will make code cleaner.
- Add a pi controller for physical time stepping.

Update:
- BDF steppers will be removed later so that we have both methods exist at the same time.
- pi controller for physical time stepper will be added with another PR.