### PR TITLE
Rework how arguments are passed to OpenMP kernels.

### DIFF
--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -8,6 +8,11 @@ from pyfr.util import memoize
 
 
 class Kernel(object):
+    def __init__(self, mats=[], views=[], misc=[]):
+        self.mats = mats
+        self.views = views
+        self.misc = misc
+
     @property
     def retval(self):
         return None
@@ -81,6 +86,9 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
         # Possible view types
         viewtypes = (self.backend.view_cls, self.backend.xchg_view_cls)
 
+        # Backend matrices and views this kernel operates on
+        argmats, argviews = [], []
+
         # First arguments are the iteration dimensions
         ndim, arglst = len(dims), [int(d) for d in dims]
 
@@ -97,6 +105,8 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
 
             # Matrix
             if isinstance(ka, mattypes):
+                argmats.append(ka)
+
                 # Check that argument is not a row sliced matrix
                 if isinstance(ka, mattypes[-1]) and ka.nrow != ka.parent.nrow:
                     raise ValueError('Row sliced matrices are not supported')
@@ -104,6 +114,8 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
                     arglst += [ka, ka.leaddim] if len(atypes) == 2 else [ka]
             # View
             elif isinstance(ka, viewtypes):
+                argviews.append(ka)
+
                 if isinstance(ka, self.backend.view_cls):
                     view = ka
                 else:
@@ -115,9 +127,9 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
             else:
                 arglst.append(ka)
 
-        return arglst
+        return arglst, (argmats, argviews)
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         pass
 
     def register(self, mod):
@@ -144,10 +156,10 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
             fun = self._build_kernel(name, src, list(it.chain(*argt)))
 
             # Process the argument list
-            argb = self._build_arglst(dims, argn, argt, kwargs)
+            argb, argmv = self._build_arglst(dims, argn, argt, kwargs)
 
             # Return a Kernel subclass instance
-            return self._instantiate_kernel(dims, fun, argb)
+            return self._instantiate_kernel(dims, fun, argb, argmv)
 
         # Attach the module to the method as an attribute
         kernel_meth._mod = mod

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -24,7 +24,7 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
                                   BasePointwiseKernelProvider):
     kernel_generator_cls = CUDAKernelGenerator
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         # Determine the block size
         if len(dims) == 1:
             block = (64, 1, 1)
@@ -43,4 +43,4 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
                 def run(self, queue, **kwargs):
                     fun.exec_async(grid, block, queue.stream, *arglst)
 
-        return PointwiseKernel()
+        return PointwiseKernel(*argmv)

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -34,7 +34,7 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
 
         self.kernel_generator_cls = KernelGenerator
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         block = self._block1d if len(dims) == 1 else self._block2d
         grid = get_grid_for_block(block, dims[-1])
 
@@ -47,4 +47,4 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
                 def run(self, queue, **kwargs):
                     fun.exec_async(grid, block, queue.stream, *arglst)
 
-        return PointwiseKernel()
+        return PointwiseKernel(*argmv)

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -30,7 +30,7 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
                                     BasePointwiseKernelProvider):
     kernel_generator_cls = OpenCLKernelGenerator
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         # Determine the work group sizes
         if len(dims) == 1:
             ls = (64,)
@@ -50,4 +50,4 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
                     narglst = [getattr(arg, 'data', arg) for arg in arglst]
                     fun(queue.cmd_q, gs, ls, *narglst)
 
-        return PointwiseKernel()
+        return PointwiseKernel(*argmv)

--- a/pyfr/backends/openmp/compiler.py
+++ b/pyfr/backends/openmp/compiler.py
@@ -13,7 +13,6 @@ from platformdirs import user_cache_dir
 from pytools.prefork import call_capture_output
 
 from pyfr.ctypesutil import platform_libname
-from pyfr.nputil import npdtype_to_ctypestype
 from pyfr.util import digest, mv, rm
 
 
