### PR TITLE
Delete multi-p elements maps explicitly after plugins have been constructed.

### DIFF
--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -25,6 +25,12 @@ class BaseDualIntegrator(BaseIntegrator):
         # Delete the memory-intensive elements map from the system
         del self.system.ele_map
 
+        # Delete also the multip elements maps, if present.
+        try:
+            self.pseudointegrator.delete_ele_maps()
+        except AttributeError:
+            pass
+
     @property
     def system(self):
         return self.pseudointegrator.system

--- a/pyfr/integrators/dual/pseudo/multip.py
+++ b/pyfr/integrators/dual/pseudo/multip.py
@@ -127,7 +127,7 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         # Initialise the restriction and prolongation matrices
         self._init_proj_mats()
 
-        # Delete remaining elements maps from multigrid systems
+    def delete_ele_maps(self):
         for l in self.levels[1:]:
             del self.pintgs[l].system.ele_map
 


### PR DESCRIPTION
This allows plugins to interact with the elements maps (and the corresponding kernels) of the lower multi-p levels.