### PR TITLE
All plugins are called for the first time outside their init function

### DIFF
--- a/pyfr/integrators/dual/phys/controllers.py
+++ b/pyfr/integrators/dual/phys/controllers.py
@@ -10,8 +10,9 @@ class BaseDualController(BaseDualIntegrator):
         # Solution filtering frequency
         self._fnsteps = self.cfg.getint('soln-filter', 'nsteps', '0')
 
-        # Fire off any event handlers
-        self.completed_step_handlers(self)
+        # Fire off any event handlers if not restarting
+        if not self.isrestart:
+            self.completed_step_handlers(self)
 
     def _accept_step(self, idxcurr):
         self.tcurr += self._dt

--- a/pyfr/integrators/dual/phys/controllers.py
+++ b/pyfr/integrators/dual/phys/controllers.py
@@ -10,6 +10,9 @@ class BaseDualController(BaseDualIntegrator):
         # Solution filtering frequency
         self._fnsteps = self.cfg.getint('soln-filter', 'nsteps', '0')
 
+        # Fire off any event handlers
+        self.completed_step_handlers(self)
+
     def _accept_step(self, idxcurr):
         self.tcurr += self._dt
         self.nacptsteps += 1

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -18,8 +18,9 @@ class BaseStdController(BaseStdIntegrator):
         # Stats on the most recent step
         self.stepinfo = []
 
-        # Fire off any event handlers
-        self.completed_step_handlers(self)
+        # Fire off any event handlers if not restarting
+        if not self.isrestart:
+            self.completed_step_handlers(self)
 
     def _accept_step(self, dt, idxcurr, err=None):
         self.tcurr += dt

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -18,6 +18,9 @@ class BaseStdController(BaseStdIntegrator):
         # Stats on the most recent step
         self.stepinfo = []
 
+        # Fire off any event handlers
+        self.completed_step_handlers(self)
+
     def _accept_step(self, dt, idxcurr, err=None):
         self.tcurr += dt
         self.nacptsteps += 1

--- a/pyfr/plugins/residual.py
+++ b/pyfr/plugins/residual.py
@@ -26,9 +26,6 @@ class ResidualPlugin(BasePlugin):
             # Open
             self.outf = init_csv(self.cfg, cfgsect, ','.join(header))
 
-        # Call ourself in case output is needed after the first step
-        self(intg)
-
     def __call__(self, intg):
         # If an output is due this step
         if intg.nacptsteps % self.nsteps == 0 and intg.nacptsteps:

--- a/pyfr/plugins/residual.py
+++ b/pyfr/plugins/residual.py
@@ -26,6 +26,14 @@ class ResidualPlugin(BasePlugin):
             # Open
             self.outf = init_csv(self.cfg, cfgsect, ','.join(header))
 
+        # Prep work if an output is due next step
+        self._prep_next_output(intg)
+
+    def _prep_next_output(self, intg):
+        if (intg.nacptsteps + 1) % self.nsteps == 0:
+            self._prev = [s.copy() for s in intg.soln]
+            self._tprev = intg.tcurr
+
     def __call__(self, intg):
         # If an output is due this step
         if intg.nacptsteps % self.nsteps == 0 and intg.nacptsteps:
@@ -58,7 +66,6 @@ class ResidualPlugin(BasePlugin):
 
             del self._prev, self._tprev
 
-        # If an output is due next step
-        if (intg.nacptsteps + 1) % self.nsteps == 0:
-            self._prev = [s.copy() for s in intg.soln]
-            self._tprev = intg.tcurr
+        # Prep work if an output is due next step
+        self._prep_next_output(intg)
+

--- a/pyfr/plugins/writer.py
+++ b/pyfr/plugins/writer.py
@@ -34,10 +34,10 @@ class WriterPlugin(PostactionMixin, RegionMixin, BasePlugin):
         # Register our output times with the integrator
         intg.call_plugin_dt(self.dt_out)
 
-        # If we're not restarting then write out the initial solution
+        # If we're not restarting then make sure we write out the initial
+        # solution when we are called for the first time
         if not intg.isrestart:
             self.tout_last -= self.dt_out
-            self(intg)
 
     def __call__(self, intg):
         if intg.tcurr - self.tout_last < self.dt_out - self.tol:


### PR DESCRIPTION
This separates the initialisation from the first call so that all plugins are initialised before any of them is actually called. This will allow plugins to interact with each other, if necessary.