### PR TITLE
Replace @lazyprop with @functools.cached_property.

### DIFF
--- a/pyfr/backends/base/backend.py
+++ b/pyfr/backends/base/backend.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from collections import defaultdict
-from functools import wraps
+from functools import cached_property, wraps
 from itertools import count
 import math
 from weakref import WeakKeyDictionary, WeakValueDictionary
@@ -10,7 +10,6 @@ import numpy as np
 
 from pyfr.backends.base.kernels import NotSuitableError
 from pyfr.template import DottedTemplateLookup
-from pyfr.util import lazyprop
 
 
 def recordmat(fn):
@@ -51,7 +50,7 @@ class BaseBackend(object):
         # Mapping from backend objects to memory extents
         self._obj_extents = WeakKeyDictionary()
 
-    @lazyprop
+    @cached_property
     def lookup(self):
         pkg = f'pyfr.backends.{self.name}.kernels'
         dfltargs = dict(fpdtype=self.fpdtype, soasz=self.soasz,

--- a/pyfr/backends/openmp/compiler.py
+++ b/pyfr/backends/openmp/compiler.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from ctypes import CDLL
+from functools import cached_property
 import itertools as it
 import os
 import platform
@@ -13,7 +14,7 @@ from pytools.prefork import call_capture_output
 
 from pyfr.ctypesutil import platform_libname
 from pyfr.nputil import npdtype_to_ctypestype
-from pyfr.util import digest, lazyprop, mv, rm
+from pyfr.util import digest, mv, rm
 
 
 class OpenMPCompiler(object):
@@ -87,7 +88,7 @@ class OpenMPCompiler(object):
         # Append any user-provided arguments and return
         return cmd + self.cflags
 
-    @lazyprop
+    @cached_property
     def cachedir(self):
         return os.environ.get('PYFR_OMP_CACHE_DIR',
                               user_cache_dir('pyfr', 'pyfr'))

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from functools import cached_property
+
 import pyfr.backends.base as base
-from pyfr.util import lazyprop
 
 
 class OpenMPMatrixBase(base.MatrixBase):
@@ -32,7 +33,7 @@ class OpenMPMatrixBase(base.MatrixBase):
 
 
 class OpenMPMatrix(OpenMPMatrixBase, base.Matrix):
-    @lazyprop
+    @cached_property
     def hdata(self):
         return self.data
 

--- a/pyfr/polys.py
+++ b/pyfr/polys.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from collections.abc import Iterable
+from functools import cached_property
 from math import sqrt
 
 import numpy as np
 
 from pyfr.nputil import clean
-from pyfr.util import lazyprop, subclass_where
+from pyfr.util import subclass_where
 
 
 def jacobi(n, a, b, z):
@@ -76,7 +77,7 @@ class BasePolyBasis(object):
     def jac_nodal_basis_at(self, epts):
         return np.linalg.solve(self.vdm, self.jac_ortho_basis_at(epts))
 
-    @lazyprop
+    @cached_property
     def vdm(self):
         return self.ortho_basis_at(self.pts)
 
@@ -91,7 +92,7 @@ class BasePolyBasis(object):
         else:
             return np.eye(len(self.pts))
 
-    @lazyprop
+    @cached_property
     @clean
     def invvdm(self):
         return np.linalg.inv(self.vdm)
@@ -108,7 +109,7 @@ class LinePolyBasis(BasePolyBasis):
         djp = jacobi_diff(self.order - 1, 0, 0, p)
         return [(sqrt(i + 0.5)*p,) for i, p in enumerate(djp)]
 
-    @lazyprop
+    @cached_property
     def degrees(self):
         return [(i,) for i in range(self.order)]
 
@@ -155,7 +156,7 @@ class TriPolyBasis(BasePolyBasis):
 
         return ob
 
-    @lazyprop
+    @cached_property
     def degrees(self):
         return [(i, j)
                 for i in range(self.order)
@@ -184,7 +185,7 @@ class QuadPolyBasis(BasePolyBasis):
                 for pi, dpi in zip(pa, dpa)
                 for pj, dpj in zip(pb, dpb)]
 
-    @lazyprop
+    @cached_property
     def degrees(self):
         return [(i, j) for i in range(self.order) for j in range(self.order)]
 
@@ -256,7 +257,7 @@ class TetPolyBasis(BasePolyBasis):
 
         return ob
 
-    @lazyprop
+    @cached_property
     def degrees(self):
         return [(i, j, k)
                 for i in range(self.order)
@@ -317,7 +318,7 @@ class PriPolyBasis(BasePolyBasis):
         return [[pij*hk, qij*hk, rij*dhk]
                 for pij, qij, rij in pab for hk, dhk in zip(hc, dhc)]
 
-    @lazyprop
+    @cached_property
     def degrees(self):
         return [(i, j, k)
                 for i in range(self.order)
@@ -387,7 +388,7 @@ class PyrPolyBasis(BasePolyBasis):
 
         return ob
 
-    @lazyprop
+    @cached_property
     def degrees(self):
         return [(i, j, k)
                 for i in range(self.order)
@@ -421,7 +422,7 @@ class HexPolyBasis(BasePolyBasis):
                 for pj, dpj in zip(pb, dpb)
                 for pk, dpk in zip(pc, dpc)]
 
-    @lazyprop
+    @cached_property
     def degrees(self):
         return [(i, j, k)
                 for i in range(self.order)

--- a/pyfr/readers/native.py
+++ b/pyfr/readers/native.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
 from collections.abc import Mapping
+from functools import cached_property
 import os
 import re
 
 import h5py
 import numpy as np
 
-from pyfr.util import lazyprop, memoize
+from pyfr.util import memoize
 
 
 class NativeReader(Mapping):
@@ -41,7 +42,7 @@ class NativeReader(Mapping):
     def __len__(self):
         return len(self._keys)
 
-    @lazyprop
+    @cached_property
     def _keys(self):
         keys = set()
 

--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from functools import cached_property
 import math
 import re
 
 import numpy as np
 
 from pyfr.nputil import npeval, fuzzysort
-from pyfr.util import lazyprop, memoize
+from pyfr.util import memoize
 
 
 class BaseElements(object):
@@ -91,7 +92,7 @@ class BaseElements(object):
         self._scal_upts = interp @ solnmat.reshape(solnb.nupts, -1)
         self._scal_upts = self._scal_upts.reshape(nupts, nvars, neles)
 
-    @lazyprop
+    @cached_property
     def plocfpts(self):
         # Construct the physical location operator matrix
         plocop = self.basis.sbasis.nodal_basis_at(self.basis.fpts)
@@ -102,7 +103,7 @@ class BaseElements(object):
 
         return plocfpts
 
-    @lazyprop
+    @cached_property
     def _srtd_face_fpts(self):
         plocfpts = self.plocfpts.transpose(1, 2, 0)
 
@@ -142,7 +143,7 @@ class BaseElements(object):
         else:
             raise ValueError('Invalid slice region')
 
-    @lazyprop
+    @cached_property
     def _src_exprs(self):
         convars = self.convarmap[self.ndims]
 
@@ -155,11 +156,11 @@ class BaseElements(object):
         return [self.cfg.getexpr('solver-source-terms', v, '0', subs=subs)
                 for v in convars]
 
-    @lazyprop
+    @cached_property
     def _ploc_in_src_exprs(self):
         return any(re.search(r'\bploc\b', ex) for ex in self._src_exprs)
 
-    @lazyprop
+    @cached_property
     def _soln_in_src_exprs(self):
         return any(re.search(r'\bu\b', ex) for ex in self._src_exprs)
 
@@ -283,11 +284,11 @@ class BaseElements(object):
     def ploc_at(self, name):
         return self._be.const_matrix(self.ploc_at_np(name), tags={'align'})
 
-    @lazyprop
+    @cached_property
     def upts(self):
         return self._be.const_matrix(self.basis.upts)
 
-    @lazyprop
+    @cached_property
     def qpts(self):
         return self._be.const_matrix(self.basis.qpts)
 
@@ -311,17 +312,17 @@ class BaseElements(object):
         self._norm_pnorm_fpts = pnorm_fpts / mag_pnorm_fpts[..., None]
         self._mag_pnorm_fpts = mag_pnorm_fpts
 
-    @lazyprop
+    @cached_property
     def _norm_pnorm_fpts(self):
         self._gen_pnorm_fpts()
         return self._norm_pnorm_fpts
 
-    @lazyprop
+    @cached_property
     def _mag_pnorm_fpts(self):
         self._gen_pnorm_fpts()
         return self._mag_pnorm_fpts
 
-    @lazyprop
+    @cached_property
     def _smats_djacs_mpts(self):
         # Metric basis with grid point (q<=p) or pseudo grid points (q>p)
         mpts = self.basis.mpts

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -12,30 +12,35 @@ import shutil
 from pyfr.ctypesutil import get_libc_function
 
 
-class memoize(object):
-    def __init__(self, func):
-        self.func = func
-
-    def __get__(self, instance, owner):
-        return self.func if instance is None else ft.partial(self, instance)
-
-    def __call__(self, *args, **kwargs):
-        instance = args[0]
-
+def memoize(meth):
+    @ft.wraps(meth)
+    def newmeth(self, *args, **kwargs):
         try:
-            cache = instance._memoize_cache
+            cache = self._memoize_cache_
         except AttributeError:
-            cache = instance._memoize_cache = {}
+            cache = self._memoize_cache_ = {}
 
-        key = (self.func, pickle.dumps(args[1:]), pickle.dumps(kwargs))
+        if kwargs:
+            key = (meth, args, tuple(kwargs.items()))
+        else:
+            key = (meth, args)
 
         try:
-            res = cache[key]
+            return cache[key]
         except KeyError:
-            res = cache[key] = self.func(*args, **kwargs)
+            pass
+        except TypeError:
+            key = (meth, pickle.dumps((args, kwargs)))
 
+            try:
+                return cache[key]
+            except KeyError:
+                pass
+
+        res = cache[key] = meth(self, *args, **kwargs)
         return res
 
+    return newmeth
 
 class proxylist(list):
     def __getattr__(self, attr):

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -131,20 +131,6 @@ def chdir(dirname):
         os.chdir(cdir)
 
 
-class lazyprop(object):
-    def __init__(self, fn):
-        self.fn = fn
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return None
-
-        value = self.fn(instance)
-        setattr(instance, self.fn.__name__, value)
-
-        return value
-
-
 def subclasses(cls, just_leaf=False):
     sc = cls.__subclasses__()
     ssc = [g for s in sc for g in subclasses(s, just_leaf)]


### PR DESCRIPTION
Since Python 3.8 equivalent functionality to our venerable @lazyprop is available through the standard library.