### PR TITLE
Rewrite the OpenCL backend to use our own wrappers.

### DIFF
--- a/doc/src/conf.py
+++ b/doc/src/conf.py
@@ -57,14 +57,8 @@ inheritance_edge_attrs = dict(
     penwidth='0.3')
 
 # The names of modules to mock and hence avoid import.
-autodoc_mock_imports = ['pyopencl',
-                        'h5py',
-                        'mpi4py',
-                        'gimmik',
-                        'numpy',
-                        'mako',
-                        'platformdirs'
-                       ]
+autodoc_mock_imports = ['h5py', 'mpi4py', 'gimmik', 'numpy', 'mako',
+                        'platformdirs']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -7,8 +7,9 @@ Installation
 Quick-start
 ===========
 
-PyFR |release| can be installed using `pip <https://pypi.python.org/pypi/pip>`_
-and `virtualenv <https://pypi.python.org/pypi/virtualenv>`_, as shown in the
+PyFR |release| can be installed using
+`pip <https://pypi.python.org/pypi/pip>`_ and
+`virtualenv <https://pypi.python.org/pypi/virtualenv>`_, as shown in the
 quick-start guides below.
 
 Alternatively, PyFR |release| can be installed from
@@ -19,57 +20,63 @@ macOS
 -----
 
 We recommend using the package manager `homebrew <https://brew.sh/>`_.
-Open the terminal and install the dependencies with the following commands::
+Open the terminal and install the dependencies with the following
+commands::
 
     brew install python3 open-mpi metis
     pip3 install virtualenv
 
-For visualisation of results, either install ParaView from the command line::
+For visualisation of results, either install ParaView from the command
+line::
 
     brew cask install paraview
 
-or dowload the app from the ParaView `website <https://www.paraview.org/>`_.
-Then create a virtual environment and activate it::
+or download the app from the ParaView
+`website <https://www.paraview.org/>`_. Then create a virtual
+environment and activate it::
 
     virtualenv --python=python3 ENV3
     source ENV3/bin/activate
 
-Finally install PyFR with `pip <https://pypi.python.org/pypi/pip>`_ in the
-virtual environment::
+Finally, install PyFR with `pip <https://pypi.python.org/pypi/pip>`_
+in the virtual environment::
 
     pip install pyfr
 
-This concludes the installation. In order to run PyFR with the OpenMP backend
-(see :ref:`running-pyfr`), use the following settings in the
+This concludes the installation. In order to run PyFR with the OpenMP
+backend (see :ref:`running-pyfr`), use the following settings in the
 :ref:`configuration-file`::
 
     [backend-openmp]
     cc = gcc-8
 
-Note the version of the compiler which must support the ``openmp`` flag.
-This has been tested on macOS 11.6 for ARM and Intel CPUs.
+Note the version of the compiler which must support the ``openmp``
+flag. This has been tested on macOS 11.6 for ARM and Intel CPUs.
 
 Ubuntu
 ------
 
-Open the terminal and install the dependencies with the following commands::
+Open the terminal and install the dependencies with the following
+commands::
 
     sudo apt install python3 python3-pip libopenmpi-dev openmpi-bin
     sudo apt install metis libmetis-dev
     pip3 install virtualenv
 
-For visualisation of results, either install ParaView from the command line::
+For visualisation of results, either install ParaView from the command
+line::
 
     sudo apt install paraview
 
-or dowload the app from the ParaView `website <https://www.paraview.org/>`_.
-Then create a virtual environment and activate it::
+or download the app from the ParaView
+`website <https://www.paraview.org/>`_.  Then create a virtual
+environment and activate it::
 
     python3 -m virtualenv pyfr-venv
     source pyfr-venv/bin/activate
 
-Finally install PyFR with `pip <https://pypi.python.org/pypi/pip>`_ in the
-virtual environment::
+Finally, install PyFR with
+`pip <https://pypi.python.org/pypi/pip>`_ in the virtual environment::
 
     pip install pyfr
 
@@ -82,16 +89,17 @@ This has been tested on Ubuntu 20.04.
 Compiling from source
 =====================
 
-PyFR can be obtained `here <https://github.com/PyFR/PyFR/tree/master>`_.
-To install the software from source, use the provided ``setup.py``
-installer or add the root PyFR directory to ``PYTHONPATH`` using::
+PyFR can be obtained
+`here <https://github.com/PyFR/PyFR/tree/master>`_.  To install the
+software from source, use the provided ``setup.py`` installer or add
+the root PyFR directory to ``PYTHONPATH`` using::
 
     user@computer ~/PyFR$ export PYTHONPATH=.:$PYTHONPATH
 
 When installing from source, we strongly recommend using
 `pip <https://pypi.python.org/pypi/pip>`_ and
-`virtualenv <https://pypi.python.org/pypi/virtualenv>`_ to manage the Python
-dependencies.
+`virtualenv <https://pypi.python.org/pypi/virtualenv>`_ to manage the
+Python dependencies.
 
 Dependencies
 ------------
@@ -127,7 +135,8 @@ The HIP backend targets AMD GPUs which are supported by the ROCm stack.
 The backend requires:
 
 1. `ROCm <https://rocmdocs.amd.com/en/latest/>`_ >= 4.5.0
