### PR TITLE
Improve support for CUDA- and HIP-aware MPI.

### DIFF
--- a/doc/src/performance_tuning.rst
+++ b/doc/src/performance_tuning.rst
@@ -69,12 +69,6 @@ this functionality can be enabled through the ``mpi-type`` key as::
         [backend-cuda]
         mpi-type = cuda-aware
 
-Note that if `UCX <https://www.openucx.org/>`_ is used as a transport,
-as is the case for recent builds of OpenMPI, it may be necessary to
-set::
-
-        $ export UCX_MEMTYPE_CACHE=n
-
 Partitioning
 ============
 

--- a/pyfr/__main__.py
+++ b/pyfr/__main__.py
@@ -213,6 +213,9 @@ def _process_common(args, mesh, soln, cfg):
 
         enable_prefork()
 
+    # Work around issues with UCX-derived MPI libraries
+    os.environ['UCX_MEMTYPE_CACHE'] = 'n'
+
     # Import but do not initialise MPI
     from mpi4py import MPI
 
@@ -241,9 +244,6 @@ def _process_common(args, mesh, soln, cfg):
 
     # Execute!
     solver.run()
-
-    # Finalise MPI
-    MPI.Finalize()
 
 
 def process_run(args):

--- a/pyfr/backends/cuda/types.py
+++ b/pyfr/backends/cuda/types.py
@@ -3,7 +3,6 @@
 import numpy as np
 
 import pyfr.backends.base as base
-from pyfr.util import make_pybuf
 
 
 class _CUDAMatrixCommon(object):
@@ -69,10 +68,17 @@ class CUDAXchgMatrix(CUDAMatrix, base.XchgMatrix):
         # Call the standard matrix constructor
         super().__init__(backend, ioshape, initval, extent, aliases, tags)
 
-        # If MPI is CUDA-aware then construct a buffer out of our CUDA
-        # device allocation and pass this directly to MPI
+        # If MPI is CUDA-aware then simply annotate our device buffer
         if backend.mpitype == 'cuda-aware':
-            self.hdata = make_pybuf(self.data, self.nbytes, 0x200)
+            class HostData(object):
+                __array_interface__ = {
+                    'version': 3,
+                    'typestr': np.dtype(self.dtype).str,
+                    'data': (self.data, False),
+                    'shape': (self.nrow, self.ncol)
+                }
+
+            self.hdata = np.array(HostData(), copy=False)
         # Otherwise, allocate a buffer on the host for MPI to send/recv from
         else:
             shape, dtype = (self.nrow, self.ncol), self.dtype

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -131,16 +131,6 @@ def chdir(dirname):
         os.chdir(cdir)
 
 
-def make_pybuf(buf, nbytes, flags):
-    from ctypes import pythonapi, py_object
-
-    _make_pybuf = pythonapi.PyMemoryView_FromMemory
-    _make_pybuf.argtypes = [c_void_p, c_ssize_t, c_int]
-    _make_pybuf.restype = py_object
-
-    return _make_pybuf(buf, nbytes, flags)
-
-
 class lazyprop(object):
     def __init__(self, fn):
         self.fn = fn

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ install_requires = [
     'gimmik >= 2.0',
     'h5py >= 2.6',
     'mako >= 1.0.0',
-    'mpi4py >= 3.0',
+    'mpi4py >= 3.1.0',
     'numpy >= 1.20',
     'pytools >= 2016.2.1'
 ]


### PR DESCRIPTION
This makes use of the newer CUDA-array-interface for decorating buffers and also automatically sets the relevant UCX environment variables.  Although we are not yet able to automatically enable such functionality, we are getting closer.