### PR TITLE
Eliminate the proxylist class.

### DIFF
--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -4,7 +4,6 @@ import math
 
 from pyfr.integrators.base import BaseIntegrator
 from pyfr.integrators.dual.pseudo import get_pseudo_integrator
-from pyfr.util import proxylist
 
 
 class BaseDualIntegrator(BaseIntegrator):
@@ -20,7 +19,7 @@ class BaseDualIntegrator(BaseIntegrator):
         )
 
         # Event handlers for advance_to
-        self.completed_step_handlers = proxylist(self._get_plugins(initsoln))
+        self.completed_step_handlers = self._get_plugins(initsoln)
 
         # Delete the memory-intensive elements map from the system
         del self.system.ele_map

--- a/pyfr/integrators/dual/phys/controllers.py
+++ b/pyfr/integrators/dual/phys/controllers.py
@@ -12,7 +12,8 @@ class BaseDualController(BaseDualIntegrator):
 
         # Fire off any event handlers if not restarting
         if not self.isrestart:
-            self.completed_step_handlers(self)
+            for csh in self.completed_step_handlers:
+                csh(self)
 
     def _accept_step(self, idxcurr):
         self.tcurr += self._dt
@@ -30,7 +31,8 @@ class BaseDualController(BaseDualIntegrator):
         self._curr_grad_soln = None
 
         # Fire off any event handlers
-        self.completed_step_handlers(self)
+        for csh in self.completed_step_handlers:
+            csh(self)
 
         # Abort if plugins request it
         self._check_abort()

--- a/pyfr/integrators/dual/pseudo/pseudocontrollers.py
+++ b/pyfr/integrators/dual/pseudo/pseudocontrollers.py
@@ -122,7 +122,7 @@ class DualPIPseudoController(BaseDualPseudoController):
             err_prev = self.backend.matrix(shape, np.ones(shape),
                                            tags={'align'})
 
-            # Append the error kernels to the proxylist
+            # Append the error kernels to the list
             self.pintgkernels['localerrest'].append(
                 self.backend.kernel(
                     'localerrest', tplargs=tplargs,
@@ -134,7 +134,9 @@ class DualPIPseudoController(BaseDualPseudoController):
         self.backend.commit()
 
     def localerrest(self, errbank):
-        self.system.eles_scal_upts_inb.active = errbank
+        for u in self.system.eles_scal_upts_inb:
+            u.active = errbank
+
         self._queue.enqueue_and_run(self.pintgkernels['localerrest'])
 
     def pseudo_advance(self, tcurr):

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -2,7 +2,6 @@
 
 from pyfr.integrators.base import BaseIntegrator
 from pyfr.integrators.base import BaseCommon
-from pyfr.util import proxylist
 
 
 class BaseStdIntegrator(BaseCommon, BaseIntegrator):
@@ -35,7 +34,7 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
         self._gndofs = self._get_gndofs()
 
         # Event handlers for advance_to
-        self.completed_step_handlers = proxylist(self._get_plugins(initsoln))
+        self.completed_step_handlers = self._get_plugins(initsoln)
 
         # Delete the memory-intensive elements map from the system
         del self.system.ele_map

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -20,7 +20,8 @@ class BaseStdController(BaseStdIntegrator):
 
         # Fire off any event handlers if not restarting
         if not self.isrestart:
-            self.completed_step_handlers(self)
+            for csh in self.completed_step_handlers:
+                csh(self)
 
     def _accept_step(self, dt, idxcurr, err=None):
         self.tcurr += dt
@@ -41,7 +42,8 @@ class BaseStdController(BaseStdIntegrator):
         self._curr_grad_soln = None
 
         # Fire off any event handlers
-        self.completed_step_handlers(self)
+        for csh in self.completed_step_handlers:
+            csh(self)
 
         # Abort if plugins request it
         self._check_abort()

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -11,10 +11,7 @@ class BaseAdvectionSystem(BaseSystem):
         q1, q2 = self._queues
         kernels = self._kernels
 
-        self._bc_inters.prepare(t)
-
-        self.eles_scal_upts_inb.active = uinbank
-        self.eles_scal_upts_outb.active = foutbank
+        self._prepare_rhs(t, uinbank, foutbank)
 
         q1.enqueue(kernels['eles', 'disu'])
         q1.enqueue(kernels['mpiint', 'scal_fpts_pack'])

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -9,10 +9,7 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         q1, q2 = self._queues
         kernels = self._kernels
 
-        self._bc_inters.prepare(t)
-
-        self.eles_scal_upts_inb.active = uinbank
-        self.eles_scal_upts_outb.active = foutbank
+        self._prepare_rhs(t, uinbank, foutbank)
 
         q1.enqueue(kernels['eles', 'disu'])
         q1.enqueue(kernels['mpiint', 'scal_fpts_pack'])
@@ -73,9 +70,7 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         q1, q2 = self._queues
         kernels = self._kernels
 
-        self._bc_inters.prepare(t)
-
-        self.eles_scal_upts_inb.active = uinbank
+        self._prepare_rhs(t, uinbank, None)
 
         q1.enqueue(kernels['eles', 'disu'])
         q1.enqueue(kernels['mpiint', 'scal_fpts_pack'])

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -42,22 +42,6 @@ def memoize(meth):
 
     return newmeth
 
-class proxylist(list):
-    def __getattr__(self, attr):
-        return proxylist(getattr(x, attr) for x in self)
-
-    def __setattr__(self, attr, val):
-        for x in self:
-            setattr(x, attr, val)
-
-    def __delattr__(self, attr):
-        for x in self:
-            delattr(x, attr)
-
-    def __call__(self, *args, **kwargs):
-        return proxylist(x(*args, **kwargs) for x in self)
-
-
 class silence(object):
     def __init__(self, stdout=os.devnull, stderr=os.devnull):
         self.outfiles = (stdout, stderr)


### PR DESCRIPTION
This class was useful back when the backend queues made extensive use of `__call__`.  However, since then their utility has diminished and many uses are vestigial.  This PR replaces any remaining uses with explicit for loops, which are arguably more intuitive.