### PR TITLE
Avoid calling pow in localerrest.

### DIFF
--- a/pyfr/backends/base/makoutil.py
+++ b/pyfr/backends/base/makoutil.py
@@ -5,6 +5,7 @@ import itertools as it
 import re
 
 from mako.runtime import supports_caller, capture
+import numpy as np
 
 import pyfr.nputil as nputil
 import pyfr.util as util
@@ -39,6 +40,16 @@ def array(context, ex_, **kwargs):
     ni = ni if isinstance(ni, Iterable) else [ni]
 
     return '{ ' + ', '.join(ex_.format(**{ix: i}) for i in range(*ni)) + ' }'
+
+
+def polyfit(context, f, a, b, n, var, nqpts=500):
+    x = np.linspace(a, b, nqpts)
+    y = f(x)
+
+    coeffs = np.polynomial.polynomial.polyfit(x, y, n)
+    pfexpr = f' + {var}*('.join(str(c) for c in coeffs) + ')'*n
+
+    return f'({pfexpr})'
 
 
 def _strip_parens(s):

--- a/pyfr/integrators/dual/pseudo/kernels/localerrest.mako
+++ b/pyfr/integrators/dual/pseudo/kernels/localerrest.mako
@@ -6,11 +6,13 @@
               err='in fpdtype_t[${str(nvars)}]'
               errprev='inout fpdtype_t[${str(nvars)}]'
               dtau_upts='inout fpdtype_t[${str(nvars)}]'>
-    fpdtype_t ferr, ufac, vfac;
+    fpdtype_t ferr, gerr, ufac, vfac;
 
 % for i in range(nvars):
     ferr = fabs(${1/atol}*err[${i}]);
-    ufac = pow(ferr, ${-expa}) * pow(errprev[${i}], ${expb});
+    gerr = errprev[${i}];
+    ufac = ${pyfr.polyfit(lambda x: x**-expa, 1e-6, 10, 8, 'ferr')}
+         * ${pyfr.polyfit(lambda x: x**expb, 1e-6, 10, 8, 'gerr')};
     vfac = min(${maxf}, max(${minf}, ${saff}*ufac));
 
     // Compute the size of the next step


### PR DESCRIPTION
Pow is slow on many platforms, especially CPU architectures without vectorised math libraries.  This PR replaces the pow calls with polynomial approximations.  Some more thought is needed around the domain and degree of these polynomials.