-2. `rocBLAS <https://github.com/ROCmSoftwarePlatform/rocBLAS>`_ >= 2.41.0
+2. `rocBLAS <https://github.com/ROCmSoftwarePlatform/rocBLAS>`_ >=
+   2.41.0
 
 OpenCL Backend
 ^^^^^^^^^^^^^^
@@ -136,9 +145,14 @@ The OpenCL backend targets a range of accelerators including GPUs from
 AMD, Intel, and NVIDIA. The backend requires:
 
 1. OpenCL
-2. `pyopencl <http://mathema.tician.de/software/pyopencl/>`_
-   >= 2015.2.4
-3. `CLBlast <https://github.com/CNugteren/CLBlast>`_
+2. `CLBlast <https://github.com/CNugteren/CLBlast>`_
+
+Note that when running on NVIDIA GPUs the OpenCL backend terminate with
+a segmentation fault after the simulation has finished.  This is due
+to a long-standing bug in how the NVIDIA OpenCL implementation handles
+sub-buffers.  As it occurs during the termination phase—after all data
+has been written out to disk—the issue does *not* impact the
+functionality or correctness of PyFR.
 
 .. _install openmp backend:
 

--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -8,6 +8,11 @@ from pyfr.util import memoize
 
 
 class Kernel(object):
+    def __init__(self, mats=[], views=[], misc=[]):
+        self.mats = mats
+        self.views = views
+        self.misc = misc
+
     @property
     def retval(self):
         return None
@@ -81,6 +86,9 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
         # Possible view types
         viewtypes = (self.backend.view_cls, self.backend.xchg_view_cls)
 
+        # Backend matrices and views this kernel operates on
+        argmats, argviews = [], []
+
         # First arguments are the iteration dimensions
         ndim, arglst = len(dims), [int(d) for d in dims]
 
@@ -97,6 +105,8 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
 
             # Matrix
             if isinstance(ka, mattypes):
+                argmats.append(ka)
+
                 # Check that argument is not a row sliced matrix
                 if isinstance(ka, mattypes[-1]) and ka.nrow != ka.parent.nrow:
                     raise ValueError('Row sliced matrices are not supported')
@@ -104,6 +114,8 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
                     arglst += [ka, ka.leaddim] if len(atypes) == 2 else [ka]
             # View
             elif isinstance(ka, viewtypes):
+                argviews.append(ka)
+
                 if isinstance(ka, self.backend.view_cls):
                     view = ka
                 else:
@@ -115,9 +127,9 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
             else:
                 arglst.append(ka)
 
-        return arglst
+        return arglst, (argmats, argviews)
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         pass
 
     def register(self, mod):
@@ -144,10 +156,10 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
             fun = self._build_kernel(name, src, list(it.chain(*argt)))
 
             # Process the argument list
-            argb = self._build_arglst(dims, argn, argt, kwargs)
+            argb, argmv = self._build_arglst(dims, argn, argt, kwargs)
 
             # Return a Kernel subclass instance
-            return self._instantiate_kernel(dims, fun, argb)
+            return self._instantiate_kernel(dims, fun, argb, argmv)
 
         # Attach the module to the method as an attribute
         kernel_meth._mod = mod

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -24,7 +24,7 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
                                   BasePointwiseKernelProvider):
     kernel_generator_cls = CUDAKernelGenerator
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         # Determine the block size
         if len(dims) == 1:
             block = (64, 1, 1)
@@ -43,4 +43,4 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
                 def run(self, queue, **kwargs):
                     fun.exec_async(grid, block, queue.stream, *arglst)
 
-        return PointwiseKernel()
+        return PointwiseKernel(*argmv)

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -34,7 +34,7 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
 
         self.kernel_generator_cls = KernelGenerator
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         block = self._block1d if len(dims) == 1 else self._block2d
         grid = get_grid_for_block(block, dims[-1])
 
@@ -47,4 +47,4 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
                 def run(self, queue, **kwargs):
                     fun.exec_async(grid, block, queue.stream, *arglst)
 
-        return PointwiseKernel()
+        return PointwiseKernel(*argmv)

--- a/pyfr/backends/opencl/blasext.py
+++ b/pyfr/backends/opencl/blasext.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pyopencl as cl
 
 from pyfr.backends.opencl.provider import OpenCLKernelProvider
 from pyfr.backends.base import Kernel
@@ -24,22 +23,24 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
         # Build the kernel
         kern = self._build_kernel('axnpby', src,
                                   [np.int32]*3 + [np.intp]*nv + [dtype]*nv)
+        kern.set_args(nrow, ncolb, ldim, *arr)
 
         class AxnpbyKernel(Kernel):
             def run(self, queue, *consts):
-                arrd = [x.data for x in arr]
-                kern(queue.cmd_q, (ncolb, nrow), None, nrow, ncolb, ldim,
-                     *arrd, *consts)
+                kern.set_args(*consts, start=3 + nv)
+                kern.exec_async(queue.cmd_q, (ncolb, nrow), None)
 
-        return AxnpbyKernel()
+        return AxnpbyKernel(mats=arr)
 
     def copy(self, dst, src):