@@ -140,7 +139,7 @@ class OpenMPCompilerModule(object):
 
     def function(self, name, restype, argtypes):
         fn = getattr(self.mod, name)
-        fn.restype = npdtype_to_ctypestype(restype)
-        fn.argtypes = [npdtype_to_ctypestype(a) for a in argtypes]
+        fn.restype = restype
+        fn.argtypes = argtypes
 
         return fn

--- a/pyfr/backends/openmp/gimmik.py
+++ b/pyfr/backends/openmp/gimmik.py
@@ -29,11 +29,10 @@ class OpenMPGiMMiKKernels(OpenMPKernelProvider):
         if np.count_nonzero(a.get()) > self.max_nnz:
             raise NotSuitableError('Matrix too dense for GiMMiK')
 
-        # Generate the GiMMiK kernel
+        # Generate and compile the GiMMiK function
         src = generate_mm(a.get(), dtype=a.dtype, platform='c',
                           alpha=alpha, beta=beta)
-        gimmik_mm = self._build_kernel('gimmik_mm', src,
-                                       [np.int32] + [np.intp, np.int32]*2)
+        gimmik_mm = self._build_function('gimmik_mm', src, 'iPiPi')
         gimmik_ptr = cast(gimmik_mm, c_void_p).value
 
         # Render our parallel wrapper kernel
@@ -41,15 +40,13 @@ class OpenMPGiMMiKKernels(OpenMPKernelProvider):
             lib='gimmik'
         )
 
-        # Argument types for batch_gemm
-        argt = [np.intp] + [np.int32]*2 + [np.intp, np.int32]*2
-
         # Build
-        batch_gemm = self._build_kernel('batch_gemm', src, argt)
+        batch_gemm = self._build_kernel('batch_gemm', src, 'PiiPiPi')
+        batch_gemm.set_args(gimmik_ptr, b.leaddim, b.nblocks, b, b.blocksz,
+                            out, out.blocksz)
 
         class MulKernel(Kernel):
             def run(self, queue):
-                batch_gemm(gimmik_ptr, b.leaddim, b.nblocks, b, b.blocksz, out,
-                           out.blocksz)
+                batch_gemm()
 
-        return MulKernel()
+        return MulKernel(mats=[b, out], misc=[gimmik_mm])

