### PR TITLE
fix a metis partitioner error when mesh has only one partition

### DIFF
--- a/pyfr/partitioners/base.py
+++ b/pyfr/partitioners/base.py
@@ -158,8 +158,8 @@ class BasePartitioner(object):
             nsp = len(svetimap) // self.nsubeles + 1
 
             # Partition the graph
-            if nsp==1:
-                svparts = [0] * len(svetimap)
+            if nsp == 1:
+                svparts = [0]*len(svetimap)
             else:
                 svparts = self._partition_graph(sgraph, [1]*nsp)
 

--- a/pyfr/partitioners/base.py
+++ b/pyfr/partitioners/base.py
@@ -158,7 +158,10 @@ class BasePartitioner(object):
             nsp = len(svetimap) // self.nsubeles + 1
 
             # Partition the graph
-            svparts = self._partition_graph(sgraph, [1]*nsp)
+            if nsp==1:
+                svparts = [0] * len(svetimap)
+            else:
+                svparts = self._partition_graph(sgraph, [1]*nsp)
 
             # Group elements according to their type (linear vs curved)
             # and sub-partition number

--- a/pyfr/partitioners/metis.py
+++ b/pyfr/partitioners/metis.py
@@ -181,4 +181,6 @@ class METISPartitioner(BasePartitioner):
                 parts.ctypes
             )
 
+        if np.max(parts) >= len(partwts):
+            raise RuntimeError('Metis Partitioner Error: partition index > npart-1 ')
         return parts

--- a/pyfr/partitioners/metis.py
+++ b/pyfr/partitioners/metis.py
@@ -183,4 +183,5 @@ class METISPartitioner(BasePartitioner):
 
         if np.max(parts) >= len(partwts):
             raise RuntimeError('Metis Partitioner Error: partition index > npart-1 ')
+            
         return parts


### PR DESCRIPTION
Changes to account for the case when the mesh has very few elements (not any multiple of 64, min n subelements). In this case the mesh is not partitioned and there is an exception to handle the case of Metis returning wrong indecies for one partition.