+        cl = self.backend.cl
+
         if dst.traits != src.traits:
             raise ValueError('Incompatible matrix types')
 
         class CopyKernel(Kernel):
             def run(self, queue):
-                cl.enqueue_copy(queue.cmd_q, dst.data, src.data)
+                cl.memcpy_async(queue.cmd_q, dst, src, dst.nbytes)
 
         return CopyKernel()
 
@@ -47,6 +48,7 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
         if any(r.traits != rs[0].traits for r in rs[1:]):
             raise ValueError('Incompatible matrix types')
 
+        cl = self.backend.cl
         nrow, ncol, ldim, dtype = rs[0].traits[1:]
         ncola, ncolb = rs[0].ioshape[1:]
 
@@ -57,9 +59,8 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
         # Empty result buffer on host with (nvars, ngroups)
         reduced_host = np.empty((ncola, gs[0] // ls[0]), dtype)
 
-        # Device memory allocation
-        reduced_dev = cl.Buffer(self.backend.ctx, cl.mem_flags.READ_WRITE,
-                                reduced_host.nbytes)
+        # Corresponding device memory allocation
+        reduced_dev = cl.mem_alloc(reduced_host.nbytes)
 
         tplargs = dict(norm=norm, sharesz=ls[0], method=method)
 
@@ -69,8 +70,7 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
         # Get the kernel template
         src = self.backend.lookup.get_template('reduction').render(**tplargs)
 
-        rdata = [r.data for r in rs]
-        rdata += [dt_mat.data] if dt_mat else []
+        regs = list(rs) + [dt_mat] if dt_mat else rs
 
         # Argument types for reduction kernel
         if method == 'errest':
@@ -82,9 +82,13 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
 
         # Build the reduction kernel
         rkern = self._build_kernel('reduction', src, argt)
+        rkern.set_args(nrow, ncolb, ldim, reduced_dev, *regs)
 
         # Norm type
         reducer = np.max if norm == 'uniform' else np.sum
+
+        # Runtime argument offset
+        facoff = argt.index(dtype)
 
         class ReductionKernel(Kernel):
             @property
@@ -92,10 +96,9 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
                 return reducer(reduced_host, axis=1)
 
             def run(self, queue, *facs):
-                rkern(queue.cmd_q, gs, ls, nrow, ncolb, ldim, reduced_dev,
-                      *rdata, *facs)
-                cevent = cl.enqueue_copy(queue.cmd_q, reduced_host,
-                                         reduced_dev, is_blocking=False)
-                queue.copy_events.append(cevent)
+                rkern.set_args(*facs, start=facoff)
+                rkern.exec_async(queue.cmd_q, gs, ls)
+                cl.memcpy_async(queue.cmd_q, reduced_host, reduced_dev,
+                                reduced_dev.nbytes)
 
-        return ReductionKernel()
+        return ReductionKernel(mats=regs)

--- a/pyfr/backends/opencl/clblast.py
+++ b/pyfr/backends/opencl/clblast.py
@@ -60,7 +60,7 @@ class OpenCLCLBlastKernels(object):
 
         class MulKernel(Kernel):
             def run(self, queue):
-                qptr = c_void_p(queue.cmd_q.int_ptr)
+                qptr = c_void_p(int(queue.cmd_q))
                 clblastgemm(w.LayoutRowMajor, w.TransposeNo, w.TransposeNo,
                             m, n, k, alpha, a, 0, a.leaddim, b, 0, b.leaddim,
                             beta, out, 0, out.leaddim, qptr, None)

--- a/pyfr/backends/opencl/driver.py
+++ b/pyfr/backends/opencl/driver.py
@@ -1,0 +1,462 @@
+from ctypes import (POINTER, byref, cast, create_string_buffer, c_char,
+                    c_char_p, c_double, c_float, c_int, c_int32, c_int64,
+                    c_size_t, c_uint, c_uint64, c_void_p, pointer, sizeof)
+
+import numpy as np
+
+from pyfr.ctypesutil import LibWrapper
+
+
+# Possible OpenCL exception types
+class OpenCLError(Exception): pass
+class OpenCLDeviceNotFound(OpenCLError): pass
+class OpenCLDeviceNotAvailable(OpenCLError): pass
+class OpenCLAllocationFailure(OpenCLError): pass
+class OpenCLOutOfResources(OpenCLError): pass
+class OpenCLBuildProgramFailure(OpenCLError): pass
+class OpenCLMisalignedSubBufferOffset(OpenCLError): pass
+class OpenCLDevicePartitioningFailed(OpenCLError): pass
+class OpenCLInvalidValue(OpenCLError): pass
+class OpenCLInvalidKernelName(OpenCLError): pass
+class OpenCLInvalidKernelArgs(OpenCLError): pass
+class OpenCLInvalidWorkGroupSize(OpenCLError): pass
+class OpenCLInvalidWorkItemSize(OpenCLError): pass
+class OpenCLInvalidGlobalWorkSize(OpenCLError): pass
+
+
+class OpenCLWrappers(LibWrapper):
+    _libname = 'OpenCL'
+
+    # Error codes
+    _statuses = {
+        -1: OpenCLDeviceNotFound,
+        -2: OpenCLDeviceNotAvailable,
+        -4: OpenCLAllocationFailure,
+        -5: OpenCLOutOfResources,
+        -11: OpenCLBuildProgramFailure,
+        -13: OpenCLMisalignedSubBufferOffset,
+        -18: OpenCLDevicePartitioningFailed,
+        -30: OpenCLInvalidValue,
+        -46: OpenCLInvalidKernelName,
+        -52: OpenCLInvalidKernelArgs,
+        -54: OpenCLInvalidWorkGroupSize,
+        -55: OpenCLInvalidWorkItemSize,
+        -63: OpenCLInvalidGlobalWorkSize,
+        '*': OpenCLError
+    }
+
+    # Constants
+    BUFFER_CREATE_TYPE_REGION = 0x1220
+    DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE = 0x20
+    DEVICE_EXTENSIONS = 0x1030
+    DEVICE_MEM_BASE_ADDR_ALIGN = 0x1019
+    DEVICE_NAME = 0x102b
+    DEVICE_PARTITION_BY_AFFINITY_DOMAIN = 0x1088
+    DEVICE_TYPE_ACCELERATOR = 0x8
+    DEVICE_TYPE_ALL = 0xffffffff
+    DEVICE_TYPE_CPU = 0x2
+    DEVICE_TYPE_GPU = 0x4
+    MEM_READ_WRITE = 0x1
+    PLATFORM_NAME = 0x0902
+    PROGRAM_BUILD_LOG = 0x1183
+    QUEUE_OUT_OF_ORDER = 0x1
+    QUEUE_PROPERTIES = 0x1093
+
+    # Functions
+    _functions = [
+        (c_int, 'clGetPlatformIDs', c_uint, POINTER(c_void_p),
+         POINTER(c_uint)),
+        (c_int, 'clGetPlatformInfo', c_void_p, c_uint, c_size_t, c_void_p,
+         POINTER(c_size_t)),
+        (c_int, 'clGetDeviceIDs', c_void_p, c_uint64, c_uint,
+         POINTER(c_void_p), POINTER(c_uint)),
+        (c_int, 'clGetDeviceInfo', c_void_p, c_uint, c_size_t, c_void_p,
+         POINTER(c_size_t)),
+        (c_int, 'clCreateSubDevices', c_void_p, POINTER(c_uint64), c_uint,
+         POINTER(c_void_p), POINTER(c_uint)),
+        (c_int, 'clReleaseDevice', c_void_p),
+        (c_void_p, 'clCreateContext', c_void_p, c_uint, POINTER(c_void_p),
+         c_void_p, c_void_p, POINTER(c_int)),
+        (c_int, 'clReleaseContext', c_void_p),
+        (c_void_p, 'clCreateCommandQueue', c_void_p, c_void_p, c_uint64,
+         POINTER(c_int)),
+        (c_void_p, 'clCreateCommandQueueWithProperties', c_void_p, c_void_p,
+         POINTER(c_uint64), POINTER(c_int)),
+        (c_int, 'clReleaseCommandQueue', c_void_p),
+        (c_int, 'clFinish', c_void_p),
+        (c_int, 'clFlush', c_void_p),
+        (c_int, 'clReleaseEvent', c_void_p),
+        (c_void_p, 'clCreateBuffer', c_void_p, c_uint64, c_size_t, c_void_p,
+         POINTER(c_int)),
+        (c_void_p, 'clCreateSubBuffer', c_void_p, c_uint64, c_uint, c_void_p,
+         POINTER(c_int)),
+        (c_int, 'clReleaseMemObject', c_void_p),
+        (c_int, 'clEnqueueReadBuffer', c_void_p, c_void_p, c_uint, c_size_t,
+         c_size_t, c_void_p, c_uint, POINTER(c_void_p), POINTER(c_void_p)),
+        (c_int, 'clEnqueueWriteBuffer', c_void_p, c_void_p, c_uint, c_size_t,
+         c_size_t, c_void_p, c_uint, POINTER(c_void_p), POINTER(c_void_p)),
+        (c_int, 'clEnqueueCopyBuffer', c_void_p, c_void_p, c_void_p, c_size_t,
+         c_size_t, c_size_t, c_uint, POINTER(c_void_p), POINTER(c_void_p)),
+        (c_int, 'clEnqueueFillBuffer', c_void_p, c_void_p, c_void_p, c_size_t,
+         c_size_t, c_size_t, c_uint, POINTER(c_void_p), POINTER(c_void_p)),
+        (c_void_p, 'clCreateProgramWithSource', c_void_p, c_uint,
+         POINTER(c_char_p), POINTER(c_size_t), POINTER(c_int)),
+        (c_int, 'clReleaseProgram', c_void_p),
+        (c_int, 'clBuildProgram', c_void_p, c_uint, POINTER(c_void_p),
+         c_char_p, c_void_p, c_void_p),
+        (c_int, 'clGetProgramBuildInfo', c_void_p, c_void_p, c_uint, c_size_t,
+         c_void_p, POINTER(c_size_t)),
+        (c_void_p, 'clCreateKernel', c_void_p, c_char_p, POINTER(c_int)),
+        (c_int, 'clReleaseKernel', c_void_p),
+        (c_int, 'clEnqueueNDRangeKernel', c_void_p, c_void_p, c_uint,
+         POINTER(c_size_t), POINTER(c_size_t), POINTER(c_size_t), c_uint,
+         POINTER(c_void_p), POINTER(c_void_p)),
+        (c_int, 'clSetKernelArg', c_void_p, c_uint, c_size_t, c_void_p)
+    ]
+
+    def __init__(self):
+        super().__init__()
+
+        # Automate error checking for functions which signal their status via
+        # output arguments rather than return values
+        for fret, fname, *fargs in self._functions:
+            if fret == c_void_p:
+                setattr(self, fname, self._argerrcheck(getattr(self, fname)))
+
+    def _argerrcheck(self, fn):
+        def newfn(*args):
+            err = c_int()
+            ret = fn(*args, err)
+
+            if err.value != 0:
+                try:
+                    raise self._statuses[err.value]
+                except KeyError:
+                    raise self._statuses['*'] from None
+
+            return ret
+
+        return newfn
+
+
+class _OpenCLBase(object):
+    _destroyfn = None
+
+    def __init__(self, lib, ptr):
+        self.lib = lib
+        self._as_parameter_ = getattr(ptr, 'value', ptr)
+
+    def __del__(self):
+        if self._destroyfn:
+            try:
+                getattr(self.lib, self._destroyfn)(self)
+            except AttributeError:
+                pass
+
+    def __int__(self):
+        return self._as_parameter_
+
+
+class OpenCLPlatform(_OpenCLBase):
+    def __init__(self, lib, ptr):
+        super().__init__(lib, ptr)
+
+        self.name = self._query_str('name')
+
+    def get_devices(self, devtype='all'):
+        devtype = getattr(self.lib, f'DEVICE_TYPE_{devtype.upper()}')
+        ndevices = c_uint()
+
+        try:
+            self.lib.clGetDeviceIDs(self, devtype, 0, None, ndevices)
+        except OpenCLDeviceNotFound:
+            return []
+
+        devices = (c_void_p * ndevices.value)()
+        self.lib.clGetDeviceIDs(self, devtype, ndevices, devices, None)
+
+        return [OpenCLDevice(self.lib, d) for d in devices]
+
+    def _query_str(self, param):
+        param = getattr(self.lib, f'PLATFORM_{param.upper()}')
+
+        nbytes = c_size_t()
+        self.lib.clGetPlatformInfo(self, param, 0, None, nbytes)
+
+        buf = create_string_buffer(nbytes.value)
+        self.lib.clGetPlatformInfo(self, param, nbytes, buf, None)
+
+        return buf.value.decode()
+
+
+class OpenCLDevice(_OpenCLBase):
+    _destroyfn = 'clReleaseDevice'
+
+    def __init__(self, lib, ptr):
+        super().__init__(lib, ptr)
+
+        self.name = self._query_str('name')
+        self.mem_align = self._query_uint('mem_base_addr_align') // 8
+
+        self.extensions = set(self._query_str('extensions').split())
+        self.has_fp64 = 'cl_khr_fp64' in self.extensions
+
+    def subdevices(self):
+        lib = self.lib
+        params = (c_uint64 * 3)(lib.DEVICE_PARTITION_BY_AFFINITY_DOMAIN,
+                                lib.DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE,
+                                0)
+        nsubdevices = c_uint()
+
+        try:
+            lib.clCreateSubDevices(self, params, 0, None, nsubdevices)
+        except OpenCLDevicePartitioningFailed:
+            return []
+
+        subdevices = (c_void_p * nsubdevices.value)
+        lib.clCreateSubDevices(self, params, nsubdevices, subdevices, None)
+
+        return [OpenCLDevice(lib, d) for d in devices]
+
+    def _query_uint(self, param):
+        param = getattr(self.lib, f'DEVICE_{param.upper()}')
+
+        v = c_uint()
+        self.lib.clGetDeviceInfo(self, param, sizeof(v), byref(v), None)
+
+        return v.value
+
+    def _query_str(self, param):
+        param = getattr(self.lib, f'DEVICE_{param.upper()}')
+
+        nbytes = c_size_t()
+        self.lib.clGetDeviceInfo(self, param, 0, None, nbytes)
+
+        buf = create_string_buffer(nbytes.value)
+        self.lib.clGetDeviceInfo(self, param, nbytes, buf, None)
+
+        return buf.value.decode()
+
+
+class OpenCLBuffer(_OpenCLBase):
+    _destroyfn = 'clReleaseMemObject'
+
+    def __init__(self, lib, ctx, nbytes):
+        self.nbytes = nbytes
+
+        ptr = lib.clCreateBuffer(ctx, lib.MEM_READ_WRITE, nbytes, None)
+
+        super().__init__(lib, ptr)
+
+    def slice(self, off, nbytes):
+        return OpenCLSubBuffer(self.lib, self, off, nbytes)
+
+
+class OpenCLSubBuffer(_OpenCLBase):
+    _destroyfn = 'clReleaseMemObject'
+
+    def __init__(self, lib, buf, off, nbytes):
+        self.parent = buf
+        self.nbytes = nbytes
+
+        rgn = (c_size_t * 2)(off, nbytes)
+        ptr = lib.clCreateSubBuffer(buf, lib.MEM_READ_WRITE,
+                                    lib.BUFFER_CREATE_TYPE_REGION, rgn)
+
+        super().__init__(lib, ptr)
+
+
+class OpenCLEvent(_OpenCLBase):
+    _destroyfn = 'clReleaseEvent'
+
+
+class OpenCLQueue(_OpenCLBase):
+    _destroyfn = 'clReleaseCommandQueue'
+
+    def __init__(self, lib, ctx, dev, out_of_order):
+        if out_of_order:
+            props = (c_uint64 * 3)(lib.QUEUE_PROPERTIES,
+                                   lib.QUEUE_OUT_OF_ORDER, 0)
+        else:
+            props = None
+
+        ptr = lib.clCreateCommandQueueWithProperties(ctx, dev, props)
+
+        super().__init__(lib, ptr)
+
+    def finish(self):
+        self.lib.clFinish(self)
+
+    def flush(self):
+        self.lib.clFlush(self)
+
+
+class OpenCLProgram(_OpenCLBase):
+    _destroyfn = 'clReleaseProgram'
+
+    def __init__(self, lib, ctx, dev, src, flags):
+        src = c_char_p(src.encode())
+        ptr = lib.clCreateProgramWithSource(ctx, 1, src, None)
+
+        super().__init__(lib, ptr)
+
+        flags = c_char_p(' '.join(flags).encode())
+        devptr = c_void_p(dev._as_parameter_)
+
+        try:
+            lib.clBuildProgram(self, 1, devptr, flags, None, None)
+        except OpenCLBuildProgramFailure:
+            nbytes = c_size_t()
+            lib.clGetProgramBuildInfo(self, devptr, lib.PROGRAM_BUILD_LOG, 0,
+                                      None, nbytes)
+
+            buf = create_string_buffer(nbytes.value)
+            lib.clGetProgramBuildInfo(self, devptr, lib.PROGRAM_BUILD_LOG,
+                                      nbytes, buf, None)
+
+            raise OpenCLBuildProgramFailure(buf.value.decode()) from None
+
+    def get_kernel(self, name, argspec):
+        return OpenCLKernel(self.lib, self, name, argspec)
+
+
+class OpenCLKernel(_OpenCLBase):
+    _destroyfn = 'clReleaseKernel'
+
+    typemap = [c_double, c_float, c_int32, c_int64]
+    typemap = {k: (k(), sizeof(k)) for k in typemap}
+
+    def __init__(self, lib, program, name, argtypes):
+        ptr = lib.clCreateKernel(program, name.encode())
+
+        super().__init__(lib, ptr)
+
+        # For each argument type fetch the corresponding ctypes instance
+        self._args = [self.typemap[atype] for atype in argtypes]
+
+        # Work group size arrays
+        self._gs = (c_size_t * 3)()
+        self._ls = (c_size_t * 3)()
+
+        # Wait-for array with an initial capacity of two events
+        self._wait_forp = (c_void_p * 2)()
+
+    def set_arg(self, i, v):
+        arg, sz = self._args[i]
+        arg.value = getattr(v, '_as_parameter_', v)
+
+        self.lib.clSetKernelArg(self, i, sz, byref(arg))
+
+    def set_args(self, *kargs, start=0):
+        for i, v in enumerate(kargs, start=start):
+            self.set_arg(i, v)
+
+    def exec_async(self, queue, gs, ls, wait_for=None, ret_evt=False):
+        ndim = len(gs)
+        evt_ptr = c_void_p() if ret_evt else None
+
+        if wait_for is None:
+            nwait = 0
+        else:
+            nwait = len(wait_for)
+            wait_forp = self._wait_forp
+
+            if len(wait_forp) < nwait:
+                self._wait_forp = wait_forp = (c_void_p * nwait)()
+
+            wait_forp[:nwait] = [int(w) for w in wait_for]
+
+        # Global work size
+        gsptr = self._gs
+        gsptr[:ndim] = gs
+
+        # Local work size
+        if ls is not None:
+            lsptr = self._ls
+            lsptr[:ndim] = ls
+        else:
+            lsptr = None
+
+        self.lib.clEnqueueNDRangeKernel(
+            queue, self, ndim, None, gsptr, lsptr, nwait, wait_for, evt_ptr
+        )
+
+        return OpenCLEvent(self.lib, evt_ptr) if ret_evt else None
+
+
+class OpenCL(object):
+    def __init__(self):
+        self.ctx = None
+        self.lib = OpenCLWrappers()
+
+    def __del__(self):
+        if self.ctx:
+            self.lib.clReleaseContext(self.ctx)
+
+    def get_platforms(self):
+        nplatforms = c_uint()
+        self.lib.clGetPlatformIDs(0, None, nplatforms)
+
+        platforms = (c_void_p * nplatforms.value)()
+        self.lib.clGetPlatformIDs(nplatforms, platforms, None)
+
+        return [OpenCLPlatform(self.lib, p) for p in platforms]
+
+    def set_device(self, dev):
+        if self.ctx:
+            raise RuntimeError('Device has already been set')
+
+        devptr = c_void_p(dev._as_parameter_)
+        self.ctx = self.lib.clCreateContext(None, 1, devptr, None, None)
+        self.dev = dev
+
+        # Allocate a default queue
+        self.qdflt = self.queue()
+
+    def mem_alloc(self, nbytes):
+        return OpenCLBuffer(self.lib, self.ctx, nbytes)
+
+    def zero(self, dst, off, nbytes):
+        z = c_char(0)
+        self.lib.clEnqueueFillBuffer(self.qdflt, dst, byref(z), 1, off,
+                                     nbytes, 0, None, None)
+        self.qdflt.finish()
+
+    def memcpy_async(self, queue, dst, src, nbytes, wait_for=None,
+                     ret_evt=False):
+        evt_ptr = c_void_p() if ret_evt else None
+
+        if wait_for is None:
+            nwait = 0
+        else:
+            nwait = len(wait_for)
+            wait_for = (c_void_p * nwait)(*map(int, wait_for))
+
+        # Device to host
+        if isinstance(dst, (np.ndarray, np.generic)):
+            dst = dst.ctypes.data
+
+            self.lib.clEnqueueReadBuffer(queue, src, False, 0, nbytes,
+                                         dst, nwait, wait_for, evt_ptr)
+        # Host to device
+        elif isinstance(src, (np.ndarray, np.generic)):
+            src = src.ctypes.data
+
+            self.lib.clEnqueueWriteBuffer(queue, dst, False, 0, nbytes,
+                                          src, nwait, wait_for, evt_ptr)
+        # Device to device
+        else:
+            self.lib.clEnqueueCopyBuffer(queue, src, dst, 0, 0, nbytes,
+                                         nwait, wait_for, evt_ptr)
+
+        return OpenCLEvent(self, evt_ptr) if ret_evt else None
+
+    def memcpy(self, dst, src, nbytes):
+        self.memcpy_async(self.qdflt, dst, src, nbytes)
+        self.qdflt.finish()
+
+    def program(self, src, flags=None):
+        return OpenCLProgram(self.lib, self.ctx, self.dev, src, flags or [])
+
+    def queue(self, out_of_order=False):
+        return OpenCLQueue(self.lib, self.ctx, self.dev, out_of_order)

--- a/pyfr/backends/opencl/gimmik.py
+++ b/pyfr/backends/opencl/gimmik.py
@@ -34,10 +34,10 @@ class OpenCLGiMMiKKernels(OpenCLKernelProvider):
         # Build
         fun = self._build_kernel('gimmik_mm', src,
                                  [np.int32] + [np.intp, np.int32]*2)
+        fun.set_args(b.ncol, b, b.leaddim, out, out.leaddim)
 
         class MulKernel(Kernel):
             def run(self, queue):
-                fun(queue.cmd_q, (b.ncol,), None, b.ncol, b.data,
-                    b.leaddim, out.data, out.leaddim)
+                fun.exec_async(queue.cmd_q, (b.ncol,), None)
 
-        return MulKernel()
+        return MulKernel(mats=[b, out])

--- a/pyfr/backends/opencl/packing.py
+++ b/pyfr/backends/opencl/packing.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pyopencl as cl
 
 from pyfr.backends.base import Kernel
 from pyfr.backends.opencl.provider import OpenCLKernelProvider
@@ -9,6 +8,8 @@ from pyfr.backends.opencl.provider import OpenCLKernelProvider
 
 class OpenCLPackingKernels(OpenCLKernelProvider):
     def pack(self, mv):
+        cl = self.backend.cl
+
         # An exchange view is simply a regular view plus an exchange matrix
         m, v = mv.xchgmat, mv.view
 
@@ -17,29 +18,24 @@ class OpenCLPackingKernels(OpenCLKernelProvider):
 
         # Build
         kern = self._build_kernel('pack_view', src, [np.int32]*3 + [np.intp]*4)
+        kern.set_args(v.n, v.nvrow, v.nvcol, v.basedata, v.mapping,
+                      v.rstrides or 0, m)
 
         class PackXchgViewKernel(Kernel):
             def run(self, queue):
-                # Kernel arguments
-                args = [v.n, v.nvrow, v.nvcol, v.basedata, v.mapping,
-                        v.rstrides, m]
-                args = [getattr(arg, 'data', arg) for arg in args]
-
                 # Pack
-                kern(queue.cmd_q, (v.n,), None, *args)
+                kern.exec_async(queue.cmd_q, (v.n,), None)
 
                 # Copy the packed buffer to the host
-                cevent = cl.enqueue_copy(queue.cmd_q, m.hdata, m.data,
-                                         is_blocking=False)
-                queue.copy_events.append(cevent)
+                cl.memcpy_async(queue.cmd_q, m.hdata, m.data, m.nbytes)
 
-        return PackXchgViewKernel()
+        return PackXchgViewKernel(mats=[mv])
 
     def unpack(self, mv):
+        cl = self.backend.cl
+
         class UnpackXchgMatrixKernel(Kernel):
             def run(self, queue):
-                cevent = cl.enqueue_copy(queue.cmd_q, mv.data, mv.hdata,
-                                         is_blocking=False)
-                queue.copy_events.append(cevent)
+                cl.memcpy_async(queue.cmd_q, mv.data, mv.hdata, mv.nbytes)
 
-        return UnpackXchgMatrixKernel()
+        return UnpackXchgMatrixKernel(mats=[mv])

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -1,29 +1,23 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-import pyopencl as cl
 
 from pyfr.backends.base import (BaseKernelProvider,
                                 BasePointwiseKernelProvider, Kernel)
 from pyfr.backends.opencl.generator import OpenCLKernelGenerator
+from pyfr.nputil import npdtype_to_ctypestype
 from pyfr.util import memoize
 
 
 class OpenCLKernelProvider(BaseKernelProvider):
     @memoize
+    def _build_program(self, src):
+        return self.backend.cl.program(src, flags=['-cl-fast-relaxed-math'])
+
     def _build_kernel(self, name, src, argtypes):
-        # Compile the source code
-        prg = cl.Program(self.backend.ctx, src)
-        prg.build(['-cl-fast-relaxed-math'])
+        argtypes = [npdtype_to_ctypestype(arg) for arg in argtypes]
 
-        # Retrieve the kernel
-        kern = getattr(prg, name)
-
-        # Set the argument types
-        dtypes = [t if t != np.intp else None for t in argtypes]
-        kern.set_scalar_arg_dtypes(dtypes)
-
-        return kern
+        return self._build_program(src).get_kernel(name, argtypes)
 
 
 class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
@@ -31,6 +25,8 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
     kernel_generator_cls = OpenCLKernelGenerator
 
     def _instantiate_kernel(self, dims, fun, arglst, argmv):
+        rtargs = []
+
         # Determine the work group sizes
         if len(dims) == 1:
             ls = (64,)
@@ -39,15 +35,18 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
             ls = (64, 4)
             gs = (dims[1] - dims[1] % -ls[0], ls[1])
 
-        class PointwiseKernel(Kernel):
-            if any(isinstance(arg, str) for arg in arglst):
-                def run(self, queue, **kwargs):
-                    narglst = [kwargs.get(ka, ka) for ka in arglst]
-                    narglst = [getattr(arg, 'data', arg) for arg in narglst]
-                    fun(queue.cmd_q, gs, ls, *narglst)
+        # Process the arguments
+        for i, k in enumerate(arglst):
+            if isinstance(k, str):
+                rtargs.append((i, k))
             else:
-                def run(self, queue, **kwargs):
-                    narglst = [getattr(arg, 'data', arg) for arg in arglst]
-                    fun(queue.cmd_q, gs, ls, *narglst)
+                fun.set_arg(i, k)
+
+        class PointwiseKernel(Kernel):
+            def run(self, queue, **kwargs):
+                for i, k in rtargs:
+                    fun.set_arg(i, kwargs[k])
+
+                fun.exec_async(queue.cmd_q, gs, ls)
 
         return PointwiseKernel(*argmv)

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -30,7 +30,7 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
                                     BasePointwiseKernelProvider):
     kernel_generator_cls = OpenCLKernelGenerator
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         # Determine the work group sizes
         if len(dims) == 1:
             ls = (64,)
@@ -50,4 +50,4 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
                     narglst = [getattr(arg, 'data', arg) for arg in arglst]
                     fun(queue.cmd_q, gs, ls, *narglst)
 
-        return PointwiseKernel()
+        return PointwiseKernel(*argmv)

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -17,7 +17,7 @@ class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
                                     BasePointwiseKernelProvider):
     kernel_generator_cls = OpenMPKernelGenerator
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         class PointwiseKernel(Kernel):
             if any(isinstance(arg, str) for arg in arglst):
                 def run(self, queue, **kwargs):