--- a/pyfr/backends/openmp/kernels/axnpby.mako
+++ b/pyfr/backends/openmp/kernels/axnpby.mako
@@ -2,11 +2,20 @@
 <%inherit file='base'/>
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-void
-axnpby(int nrow, int nblocks,
-       ${', '.join(f'fpdtype_t *restrict x{i}' for i in range(nv))},
-       ${', '.join(f'fpdtype_t a{i}' for i in range(nv))})
+struct kargs
 {
+    int nrow, nblocks;
+    fpdtype_t ${','.join(f'*x{i}' for i in range(nv))};
+    fpdtype_t ${','.join(f'a{i}' for i in range(nv))};
+};
+
+void axnpby(const struct kargs *restrict args)
+{
+    int nrow = args->nrow, nblocks = args->nblocks;
+% for i in range(nv):
+    fpdtype_t *x${i} = args->x${i}, a${i} = args->a${i};
+% endfor
+
 % if sorted(subdims) == list(range(ncola)):
     #pragma omp parallel for
     for (int ib = 0; ib < nblocks; ib++)

--- a/pyfr/backends/openmp/kernels/pack.mako
+++ b/pyfr/backends/openmp/kernels/pack.mako
@@ -2,13 +2,20 @@
 <%inherit file='base'/>
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-void
-pack_view(int n,
-          const fpdtype_t *__restrict__ v,
-          const int *__restrict__ vix,
-          const int *__restrict__ vrstri,
-          fpdtype_t *__restrict__ pmat)
+struct kargs
 {
+    int n;
+    fpdtype_t *v;
+    int *vix, *vrstri;
+    fpdtype_t *pmat;
+};
+
+void pack_view(const struct kargs *restrict args)
+{
+    int n = args->n;
+    int *vix = args->vix, *vrstri = args->vrstri;
+    fpdtype_t *v = args->v, *pmat = args->pmat;
+
     #pragma omp simd
     for (int i = 0; i < n; i++)
     {

--- a/pyfr/backends/openmp/kernels/par-memcpy.mako
+++ b/pyfr/backends/openmp/kernels/par-memcpy.mako
@@ -4,12 +4,18 @@
 
 #include <string.h>
 
-void
-par_memcpy(char *dst, int dbbytes, const char *src, int sbbytes, int bnbytes,
-           int nblocks)
+struct kargs
+{
+    char *dst;
+    int dbbytes;
+    const char *src;
+    int sbbytes, bnbytes, nblocks;
+};
+
+void par_memcpy(const struct kargs *restrict args)
 {
     #pragma omp parallel for
-    for (int ib = 0; ib < nblocks; ib++)
-        memcpy(dst + ((size_t) dbbytes)*ib, src + ((size_t) sbbytes)*ib,
-               bnbytes);
+    for (int ib = 0; ib < args->nblocks; ib++)
+        memcpy(args->dst + ((size_t) args->dbbytes)*ib,
+               args->src + ((size_t) args->sbbytes)*ib, args->bnbytes);
 }

--- a/pyfr/backends/openmp/kernels/reduction.mako
+++ b/pyfr/backends/openmp/kernels/reduction.mako
@@ -2,17 +2,31 @@
 <%inherit file='base'/>
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-void
-reduction(int nrow, int nblocks, fpdtype_t *restrict reduced,
-          fpdtype_t *restrict rcurr, fpdtype_t *restrict rold,
-% if method == 'errest':
-          fpdtype_t *restrict rerr, fpdtype_t atol, fpdtype_t rtol)
-% elif method == 'resid' and dt_type == 'matrix':
-          fpdtype_t *restrict dt_mat, fpdtype_t dt_fac)
-% elif method == 'resid':
-          fpdtype_t dt_fac)
-% endif
+struct kargs
 {
+    int nrow, nblocks;
+    fpdtype_t *reduced, *rcurr, *rold;
+% if method == 'errest':
+    fpdtype_t *rerr, atol, rtol;
+% elif method == 'resid' and dt_type == 'matrix':
+    fpdtype_t *dt_mat, dt_fac;
+% elif method == 'resid':
+    fpdtype_t dt_fac;
+% endif
+};
+
+void reduction(const struct kargs *restrict args)
+{
+    int nrow = args->nrow, nblocks = args->nblocks;
+    fpdtype_t *reduced = args->reduced, *rcurr = args->rcurr, *rold = args->rold;
+% if method == 'errest':
+    fpdtype_t *rerr = args->rerr, atol = args->atol, rtol = args->rtol;
+% elif method == 'resid' and dt_type == 'matrix':
+    fpdtype_t *dt_mat = args->dt_mat, dt_fac = args->dt_fac;
+% elif method == 'resid':
+    fpdtype_t dt_fac = args->dt_fac;
+% endif
+
     #define X_IDX_AOSOA(v, nv) ((_xi/SOA_SZ*(nv) + (v))*SOA_SZ + _xj)
 
     // Initalise the reduction variables

--- a/pyfr/backends/openmp/packing.py
+++ b/pyfr/backends/openmp/packing.py
@@ -15,12 +15,13 @@ class OpenMPPackingKernels(OpenMPKernelProvider):
 
         # Build
         kern = self._build_kernel('pack_view', src, 'iPPPP')
+        kern.set_args(v.n, v.basedata, v.mapping, v.rstrides or 0, m)
 
         class PackXchgViewKernel(Kernel):
             def run(self, queue):
-                kern(v.n, v.basedata, v.mapping, v.rstrides or 0, m)
+                kern()
 
-        return PackXchgViewKernel()
+        return PackXchgViewKernel(mats=[mv])
 
     def unpack(self, mv):
         return NullKernel()

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -17,7 +17,7 @@ class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
                                     BasePointwiseKernelProvider):
     kernel_generator_cls = OpenMPKernelGenerator
 
-    def _instantiate_kernel(self, dims, fun, arglst):
+    def _instantiate_kernel(self, dims, fun, arglst, argmv):
         class PointwiseKernel(Kernel):
             if any(isinstance(arg, str) for arg in arglst):
                 def run(self, queue, **kwargs):
@@ -26,4 +26,4 @@ class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
                 def run(self, queue, **kwargs):
                     fun(*arglst)
 
-        return PointwiseKernel()
+        return PointwiseKernel(*argmv)

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -1,16 +1,51 @@
 # -*- coding: utf-8 -*-
 
+from ctypes import Structure, byref
+
 from pyfr.backends.base import (BaseKernelProvider,
                                 BasePointwiseKernelProvider, Kernel)
 from pyfr.backends.openmp.generator import OpenMPKernelGenerator
+from pyfr.nputil import npdtype_to_ctypestype
 from pyfr.util import memoize
+
+
+class OpenMPKernelFunction(object):
+    def __init__(self, fun, argcls):
+        self.fun = fun
+        self.kargs = argcls()
+
+    def set_arg(self, i, v):
+        setattr(self.kargs, f'arg{i}', getattr(v, '_as_parameter_', v))
+
+    def set_args(self, *args, start=0):
+        for i, arg in enumerate(args, start=start):
+            self.set_arg(i, arg)
+
+    def __call__(self):
+        self.fun(byref(self.kargs))
 
 
 class OpenMPKernelProvider(BaseKernelProvider):
     @memoize
-    def _build_kernel(self, name, src, argtypes, restype=None):
-        mod = self.backend.compiler.build(src)
-        return mod.function(name, restype, argtypes)
+    def _get_arg_cls(self, argtypes):
+        fields = [(f'arg{i}', npdtype_to_ctypestype(arg))
+                  for i, arg in enumerate(argtypes)]
+
+        return type('ArgStruct', (Structure,), {'_fields_': fields})
+
+    @memoize
+    def _build_library(self, src):
+        return self.backend.compiler.build(src)
+
+    def _build_function(self, name, src, argtypes, restype=None):
+        lib = self._build_library(src)
+        return lib.function(name, restype,
+                            [npdtype_to_ctypestype(arg) for arg in argtypes])
+
+    def _build_kernel(self, name, src, argtypes):
+        fun = self._build_function(name, [np.intp])
+
+        return OpenMPKernelFunction(fun, self._get_arg_cls(tuple(argtypes)))
 
 
 class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
@@ -18,12 +53,20 @@ class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
     kernel_generator_cls = OpenMPKernelGenerator
 
     def _instantiate_kernel(self, dims, fun, arglst, argmv):
-        class PointwiseKernel(Kernel):
-            if any(isinstance(arg, str) for arg in arglst):
-                def run(self, queue, **kwargs):
-                    fun(*[kwargs.get(ka, ka) for ka in arglst])
+        rtargs = []
+
+        # Process the arguments
+        for i, k in enumerate(arglst):
+            if isinstance(k, str):
+                rtargs.append((i, k))
             else:
-                def run(self, queue, **kwargs):
-                    fun(*arglst)
+                fun.set_arg(i, k)
+
+        class PointwiseKernel(Kernel):
+            def run(self, queue, **kwargs):
+                for i, k in rtargs:
+                    fun.set_arg(i, kwargs[k])
+
+                fun()
 
         return PointwiseKernel(*argmv)


### PR DESCRIPTION
All kernels now accept a pointer to a structure.  This reduces overhead and will, in the feature, enable the OpenMP backend to support a task-graph interface.