@@ -26,4 +26,4 @@ class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
                 def run(self, queue, **kwargs):
                     fun(*arglst)
 
-        return PointwiseKernel()
+        return PointwiseKernel(*argmv)

--- a/pyfr/ctypesutil.py
+++ b/pyfr/ctypesutil.py
@@ -32,7 +32,7 @@ class LibWrapper(object):
             try:
                 raise self._statuses[status]
             except KeyError:
-                raise self._statuses['*']
+                raise self._statuses['*'] from None
 
 
 def get_libc_function(fn):

--- a/setup.py
+++ b/setup.py
@@ -114,11 +114,6 @@ install_requires = [
     'pytools >= 2016.2.1'
 ]
 
-# Soft dependencies
-extras_require = {
-    'opencl': ['pyopencl >= 2015.2.4']
-}
-
 # Scripts
 console_scripts = [
     'pyfr = pyfr.__main__:main'
@@ -156,6 +151,5 @@ setup(name='pyfr',
       entry_points={'console_scripts': console_scripts},
       python_requires='>=3.8',
       install_requires=install_requires,
-      extras_require=extras_require,
       classifiers=classifiers
 )


### PR DESCRIPTION
This eliminates a dependency and also enables us to reduce API overhead by caching kernel arguments (something which is not possible with PyOpenCL).