### PR TITLE
Switch to a task graph interface.

### DIFF
--- a/pyfr/backends/base/__init__.py
+++ b/pyfr/backends/base/__init__.py
@@ -6,4 +6,5 @@ from pyfr.backends.base.kernels import (BaseKernelProvider,
                                         Kernel, MetaKernel, NotSuitableError,
                                         NullKernel)
 from pyfr.backends.base.types import (ConstMatrix, Matrix, MatrixBase,
-                                      MatrixSlice, View, XchgMatrix, XchgView)
+                                      MatrixSlice, Graph, View, XchgMatrix,
+                                      XchgView)

--- a/pyfr/backends/base/__init__.py
+++ b/pyfr/backends/base/__init__.py
@@ -6,5 +6,4 @@ from pyfr.backends.base.kernels import (BaseKernelProvider,
                                         Kernel, MetaKernel, NotSuitableError,
                                         NullKernel)
 from pyfr.backends.base.types import (ConstMatrix, Matrix, MatrixBase,
-                                      MatrixSlice, Queue, View, XchgMatrix,
-                                      XchgView)
+                                      MatrixSlice, View, XchgMatrix, XchgView)

--- a/pyfr/backends/base/backend.py
+++ b/pyfr/backends/base/backend.py
@@ -50,12 +50,6 @@ class BaseBackend:
         # Mapping from backend objects to memory extents
         self._obj_extents = WeakKeyDictionary()
 
-        from mpi4py import MPI
-
-        # MPI wrappers
-        self._startall = MPI.Prequest.Startall
-        self._waitall = MPI.Prequest.Waitall
-
     @cached_property
     def lookup(self):
         pkg = f'pyfr.backends.{self.name}.kernels'

--- a/pyfr/backends/base/backend.py
+++ b/pyfr/backends/base/backend.py
@@ -23,16 +23,6 @@ def recordmat(fn):
     return newfn
 
 
-def recordkern(fn):
-    @wraps(fn)
-    def newfn(self, *args, **kwargs):
-        k = fn(self, *args, **kwargs)
-        k.kid = next(self._kern_counter)
-
-        return k
-    return newfn
-
-
 class BaseBackend:
     name = None
 
@@ -50,10 +40,7 @@ class BaseBackend:
 
         # Allocated matrices
         self.mats = WeakValueDictionary()
-
-        # Counters
         self._mat_counter = count()
-        self._kern_counter = count()
 
         # Aliases and extents
         self._pend_aliases = {}
@@ -169,7 +156,6 @@ class BaseBackend:
         return self.xchg_view_cls(self, matmap, rmap, cmap, rstridemap,
                                   vshape, tags)
 
-    @recordkern
     def kernel(self, name, *args, **kwargs):
         for prov in self._providers:
             kern = getattr(prov, name, None)
@@ -181,10 +167,11 @@ class BaseBackend:
         else:
             raise KeyError(f'Kernel "{name}" has no providers')
 
-    @recordkern
     def ordered_meta_kernel(self, kerns):
         return self.ordered_meta_kernel_cls(kerns)
 
-    @recordkern
     def unordered_meta_kernel(self, kerns):
         return self.unordered_meta_kernel_cls(kerns)
+
+    def graph(self):
+        return self.graph_cls(self)

--- a/pyfr/backends/base/backend.py
+++ b/pyfr/backends/base/backend.py
@@ -63,6 +63,12 @@ class BaseBackend:
         # Mapping from backend objects to memory extents
         self._obj_extents = WeakKeyDictionary()
 
+        from mpi4py import MPI
+
+        # MPI wrappers
+        self._startall = MPI.Prequest.Startall
+        self._waitall = MPI.Prequest.Waitall
+
     @cached_property
     def lookup(self):
         pkg = f'pyfr.backends.{self.name}.kernels'
@@ -182,6 +188,3 @@ class BaseBackend:
     @recordkern
     def unordered_meta_kernel(self, kerns):
         return self.unordered_meta_kernel_cls(kerns)
-
-    def queue(self):
-        return self.queue_cls(self)

--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -17,7 +17,7 @@ class Kernel:
     def retval(self):
         return None
 
-    def run(self, queue, *args, **kwargs):
+    def run(self, *args):
         pass
 
 
@@ -31,9 +31,9 @@ class MetaKernel(Kernel):
 
         self._kernels = list(kernels)
 
-    def run(self, queue, *args, **kwargs):
+    def run(self, *args):
         for k in self._kernels:
-            k.run(queue, *args, **kwargs)
+            k.run(*args)
 
 
 class BaseKernelProvider:

--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -29,10 +29,10 @@ class MetaKernel(Kernel):
     def __init__(self, kernels):
         super().__init__()
 
-        self._kernels = list(kernels)
+        self.kernels = list(kernels)
 
     def run(self, *args):
-        for k in self._kernels:
+        for k in self.kernels:
             k.run(*args)
 
 

--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -27,6 +27,8 @@ class NullKernel(Kernel):
 
 class MetaKernel(Kernel):
     def __init__(self, kernels):
+        super().__init__()
+
         self._kernels = list(kernels)
 
     def run(self, queue, *args, **kwargs):

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -284,7 +284,7 @@ class XchgView:
         return self.xchgmat.sendreq(pid, tag)
 
 
-class Graph(object):
+class Graph:
     def __init__(self, backend):
         self.backend = backend
         self.committed = False
@@ -300,7 +300,7 @@ class Graph(object):
 
     def add(self, kern, deps=[]):
         if self.committed:
-            raise RuntimeError('Can not add nodes to a commited graph')
+            raise RuntimeError('Can not add nodes to a committed graph')
 
         if kern in self.knodes:
             raise RuntimeError('Can only add a kernel to a graph once')
@@ -324,7 +324,7 @@ class Graph(object):
             raise RuntimeError('Can not add nodes to a committed graph')
 
         if req in self.mpi_reqs:
-            raise RuntimeError('Can only add a request to a graph once')
+            raise ValueError('Can only add an MPI request to a graph once')
 
         # Add the request
         self.mpi_reqs.append(req)

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -282,3 +282,39 @@ class XchgView:
 
     def sendreq(self, pid, tag):
         return self.xchgmat.sendreq(pid, tag)
+
+
+class Graph(object):
+    def __init__(self, backend):
+        self.backend = backend
+        self.committed = False
+
+        # Kernels and their dependencies
+        self.knodes = {}
+        self.kdeps = {}
+
+    def add(self, kern, deps=[]):
+        if self.committed:
+            raise RuntimeError('Can not add nodes to a commited graph')
+
+        if kern in self.knodes:
+            raise RuntimeError('Can only add a kernel to a graph once')
+
+        # Resolve the dependency list
+        rdeps = [self.knodes[d] for d in deps]
+
+        # Ask the kernel to add itself
+        self.knodes[kern] = kern.add_to_graph(self, rdeps)
+
+        # Note our dependencies
+        self.kdeps[kern] = deps
+
+    def add_all(self, kerns, deps=[]):
+        for k in kerns:
+            self.add(k, deps)
+
+    def commit(self):
+        self.committed = True
+
+    def run(self, *args):
+        pass

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -292,6 +292,11 @@ class Graph(object):
         # Kernels and their dependencies
         self.knodes = {}
         self.kdeps = {}
+        self.depk = set()
+
+        # MPI requests along with their associated dependencies
+        self.mpi_reqs = []
+        self.mpi_req_deps = []
 
     def add(self, kern, deps=[]):
         if self.committed:
@@ -308,13 +313,35 @@ class Graph(object):
 
         # Note our dependencies
         self.kdeps[kern] = deps
+        self.depk.update(deps)
 
     def add_all(self, kerns, deps=[]):
         for k in kerns:
             self.add(k, deps)
 
+    def add_mpi_req(self, req, deps=[]):
+        if self.committed:
+            raise RuntimeError('Can not add nodes to a committed graph')
+
+        if req in self.mpi_reqs:
+            raise RuntimeError('Can only add a request to a graph once')
+
+        # Add the request
+        self.mpi_reqs.append(req)
+        self.mpi_req_deps.append(deps)
+
+        # Note any dependencies
+        self.depk.update(deps)
+
+    def add_mpi_reqs(self, reqs, deps=[]):
+        for r in reqs:
+            self.add_mpi_req(r, deps)
+
     def commit(self):
+        mreqs, mdeps = self.mpi_reqs, self.mpi_req_deps
+
         self.committed = True
+        self.mpi_root_reqs = [r for r, d in zip(mreqs, mdeps) if not d]
 
     def run(self, *args):
         pass

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -282,30 +282,3 @@ class XchgView:
 
     def sendreq(self, pid, tag):
         return self.xchgmat.sendreq(pid, tag)
-
-
-class Queue:
-    def __init__(self, backend):
-        from mpi4py import MPI
-
-        self.backend = backend
-
-        # MPI wrappers
-        self._startall = MPI.Prequest.Startall
-        self._waitall = MPI.Prequest.Waitall
-
-        # Items waiting to be executed
-        self._items = []
-
-    def enqueue(self, items, *args, **kwargs):
-        self._items.extend((item, args, kwargs) for item in items)
-
-    def enqueue_and_run(self, items, *args, **kwargs):
-        if self._items:
-            self.run()
-
-        self.enqueue(items, *args, **kwargs)
-        self.run()
-
-    def __bool__(self):
-        return bool(self._items)

--- a/pyfr/backends/cuda/base.py
+++ b/pyfr/backends/cuda/base.py
@@ -72,6 +72,8 @@ class CUDABackend(BaseBackend):
         self.view_cls = types.CUDAView
         self.xchg_matrix_cls = types.CUDAXchgMatrix
         self.xchg_view_cls = types.CUDAXchgView
+        self.ordered_meta_kernel_cls = types.CUDAOrderedMetaKernel
+        self.unordered_meta_kernel_cls = types.CUDAUnorderedMetaKernel
 
         # Instantiate the base kernel providers
         kprovs = [provider.CUDAPointwiseKernelProvider,

--- a/pyfr/backends/cuda/base.py
+++ b/pyfr/backends/cuda/base.py
@@ -89,16 +89,19 @@ class CUDABackend(BaseBackend):
         # Create a stream to run kernels on
         self._stream = self.cuda.create_stream()
 
-    def run_kernels(self, kernels):
+    def run_kernels(self, kernels, wait=False):
         # Submit the kernels to the CUDA stream
         for k in kernels:
             k.run(self._stream)
 
-        # Wait for the kernels to finish
-        self._stream.synchronize()
+        if wait:
+            self._stream.synchronize()
 
-    def run_graph(self, graph):
+    def run_graph(self, graph, wait=False):
         graph.run(self._stream)
+
+        if wait:
+            self._stream.synchronize()
 
     def _malloc_impl(self, nbytes):
         # Allocate

--- a/pyfr/backends/cuda/base.py
+++ b/pyfr/backends/cuda/base.py
@@ -89,26 +89,16 @@ class CUDABackend(BaseBackend):
         # Create a stream to run kernels on
         self._stream = self.cuda.create_stream()
 
-    def run_kernels(self, kernels, mpireqs=None):
-        stream = self._stream
-
-        # Start any MPI requests
-        if mpireqs:
-            self._startall(mpireqs)
-
+    def run_kernels(self, kernels):
         # Submit the kernels to the CUDA stream
         for k in kernels:
-            k.run(stream)
-
-        # If we started any MPI requests, wait for them
-        if mpireqs:
-            self._waitall(mpireqs)
+            k.run(self._stream)
 
         # Wait for the kernels to finish
-        stream.synchronize()
+        self._stream.synchronize()
 
-    def run_graph(self, graph, mpireqs=None):
-        self.run_kernels([graph], mpireqs)
+    def run_graph(self, graph):
+        graph.run(self._stream)
 
     def _malloc_impl(self, nbytes):
         # Allocate

--- a/pyfr/backends/cuda/cublas.py
+++ b/pyfr/backends/cuda/cublas.py
@@ -92,8 +92,8 @@ class CUDACUBLASKernels:
             alpha_ct, beta_ct = c_float(alpha), c_float(beta)
 
         class MulKernel(Kernel):
-            def run(iself, queue):
-                lib.cublasSetStream(self, queue.stream)
+            def run(iself, stream):
+                lib.cublasSetStream(self, stream)
                 cublasgemm(self, lib.OP_N, lib.OP_N, m, n, k,
                            alpha_ct, A, A.leaddim, B, B.leaddim,
                            beta_ct, C, C.leaddim)

--- a/pyfr/backends/cuda/gimmik.py
+++ b/pyfr/backends/cuda/gimmik.py
@@ -3,8 +3,8 @@
 from gimmik import generate_mm
 import numpy as np
 
-from pyfr.backends.base import Kernel, NotSuitableError
-from pyfr.backends.cuda.provider import (CUDAKernelProvider,
+from pyfr.backends.base import NotSuitableError
+from pyfr.backends.cuda.provider import (CUDAKernel, CUDAKernelProvider,
                                          get_grid_for_block)
 
 
@@ -45,7 +45,10 @@ class CUDAGiMMiKKernels(CUDAKernelProvider):
         params = fun.make_params(grid, block)
         params.set_args(b, out)
 
-        class MulKernel(Kernel):
+        class MulKernel(CUDAKernel):
+            def add_to_graph(self, graph, deps):
+                return graph.graph.add_kernel(params, deps)
+
             def run(self, stream):
                 fun.exec_async(stream, params)
 

--- a/pyfr/backends/cuda/gimmik.py
+++ b/pyfr/backends/cuda/gimmik.py
@@ -46,7 +46,7 @@ class CUDAGiMMiKKernels(CUDAKernelProvider):
         params.set_args(b, out)
 
         class MulKernel(Kernel):
-            def run(self, queue):
-                fun.exec_async(queue.stream, params)
+            def run(self, stream):
+                fun.exec_async(stream, params)
 
         return MulKernel(mats=[b, out])

--- a/pyfr/backends/cuda/gimmik.py
+++ b/pyfr/backends/cuda/gimmik.py
@@ -34,15 +34,19 @@ class CUDAGiMMiKKernels(CUDAKernelProvider):
                           n=b.ncol, ldb=b.leaddim, ldc=out.leaddim)
 
         # Build
-        fun = self._build_kernel('gimmik_mm', src, [np.intp, np.intp])
+        fun = self._build_kernel('gimmik_mm', src, 'PP')
         fun.set_cache_pref(prefer_l1=True)
 
         # Determine the grid/block
         block = (128, 1, 1)
         grid = get_grid_for_block(block, b.ncol)
 
+        # Set the parameters
+        params = fun.make_params(grid, block)
+        params.set_args(b, out)
+
         class MulKernel(Kernel):
             def run(self, queue):
-                fun.exec_async(grid, block, queue.stream, b, out)
+                fun.exec_async(queue.stream, params)
 
-        return MulKernel()
+        return MulKernel(mats=[b, out])

--- a/pyfr/backends/cuda/packing.py
+++ b/pyfr/backends/cuda/packing.py
@@ -29,14 +29,14 @@ class CUDAPackingKernels(CUDAKernelProvider):
         # If MPI is CUDA aware then we just need to pack the buffer
         if self.backend.mpitype == 'cuda-aware':
             class PackXchgViewKernel(Kernel):
-                def run(self, queue):
-                    kern.exec_async(queue.stream, params)
+                def run(self, stream):
+                    kern.exec_async(stream, params)
         # Otherwise, we need to both pack the buffer and copy it back
         else:
             class PackXchgViewKernel(Kernel):
-                def run(self, queue):
-                    kern.exec_async(queue.stream, params)
-                    cuda.memcpy(m.hdata, m.data, m.nbytes, queue.stream)
+                def run(self, stream):
+                    kern.exec_async(stream, params)
+                    cuda.memcpy(m.hdata, m.data, m.nbytes, stream)
 
         return PackXchgViewKernel(mats=[mv])
 
@@ -47,7 +47,7 @@ class CUDAPackingKernels(CUDAKernelProvider):
             return NullKernel()
         else:
             class UnpackXchgMatrixKernel(Kernel):
-                def run(self, queue):
-                    cuda.memcpy(mv.data, mv.hdata, mv.nbytes, queue.stream)
+                def run(self, stream):
+                    cuda.memcpy(mv.data, mv.hdata, mv.nbytes, stream)
 
             return UnpackXchgMatrixKernel()

--- a/pyfr/backends/cuda/packing.py
+++ b/pyfr/backends/cuda/packing.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from pyfr.backends.base import Kernel, NullKernel
-from pyfr.backends.cuda.provider import CUDAKernelProvider, get_grid_for_block
+from pyfr.backends.base import NullKernel
+from pyfr.backends.cuda.provider import (CUDAKernel, CUDAKernelProvider,
+                                         get_grid_for_block)
 
 
 class CUDAPackingKernels(CUDAKernelProvider):
@@ -28,12 +29,21 @@ class CUDAPackingKernels(CUDAKernelProvider):
 
         # If MPI is CUDA aware then we just need to pack the buffer
         if self.backend.mpitype == 'cuda-aware':
-            class PackXchgViewKernel(Kernel):
+            class PackXchgViewKernel(CUDAKernel):
+                def add_to_graph(self, graph, deps):
+                    return graph.graph.add_kernel(params, deps)
+
                 def run(self, stream):
                     kern.exec_async(stream, params)
         # Otherwise, we need to both pack the buffer and copy it back
         else:
-            class PackXchgViewKernel(Kernel):
+            class PackXchgViewKernel(CUDAKernel):
+                def add_to_graph(self, graph, deps):
+                    gpack = graph.graph.add_kernel(params, deps)
+                    return graph.graph.add_memcpy(
+                        m.hdata, m.data, m.nbytes, [gpack]
+                    )
+
                 def run(self, stream):
                     kern.exec_async(stream, params)
                     cuda.memcpy(m.hdata, m.data, m.nbytes, stream)
@@ -46,8 +56,12 @@ class CUDAPackingKernels(CUDAKernelProvider):
         if self.backend.mpitype == 'cuda-aware':
             return NullKernel()
         else:
-            class UnpackXchgMatrixKernel(Kernel):
+            class UnpackXchgMatrixKernel(CUDAKernel):
+                def add_to_graph(self, graph, deps):
+                    return graph.graph.add_memcpy(mv.data, mv.hdata, mv.nbytes,
+                                                  deps)
+
                 def run(self, stream):
                     cuda.memcpy(mv.data, mv.hdata, mv.nbytes, stream)
 
-            return UnpackXchgMatrixKernel()
+            return UnpackXchgMatrixKernel(mats=[mv])

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -43,10 +43,12 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
                 params.set_arg(i, k)
 
         class PointwiseKernel(Kernel):
-            def run(self, queue, **kwargs):
-                for i, k in rtargs:
-                    params.set_arg(i, kwargs[k])
+            if rtargs:
+                def bind(self, **kwargs):
+                    for i, k in rtargs:
+                        params.set_arg(i, kwargs[k])
 
-                fun.exec_async(queue.stream, params)
+            def run(self, stream):
+                fun.exec_async(stream, params)
 
         return PointwiseKernel(*argmv)

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from weakref import WeakKeyDictionary
+
 from pyfr.backends.base import (BaseKernelProvider,
-                                BasePointwiseKernelProvider, Kernel)
+                                BasePointwiseKernelProvider, Kernel,
+                                MetaKernel)
 from pyfr.backends.cuda.generator import CUDAKernelGenerator
 from pyfr.backends.cuda.compiler import SourceModule
 from pyfr.util import memoize
@@ -9,6 +12,29 @@ from pyfr.util import memoize
 
 def get_grid_for_block(block, nrow, ncol=1):
     return (-(-nrow // block[0]), -(-ncol // block[1]), 1)
+
+
+class CUDAKernel(Kernel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if hasattr(self, 'bind') and hasattr(self, 'add_to_graph'):
+            self.gnodes = WeakKeyDictionary()
+
+
+class CUDAOrderedMetaKernel(MetaKernel):
+    def add_to_graph(self, graph, dnodes):
+        for k in self.kernels:
+            dnodes = [k.add_to_graph(graph, dnodes)]
+
+        return dnodes[0]
+
+
+class CUDAUnorderedMetaKernel(MetaKernel):
+    def add_to_graph(self, graph, dnodes):
+        nodes = [k.add_to_graph(graph, dnodes) for k in self.kernels]
+
+        return graph.graph.add_empty(nodes)
 
 
 class CUDAKernelProvider(BaseKernelProvider):
@@ -42,11 +68,25 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
             else:
                 params.set_arg(i, k)
 
-        class PointwiseKernel(Kernel):
+        class PointwiseKernel(CUDAKernel):
             if rtargs:
                 def bind(self, **kwargs):
                     for i, k in rtargs:
                         params.set_arg(i, kwargs[k])
+
+                    # Notify any graphs we're in about our new parameters
+                    for graph, gnode in self.gnodes.items():
+                        graph.stale_kparams[gnode] = params
+
+            def add_to_graph(self, graph, deps):
+                gnode = graph.graph.add_kernel(params, deps)
+
+                # If our parameters can change then we need to keep a
+                # (weak) reference to the graph so we can notify it
+                if rtargs:
+                    self.gnodes[graph] = gnode
+
+                return gnode
 
             def run(self, stream):
                 fun.exec_async(stream, params)

--- a/pyfr/backends/cuda/types.py
+++ b/pyfr/backends/cuda/types.py
@@ -87,6 +87,14 @@ class CUDAXchgView(base.XchgView):
     pass
 
 
+class CUDAOrderedMetaKernel(base.MetaKernel):
+    pass
+
+
+class CUDAUnorderedMetaKernel(base.MetaKernel):
+    pass
+
+
 class CUDAQueue(base.Queue):
     def __init__(self, backend):
         super().__init__(backend)

--- a/pyfr/backends/cuda/types.py
+++ b/pyfr/backends/cuda/types.py
@@ -110,8 +110,7 @@ class CUDAGraph(base.Graph):
         self.stale_kparams.clear()
 
         # Start all dependency-free MPI requests
-        if self.mpi_root_reqs:
-            MPI.Prequest.Startall(self.mpi_root_reqs)
+        MPI.Prequest.Startall(self.mpi_root_reqs)
 
         # Start any remaining requests once their dependencies are satisfied
         for event, req in self.mpi_events:
@@ -119,8 +118,4 @@ class CUDAGraph(base.Graph):
             req.Start()
 
         # Wait for all of the MPI requests to finish
-        if self.mpi_reqs:
-            MPI.Prequest.Waitall(self.mpi_reqs)
-
-        # Wait for all of the kernels to finish
-        stream.synchronize()
+        MPI.Prequest.Waitall(self.mpi_reqs)

--- a/pyfr/backends/cuda/types.py
+++ b/pyfr/backends/cuda/types.py
@@ -93,28 +93,3 @@ class CUDAOrderedMetaKernel(base.MetaKernel):
 
 class CUDAUnorderedMetaKernel(base.MetaKernel):
     pass
-
-
-class CUDAQueue(base.Queue):
-    def __init__(self, backend):
-        super().__init__(backend)
-
-        # CUDA stream
-        self.stream = backend.cuda.create_stream()
-
-    def run(self, mpireqs=[]):
-        # Start any MPI requests
-        if mpireqs:
-            self._startall(mpireqs)
-
-        # Submit the kernels to the CUDA stream
-        for item, args, kwargs in self._items:
-            item.run(self, *args, **kwargs)
-
-        # If we started any MPI requests, wait for them
-        if mpireqs:
-            self._waitall(mpireqs)
-
-        # Wait for the kernels to finish and clear the queue
-        self.stream.synchronize()
-        self._items.clear()

--- a/pyfr/backends/hip/base.py
+++ b/pyfr/backends/hip/base.py
@@ -59,6 +59,8 @@ class HIPBackend(BaseBackend):
         self.view_cls = types.HIPView
         self.xchg_matrix_cls = types.HIPXchgMatrix
         self.xchg_view_cls = types.HIPXchgView
+        self.ordered_meta_kernel_cls = types.HIPOrderedMetaKernel
+        self.unordered_meta_kernel_cls = types.HIPUnorderedMetaKernel
 
         # Instantiate the base kernel providers
         kprovs = [provider.HIPPointwiseKernelProvider,

--- a/pyfr/backends/hip/base.py
+++ b/pyfr/backends/hip/base.py
@@ -76,26 +76,16 @@ class HIPBackend(BaseBackend):
         # Create a stream to run kernels on
         self._stream = self.hip.create_stream()
 
-    def run_kernels(self, kernels, mpireqs=None):
-        stream = self._stream
-
-        # Start any MPI requests
-        if mpireqs:
-            self._startall(mpireqs)
-
+    def run_kernels(self, kernels):
         # Submit the kernels to the HIP stream
         for k in kernels:
-            k.run(stream)
-
-        # If we started any MPI requests, wait for them
-        if mpireqs:
-            self._waitall(mpireqs)
+            k.run(self._stream)
 
         # Wait for the kernels to finish
-        stream.synchronize()
+        self._stream.synchronize()
 
-    def run_graph(self, graph, mpireqs=None):
-        self.run_kernels([graph], mpireqs)
+    def run_graph(self, graph):
+        graph.run(self._stream)
 
     def _malloc_impl(self, nbytes):
         # Allocate

--- a/pyfr/backends/hip/base.py
+++ b/pyfr/backends/hip/base.py
@@ -76,16 +76,19 @@ class HIPBackend(BaseBackend):
         # Create a stream to run kernels on
         self._stream = self.hip.create_stream()
 
-    def run_kernels(self, kernels):
+    def run_kernels(self, kernels, wait=False):
         # Submit the kernels to the HIP stream
         for k in kernels:
             k.run(self._stream)
 
-        # Wait for the kernels to finish
-        self._stream.synchronize()
+        if wait:
+            self._stream.synchronize()
 
-    def run_graph(self, graph):
+    def run_graph(self, graph, wait=False):
         graph.run(self._stream)
+
+        if wait:
+            self._stream.synchronize()
 
     def _malloc_impl(self, nbytes):
         # Allocate

--- a/pyfr/backends/hip/blasext.py
+++ b/pyfr/backends/hip/blasext.py
@@ -28,12 +28,16 @@ class HIPBlasExtKernels(HIPKernelProvider):
         kern = self._build_kernel('axnpby', src,
                                   [np.int32]*3 + [np.intp]*nv + [dtype]*nv)
 
+        # Set the parameters
+        params = kern.make_params(grid, block)
+        params.set_args(nrow, ncolb, ldim, *arr)
+
         class AxnpbyKernel(Kernel):
             def run(self, queue, *consts):
-                kern.exec_async(grid, block, queue.stream, nrow, ncolb, ldim,
-                                *arr, *consts)
+                params.set_args(*consts, start=3 + nv)
+                kern.exec_async(queue.stream, params)
 
-        return AxnpbyKernel()
+        return AxnpbyKernel(mats=arr)
 
     def copy(self, dst, src):
         hip = self.backend.hip
@@ -88,6 +92,13 @@ class HIPBlasExtKernels(HIPKernelProvider):
         # Build the reduction kernel
         rkern = self._build_kernel('reduction', src, argt)
 
+        # Set the parameters
+        params = rkern.make_params(grid, block)
+        params.set_args(nrow, ncolb, ldim, reduced_dev, *regs)
+
+        # Runtime argument offset
+        facoff = argt.index(dtype)
+
         # Norm type
         reducer = np.max if norm == 'uniform' else np.sum
 
@@ -97,9 +108,9 @@ class HIPBlasExtKernels(HIPKernelProvider):
                 return reducer(reduced_host, axis=1)
 
             def run(self, queue, *facs):
-                rkern.exec_async(grid, block, queue.stream,
-                                 nrow, ncolb, ldim, reduced_dev, *regs, *facs)
+                params.set_args(*facs, start=facoff)
+                rkern.exec_async(queue.stream, params)
                 hip.memcpy(reduced_host, reduced_dev, reduced_dev.nbytes,
                            queue.stream)
 
-        return ReductionKernel()
+        return ReductionKernel(mats=regs)

--- a/pyfr/backends/hip/blasext.py
+++ b/pyfr/backends/hip/blasext.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 
-from pyfr.backends.hip.provider import HIPKernelProvider, get_grid_for_block
-from pyfr.backends.base import Kernel
+from pyfr.backends.hip.provider import (HIPKernel, HIPKernelProvider,
+                                        get_grid_for_block)
 
 
 class HIPBlasExtKernels(HIPKernelProvider):
@@ -32,7 +32,7 @@ class HIPBlasExtKernels(HIPKernelProvider):
         params = kern.make_params(grid, block)
         params.set_args(nrow, ncolb, ldim, *arr)
 
-        class AxnpbyKernel(Kernel):
+        class AxnpbyKernel(HIPKernel):
             def bind(self, *consts):
                 params.set_args(*consts, start=3 + nv)
 
@@ -47,11 +47,14 @@ class HIPBlasExtKernels(HIPKernelProvider):
         if dst.traits != src.traits:
             raise ValueError('Incompatible matrix types')
 
-        class CopyKernel(Kernel):
+        class CopyKernel(HIPKernel):
+            def add_to_graph(self, graph, deps):
+                return graph.graph.add_memcpy(dst, src, dst.nbytes, deps)
+
             def run(self, stream):
                 hip.memcpy(dst, src, dst.nbytes, stream)
 
-        return CopyKernel()
+        return CopyKernel(mats=[dst, src])
 
     def reduction(self, *rs, method, norm, dt_mat=None):
         if any(r.traits != rs[0].traits for r in rs[1:]):
@@ -104,7 +107,7 @@ class HIPBlasExtKernels(HIPKernelProvider):
         # Norm type
         reducer = np.max if norm == 'uniform' else np.sum
 
-        class ReductionKernel(Kernel):
+        class ReductionKernel(HIPKernel):
             @property
             def retval(self):
                 return reducer(reduced_host, axis=1)

--- a/pyfr/backends/hip/blasext.py
+++ b/pyfr/backends/hip/blasext.py
@@ -33,9 +33,11 @@ class HIPBlasExtKernels(HIPKernelProvider):
         params.set_args(nrow, ncolb, ldim, *arr)
 
         class AxnpbyKernel(Kernel):
-            def run(self, queue, *consts):
+            def bind(self, *consts):
                 params.set_args(*consts, start=3 + nv)
-                kern.exec_async(queue.stream, params)
+
+            def run(self, stream):
+                kern.exec_async(stream, params)
 
         return AxnpbyKernel(mats=arr)
 
@@ -46,8 +48,8 @@ class HIPBlasExtKernels(HIPKernelProvider):
             raise ValueError('Incompatible matrix types')
 
         class CopyKernel(Kernel):
-            def run(self, queue):
-                hip.memcpy(dst, src, dst.nbytes, queue.stream)
+            def run(self, stream):
+                hip.memcpy(dst, src, dst.nbytes, stream)
 
         return CopyKernel()
 
@@ -107,10 +109,12 @@ class HIPBlasExtKernels(HIPKernelProvider):
             def retval(self):
                 return reducer(reduced_host, axis=1)
 
-            def run(self, queue, *facs):
+            def bind(self, *facs):
                 params.set_args(*facs, start=facoff)
-                rkern.exec_async(queue.stream, params)
+
+            def run(self, stream):
+                rkern.exec_async(stream, params)
                 hip.memcpy(reduced_host, reduced_dev, reduced_dev.nbytes,
-                           queue.stream)
+                           stream)
 
         return ReductionKernel(mats=regs)

--- a/pyfr/backends/hip/blasext.py
+++ b/pyfr/backends/hip/blasext.py
@@ -49,7 +49,7 @@ class HIPBlasExtKernels(HIPKernelProvider):
 
         class CopyKernel(HIPKernel):
             def add_to_graph(self, graph, deps):
-                return graph.graph.add_memcpy(dst, src, dst.nbytes, deps)
+                pass
 
             def run(self, stream):
                 hip.memcpy(dst, src, dst.nbytes, stream)

--- a/pyfr/backends/hip/driver.py
+++ b/pyfr/backends/hip/driver.py
@@ -276,7 +276,7 @@ class HIPEvent(_HIPBase):
 
         super().__init__(hip, ptr)
 
-    def wait(self):
+    def synchronize(self):
         self.hip.lib.hipEventSynchronize(self)
 
 

--- a/pyfr/backends/hip/driver.py
+++ b/pyfr/backends/hip/driver.py
@@ -176,6 +176,7 @@ class HIPWrappers(LibWrapper):
         (c_int, 'hipStreamEndCapture', c_void_p, POINTER(c_void_p)),
         (c_int, 'hipStreamSynchronize', c_void_p),
         (c_int, 'hipEventCreate', POINTER(c_void_p)),
+        (c_int, 'hipEventRecord', c_void_p, c_void_p),
         (c_int, 'hipEventDestroy', c_void_p),
         (c_int, 'hipEventSynchronize', c_void_p),
         (c_int, 'hipModuleLoadData', POINTER(c_void_p), c_char_p),
@@ -275,6 +276,9 @@ class HIPEvent(_HIPBase):
         hip.lib.hipEventCreate(ptr)
 
         super().__init__(hip, ptr)
+
+    def record(self, stream):
+        self.hip.lib.hipEventRecord(self, stream)
 
     def synchronize(self):
         self.hip.lib.hipEventSynchronize(self)

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -44,7 +44,7 @@ class HIPGiMMiKKernels(HIPKernelProvider):
         params.set_args(b, out)
 
         class MulKernel(Kernel):
-            def run(self, queue):
-                fun.exec_async(queue.stream, params)
+            def run(self, stream):
+                fun.exec_async(stream, params)
 
         return MulKernel(mats=[b, out])

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -46,7 +46,7 @@ class HIPGiMMiKKernels(HIPKernelProvider):
 
         class MulKernel(HIPKernel):
             def add_to_graph(self, graph, deps):
-                return graph.graph.add_kernel(params, deps)
+                pass
 
             def run(self, stream):
                 fun.exec_async(stream, params)

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -37,10 +37,14 @@ class HIPGiMMiKKernels(HIPKernelProvider):
                           n=b.ncol, ldb=b.leaddim, ldc=out.leaddim)
 
         # Build
-        fun = self._build_kernel('gimmik_mm', src, [np.intp, np.intp])
+        fun = self._build_kernel('gimmik_mm', src, 'PP')
+
+        # Set the parameters
+        params = fun.make_params(grid, block)
+        params.set_args(b, out)
 
         class MulKernel(Kernel):
             def run(self, queue):
-                fun.exec_async(grid, block, queue.stream, b, out)
+                fun.exec_async(queue.stream, params)
 
-        return MulKernel()
+        return MulKernel(mats=[b, out])

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -3,8 +3,9 @@
 from gimmik import generate_mm
 import numpy as np
 
-from pyfr.backends.base import Kernel, NotSuitableError
-from pyfr.backends.hip.provider import HIPKernelProvider, get_grid_for_block
+from pyfr.backends.base import NotSuitableError
+from pyfr.backends.hip.provider import (HIPKernel, HIPKernelProvider,
+                                        get_grid_for_block)
 
 
 class HIPGiMMiKKernels(HIPKernelProvider):
@@ -43,7 +44,10 @@ class HIPGiMMiKKernels(HIPKernelProvider):
         params = fun.make_params(grid, block)
         params.set_args(b, out)
 
-        class MulKernel(Kernel):
+        class MulKernel(HIPKernel):
+            def add_to_graph(self, graph, deps):
+                return graph.graph.add_kernel(params, deps)
+
             def run(self, stream):
                 fun.exec_async(stream, params)
 

--- a/pyfr/backends/hip/packing.py
+++ b/pyfr/backends/hip/packing.py
@@ -29,14 +29,14 @@ class HIPPackingKernels(HIPKernelProvider):
         # If MPI is HIP aware then we just need to pack the buffer
         if self.backend.mpitype == 'hip-aware':
             class PackXchgViewKernel(Kernel):
-                def run(self, queue):
-                    kern.exec_async(queue.stream, params)
+                def run(self, stream):
+                    kern.exec_async(stream, params)
         # Otherwise, we need to both pack the buffer and copy it back
         else:
             class PackXchgViewKernel(Kernel):
-                def run(self, queue):
-                    kern.exec_async(queue.stream, params)
-                    hip.memcpy(m.hdata, m.data, m.nbytes, queue.stream)
+                def run(self, stream):
+                    kern.exec_async(stream, params)
+                    hip.memcpy(m.hdata, m.data, m.nbytes, stream)
 
         return PackXchgViewKernel(mats=[mv])
 
@@ -47,7 +47,7 @@ class HIPPackingKernels(HIPKernelProvider):
             return NullKernel()
         else:
             class UnpackXchgMatrixKernel(Kernel):
-                def run(self, queue):
-                    hip.memcpy(mv.data, mv.hdata, mv.nbytes, queue.stream)
+                def run(self, stream):
+                    hip.memcpy(mv.data, mv.hdata, mv.nbytes, stream)
 
             return UnpackXchgMatrixKernel()

--- a/pyfr/backends/hip/packing.py
+++ b/pyfr/backends/hip/packing.py
@@ -31,7 +31,7 @@ class HIPPackingKernels(HIPKernelProvider):
         if self.backend.mpitype == 'hip-aware':
             class PackXchgViewKernel(HIPKernel):
                 def add_to_graph(self, graph, deps):
-                    return graph.graph.add_kernel(params, deps)
+                    pass
 
                 def run(self, stream):
                     kern.exec_async(stream, params)
@@ -39,10 +39,7 @@ class HIPPackingKernels(HIPKernelProvider):
         else:
             class PackXchgViewKernel(HIPKernel):
                 def add_to_graph(self, graph, deps):
-                    gpack = graph.graph.add_kernel(params, deps)
-                    return graph.graph.add_memcpy(
-                        m.hdata, m.data, m.nbytes, [gpack]
-                    )
+                    pass
 
                 def run(self, stream):
                     kern.exec_async(stream, params)
@@ -58,8 +55,7 @@ class HIPPackingKernels(HIPKernelProvider):
         else:
             class UnpackXchgMatrixKernel(HIPKernel):
                 def add_to_graph(self, graph, deps):
-                    return graph.graph.add_memcpy(mv.data, mv.hdata, mv.nbytes,
-                                                  deps)
+                    pass
 
                 def run(self, stream):
                     hip.memcpy(mv.data, mv.hdata, mv.nbytes, stream)

--- a/pyfr/backends/hip/packing.py
+++ b/pyfr/backends/hip/packing.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from pyfr.backends.base import Kernel, NullKernel
-from pyfr.backends.hip.provider import HIPKernelProvider, get_grid_for_block
+from pyfr.backends.base import NullKernel
+from pyfr.backends.hip.provider import (HIPKernel, HIPKernelProvider,
+                                        get_grid_for_block)
 
 
 class HIPPackingKernels(HIPKernelProvider):
@@ -28,12 +29,21 @@ class HIPPackingKernels(HIPKernelProvider):
 
         # If MPI is HIP aware then we just need to pack the buffer
         if self.backend.mpitype == 'hip-aware':
-            class PackXchgViewKernel(Kernel):
+            class PackXchgViewKernel(HIPKernel):
+                def add_to_graph(self, graph, deps):
+                    return graph.graph.add_kernel(params, deps)
+
                 def run(self, stream):
                     kern.exec_async(stream, params)
         # Otherwise, we need to both pack the buffer and copy it back
         else:
-            class PackXchgViewKernel(Kernel):
+            class PackXchgViewKernel(HIPKernel):
+                def add_to_graph(self, graph, deps):
+                    gpack = graph.graph.add_kernel(params, deps)
+                    return graph.graph.add_memcpy(
+                        m.hdata, m.data, m.nbytes, [gpack]
+                    )
+
                 def run(self, stream):
                     kern.exec_async(stream, params)
                     hip.memcpy(m.hdata, m.data, m.nbytes, stream)
@@ -46,8 +56,12 @@ class HIPPackingKernels(HIPKernelProvider):
         if self.backend.mpitype == 'hip-aware':
             return NullKernel()
         else:
-            class UnpackXchgMatrixKernel(Kernel):
+            class UnpackXchgMatrixKernel(HIPKernel):
+                def add_to_graph(self, graph, deps):
+                    return graph.graph.add_memcpy(mv.data, mv.hdata, mv.nbytes,
+                                                  deps)
+
                 def run(self, stream):
                     hip.memcpy(mv.data, mv.hdata, mv.nbytes, stream)
 
-            return UnpackXchgMatrixKernel()
+            return UnpackXchgMatrixKernel(mats=[mv])

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from weakref import WeakKeyDictionary
+
 from pyfr.backends.base import (BaseKernelProvider,
-                                BasePointwiseKernelProvider, Kernel)
+                                BasePointwiseKernelProvider, Kernel,
+                                MetaKernel)
 from pyfr.backends.hip.compiler import SourceModule
 from pyfr.backends.hip.generator import HIPKernelGenerator
 from pyfr.util import memoize
@@ -9,6 +12,29 @@ from pyfr.util import memoize
 
 def get_grid_for_block(block, nrow, ncol=1):
     return (-(-nrow // block[0]), -(-ncol // block[1]), 1)
+
+
+class HIPKernel(Kernel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if hasattr(self, 'bind') and hasattr(self, 'add_to_graph'):
+            self.gnodes = WeakKeyDictionary()
+
+
+class HIPOrderedMetaKernel(MetaKernel):
+    def add_to_graph(self, graph, dnodes):
+        for k in self.kernels:
+            dnodes = [k.add_to_graph(graph, dnodes)]
+
+        return dnodes[0]
+
+
+class HIPUnorderedMetaKernel(MetaKernel):
+    def add_to_graph(self, graph, dnodes):
+        nodes = [k.add_to_graph(graph, dnodes) for k in self.kernels]
+
+        return graph.graph.add_empty(nodes)
 
 
 class HIPKernelProvider(BaseKernelProvider):
@@ -46,11 +72,25 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
             else:
                 params.set_arg(i, k)
 
-        class PointwiseKernel(Kernel):
+        class PointwiseKernel(HIPKernel):
             if rtargs:
                 def bind(self, **kwargs):
                     for i, k in rtargs:
                         params.set_arg(i, kwargs[k])
+
+                    # Notify any graphs we're in about our new parameters
+                    for graph, gnode in self.gnodes.items():
+                        graph.stale_kparams[gnode] = params
+
+            def add_to_graph(self, graph, deps):
+                gnode = graph.graph.add_kernel(params, deps)
+
+                # If our parameters can change then we need to keep a
+                # (weak) reference to the graph so we can notify it
+                if rtargs:
+                    self.gnodes[graph] = gnode
+
+                return gnode
 
             def run(self, stream):
                 fun.exec_async(stream, params)

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -24,17 +24,12 @@ class HIPKernel(Kernel):
 
 class HIPOrderedMetaKernel(MetaKernel):
     def add_to_graph(self, graph, dnodes):
-        for k in self.kernels:
-            dnodes = [k.add_to_graph(graph, dnodes)]
-
-        return dnodes[0]
+        pass
 
 
 class HIPUnorderedMetaKernel(MetaKernel):
     def add_to_graph(self, graph, dnodes):
-        nodes = [k.add_to_graph(graph, dnodes) for k in self.kernels]
-
-        return graph.graph.add_empty(nodes)
+        pass
 
 
 class HIPKernelProvider(BaseKernelProvider):
@@ -78,19 +73,8 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
                     for i, k in rtargs:
                         params.set_arg(i, kwargs[k])
 
-                    # Notify any graphs we're in about our new parameters
-                    for graph, gnode in self.gnodes.items():
-                        graph.stale_kparams[gnode] = params
-
             def add_to_graph(self, graph, deps):
-                gnode = graph.graph.add_kernel(params, deps)
-
-                # If our parameters can change then we need to keep a
-                # (weak) reference to the graph so we can notify it
-                if rtargs:
-                    self.gnodes[graph] = gnode
-
-                return gnode
+                pass
 
             def run(self, stream):
                 fun.exec_async(stream, params)

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -47,10 +47,12 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
                 params.set_arg(i, k)
 
         class PointwiseKernel(Kernel):
-            def run(self, queue, **kwargs):
-                for i, k in rtargs:
-                    params.set_arg(i, kwargs[k])
+            if rtargs:
+                def bind(self, **kwargs):
+                    for i, k in rtargs:
+                        params.set_arg(i, kwargs[k])
 
-                fun.exec_async(queue.stream, params)
+            def run(self, stream):
+                fun.exec_async(stream, params)
 
         return PointwiseKernel(*argmv)

--- a/pyfr/backends/hip/rocblas.py
+++ b/pyfr/backends/hip/rocblas.py
@@ -89,8 +89,8 @@ class HIPRocBLASKernels:
             alpha_ct, beta_ct = c_float(alpha), c_float(beta)
 
         class MulKernel(Kernel):
-            def run(self, queue):
-                w.rocblas_set_stream(h, queue.stream)
+            def run(self, stream):
+                w.rocblas_set_stream(h, stream)
                 rocblas_gemm(h, opA, opB, m, n, k,
                              alpha_ct, A, A.leaddim, B, B.leaddim,
                              beta_ct, C, C.leaddim)

--- a/pyfr/backends/hip/rocblas.py
+++ b/pyfr/backends/hip/rocblas.py
@@ -64,7 +64,6 @@ class HIPRocBLASKernels:
             pass
 
     def mul(self, a, b, out, alpha=1.0, beta=0.0):
-        hip = self.backend.hip
         h, w = self._handle, self._wrappers
 
         # Ensure the matrices are compatible
@@ -91,15 +90,7 @@ class HIPRocBLASKernels:
 
         class MulKernel(HIPKernel):
             def add_to_graph(self, graph, deps):
-                stream = hip.create_stream()
-
-                # Capture the execution of rocBLAS to obtain a graph
-                stream.begin_capture()
-                self.run(stream)
-                gnode = stream.end_capture()
-
-                # Embed this graph in our main graph
-                return graph.graph.add_graph(gnode, deps)
+                pass
 
             def run(self, stream):
                 w.rocblas_set_stream(h, stream)

--- a/pyfr/backends/hip/types.py
+++ b/pyfr/backends/hip/types.py
@@ -87,6 +87,14 @@ class HIPXchgView(base.XchgView):
     pass
 
 
+class HIPOrderedMetaKernel(base.MetaKernel):
+    pass
+
+
+class HIPUnorderedMetaKernel(base.MetaKernel):
+    pass
+
+
 class HIPQueue(base.Queue):
     def __init__(self, backend):
         super().__init__(backend)

--- a/pyfr/backends/hip/types.py
+++ b/pyfr/backends/hip/types.py
@@ -93,28 +93,3 @@ class HIPOrderedMetaKernel(base.MetaKernel):
 
 class HIPUnorderedMetaKernel(base.MetaKernel):
     pass
-
-
-class HIPQueue(base.Queue):
-    def __init__(self, backend):
-        super().__init__(backend)
-
-        # HIP stream
-        self.stream = backend.hip.create_stream()
-
-    def run(self, mpireqs=[]):
-        # Start any MPI requests
-        if mpireqs:
-            self._startall(mpireqs)
-
-        # Submit the kernels to the HIP stream
-        for item, args, kwargs in self._items:
-            item.run(self, *args, **kwargs)
-
-        # If we started any MPI requests, wait for them
-        if mpireqs:
-            self._waitall(mpireqs)
-
-        # Wait for the kernels to finish and clear the queue
-        self.stream.synchronize()
-        self._items.clear()

--- a/pyfr/backends/hip/types.py
+++ b/pyfr/backends/hip/types.py
@@ -83,6 +83,16 @@ class HIPGraph(base.Graph):
 
         self.graph = backend.hip.create_graph()
         self.stale_kparams = {}
+        self.mpi_events = []
+
+    def add_mpi_req(self, req, deps=[]):
+        super().add_mpi_req(req, deps)
+
+        if deps:
+            event = self.backend.hip.create_event()
+            self.graph.add_event_record(event, [self.knodes[d] for d in deps])
+
+            self.mpi_events.append((event, req))
 
     def commit(self):
         super().commit()
@@ -90,8 +100,27 @@ class HIPGraph(base.Graph):
         self.exc_graph = self.graph.instantiate()
 
     def run(self, stream):
+        from mpi4py import MPI
+
+        # Ensure our kernel parameters are up to date
         for node, params in self.stale_kparams.items():
             self.exc_graph.set_kernel_node_params(node, params)
 
         self.exc_graph.launch(stream)
         self.stale_kparams.clear()
+
+        # Start all dependency-free MPI requests
+        if self.mpi_root_reqs:
+            MPI.Prequest.Startall(self.mpi_root_reqs)
+
+        # Start any remaining requests once their dependencies are satisfied
+        for event, req in self.mpi_events:
+            event.synchronize()
+            req.Start()
+
+        # Wait for all of the MPI requests to finish
+        if self.mpi_reqs:
+            MPI.Prequest.Waitall(self.mpi_reqs)
+
+        # Wait for all of the kernels to finish
+        stream.synchronize()

--- a/pyfr/backends/hip/types.py
+++ b/pyfr/backends/hip/types.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from collections import defaultdict
 from functools import cached_property
 
 import numpy as np
@@ -78,44 +79,49 @@ class HIPXchgMatrix(HIPMatrix, base.XchgMatrix):
 
 
 class HIPGraph(base.Graph):
-    def __init__(self, backend):
-        super().__init__(backend)
-
-        self.graph = backend.hip.create_graph()
-        self.stale_kparams = {}
-        self.mpi_events = []
-
-    def add_mpi_req(self, req, deps=[]):
-        super().add_mpi_req(req, deps)
-
-        if deps:
-            event = self.backend.hip.create_event()
-            self.graph.add_event_record(event, [self.knodes[d] for d in deps])
-
-            self.mpi_events.append((event, req))
-
     def commit(self):
         super().commit()
 
-        self.exc_graph = self.graph.instantiate()
+        # Schedule the MPI requests in the stream
+        mpi_events = defaultdict(list)
+        for req, deps in zip(self.mpi_reqs, self.mpi_req_deps):
+            ix = -1
+            for d in deps:
+                for i, k in enumerate(self.knodes):
+                    if k == d:
+                        ix = max(ix, i)
+                        break
+
+            if ix != -1:
+                mpi_events[ix].append(req)
+
+        self.mpi_events = {ix: (self.backend.hip.create_event(), reqs)
+                           for ix, reqs in mpi_events.items()}
+
+        # Schedule the kernels
+        self.klist = []
+        for i, k in enumerate(self.knodes):
+            event = self.mpi_events.get(i, (None, None))[0]
+
+            self.klist.append((k, event))
 
     def run(self, stream):
         from mpi4py import MPI
 
-        # Ensure our kernel parameters are up to date
-        for node, params in self.stale_kparams.items():
-            self.exc_graph.set_kernel_node_params(node, params)
+        # Submit the kernels to the stream
+        for k, event in self.klist:
+            k.run(stream)
 
-        self.exc_graph.launch(stream)
-        self.stale_kparams.clear()
+            if event:
+                event.record(stream)
 
         # Start all dependency-free MPI requests
         MPI.Prequest.Startall(self.mpi_root_reqs)
 
         # Start any remaining requests once their dependencies are satisfied
-        for event, req in self.mpi_events:
+        for event, reqs in self.mpi_events.values():
             event.synchronize()
-            req.Start()
+            MPI.Prequest.Startall(reqs)
 
         # Wait for all of the MPI requests to finish
         MPI.Prequest.Waitall(self.mpi_reqs)

--- a/pyfr/backends/hip/types.py
+++ b/pyfr/backends/hip/types.py
@@ -110,8 +110,7 @@ class HIPGraph(base.Graph):
         self.stale_kparams.clear()
 
         # Start all dependency-free MPI requests
-        if self.mpi_root_reqs:
-            MPI.Prequest.Startall(self.mpi_root_reqs)
+        MPI.Prequest.Startall(self.mpi_root_reqs)
 
         # Start any remaining requests once their dependencies are satisfied
         for event, req in self.mpi_events:
@@ -119,8 +118,4 @@ class HIPGraph(base.Graph):
             req.Start()
 
         # Wait for all of the MPI requests to finish
-        if self.mpi_reqs:
-            MPI.Prequest.Waitall(self.mpi_reqs)
-
-        # Wait for all of the kernels to finish
-        stream.synchronize()
+        MPI.Prequest.Waitall(self.mpi_reqs)

--- a/pyfr/backends/opencl/base.py
+++ b/pyfr/backends/opencl/base.py
@@ -67,6 +67,8 @@ class OpenCLBackend(BaseBackend):
         self.view_cls = types.OpenCLView
         self.xchg_matrix_cls = types.OpenCLXchgMatrix
         self.xchg_view_cls = types.OpenCLXchgView
+        self.ordered_meta_kernel_cls = types.OpenCLOrderedMetaKernel
+        self.unordered_meta_kernel_cls = types.OpenCLUnorderedMetaKernel
 
         # Instantiate the base kernel providers
         kprovs = [provider.OpenCLPointwiseKernelProvider,

--- a/pyfr/backends/opencl/blasext.py
+++ b/pyfr/backends/opencl/blasext.py
@@ -42,8 +42,8 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
 
         class CopyKernel(OpenCLKernel):
             def run(self, queue, wait_for=None, ret_evt=False):
-                return cl.memcpy_async(queue, dst, src, dst.nbytes, wait_for,
-                                       ret_evt)
+                return cl.memcpy(queue, dst, src, dst.nbytes, blocking=False,
+                                 wait_for=wait_for, ret_evt=ret_evt)
 
         return CopyKernel(mats=[dst, src])
 
@@ -104,7 +104,7 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
 
             def run(self, queue, wait_for=None, ret_evt=False):
                 revt = rkern.exec_async(queue, wait_for, True)
-                return cl.memcpy_async(queue, reduced_host, reduced_dev,
-                                       reduced_dev.nbytes, [revt], ret_evt)
+                return cl.memcpy(queue, reduced_host, reduced_dev,
+                                 reduced_dev.nbytes, False, [revt], ret_evt)
 
         return ReductionKernel(mats=regs)

--- a/pyfr/backends/opencl/blasext.py
+++ b/pyfr/backends/opencl/blasext.py
@@ -2,8 +2,7 @@
 
 import numpy as np
 
-from pyfr.backends.opencl.provider import OpenCLKernelProvider
-from pyfr.backends.base import Kernel
+from pyfr.backends.opencl.provider import OpenCLKernel, OpenCLKernelProvider
 
 
 class OpenCLBlasExtKernels(OpenCLKernelProvider):
@@ -23,14 +22,15 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
         # Build the kernel
         kern = self._build_kernel('axnpby', src,
                                   [np.int32]*3 + [np.intp]*nv + [dtype]*nv)
+        kern.set_dims((ncolb, nrow))
         kern.set_args(nrow, ncolb, ldim, *arr)
 
-        class AxnpbyKernel(Kernel):
+        class AxnpbyKernel(OpenCLKernel):
             def bind(self, *consts):
                 kern.set_args(*consts, start=3 + nv)
 
-            def run(self, queue):
-                kern.exec_async(queue, (ncolb, nrow), None)
+            def run(self, queue, wait_for=None, ret_evt=False):
+                return kern.exec_async(queue, wait_for, ret_evt)
 
         return AxnpbyKernel(mats=arr)
 
@@ -40,11 +40,12 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
         if dst.traits != src.traits:
             raise ValueError('Incompatible matrix types')
 
-        class CopyKernel(Kernel):
-            def run(self, queue):
-                cl.memcpy_async(queue, dst, src, dst.nbytes)
+        class CopyKernel(OpenCLKernel):
+            def run(self, queue, wait_for=None, ret_evt=False):
+                return cl.memcpy_async(queue, dst, src, dst.nbytes, wait_for,
+                                       ret_evt)
 
-        return CopyKernel()
+        return CopyKernel(mats=[dst, src])
 
     def reduction(self, *rs, method, norm, dt_mat=None):
         if any(r.traits != rs[0].traits for r in rs[1:]):
@@ -84,6 +85,7 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
 
         # Build the reduction kernel
         rkern = self._build_kernel('reduction', src, argt)
+        rkern.set_dims(gs, ls)
         rkern.set_args(nrow, ncolb, ldim, reduced_dev, *regs)
 
         # Norm type
@@ -92,7 +94,7 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
         # Runtime argument offset
         facoff = argt.index(dtype)
 
-        class ReductionKernel(Kernel):
+        class ReductionKernel(OpenCLKernel):
             @property
             def retval(self):
                 return reducer(reduced_host, axis=1)
@@ -100,9 +102,9 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
             def bind(self, *facs):
                 rkern.set_args(*facs, start=facoff)
 
-            def run(self, queue):
-                rkern.exec_async(queue, gs, ls)
-                cl.memcpy_async(queue, reduced_host, reduced_dev,
-                                reduced_dev.nbytes)
+            def run(self, queue, wait_for=None, ret_evt=False):
+                revt = rkern.exec_async(queue, wait_for, True)
+                return cl.memcpy_async(queue, reduced_host, reduced_dev,
+                                       reduced_dev.nbytes, [revt], ret_evt)
 
         return ReductionKernel(mats=regs)

--- a/pyfr/backends/opencl/clblast.py
+++ b/pyfr/backends/opencl/clblast.py
@@ -4,7 +4,7 @@ from ctypes import POINTER, c_int, c_double, c_float, c_size_t, c_void_p
 
 import numpy as np
 
-from pyfr.backends.base import Kernel
+from pyfr.backends.opencl.provider import OpenCLKernel
 from pyfr.ctypesutil import LibWrapper
 
 
@@ -31,21 +31,22 @@ class CLBlastWrappers(LibWrapper):
         (c_int, 'CLBlastDgemm', c_int, c_int, c_int, c_size_t, c_size_t,
          c_size_t, c_double, c_void_p, c_size_t, c_size_t, c_void_p, c_size_t,
          c_size_t, c_double, c_void_p, c_size_t, c_size_t, POINTER(c_void_p),
-         c_void_p),
+         POINTER(c_void_p)),
         (c_int, 'CLBlastSgemm', c_int, c_int, c_int, c_size_t, c_size_t,
          c_size_t, c_float, c_void_p, c_size_t, c_size_t, c_void_p, c_size_t,
          c_size_t, c_float, c_void_p, c_size_t, c_size_t, POINTER(c_void_p),
-         c_void_p)
+         POINTER(c_void_p))
     ]
 
 
 class OpenCLCLBlastKernels:
     def __init__(self, backend):
-        # Load and wrap CLBlast
+        self.backend = backend
         self._wrappers = CLBlastWrappers()
 
     def mul(self, a, b, out, alpha=1.0, beta=0.0):
         w = self._wrappers
+        cl = self.backend.cl
 
         # Ensure the matrices are compatible
         if a.nrow != out.nrow or a.ncol != b.nrow or b.ncol != out.ncol:
@@ -58,11 +59,21 @@ class OpenCLCLBlastKernels:
         else:
             clblastgemm = w.CLBlastSgemm
 
-        class MulKernel(Kernel):
-            def run(self, queue):
+        class MulKernel(OpenCLKernel):
+            def run(self, queue, wait_for=None, ret_evt=False):
+                evt_ptr = c_void_p() if ret_evt else None
+
+                # CLBlast does not support waiting for events so we
+                # instead insert a barrier into the queue
+                if wait_for:
+                    queue.barrier(wait_for)
+
                 qptr = c_void_p(int(queue))
                 clblastgemm(w.LayoutRowMajor, w.TransposeNo, w.TransposeNo,
                             m, n, k, alpha, a, 0, a.leaddim, b, 0, b.leaddim,
-                            beta, out, 0, out.leaddim, qptr, None)
+                            beta, out, 0, out.leaddim, qptr, evt_ptr)
 
-        return MulKernel()
+                if ret_evt:
+                    return cl.event(evt_ptr)
+
+        return MulKernel(mats=[a, b, out])

--- a/pyfr/backends/opencl/clblast.py
+++ b/pyfr/backends/opencl/clblast.py
@@ -60,7 +60,7 @@ class OpenCLCLBlastKernels:
 
         class MulKernel(Kernel):
             def run(self, queue):
-                qptr = c_void_p(int(queue.cmd_q))
+                qptr = c_void_p(int(queue))
                 clblastgemm(w.LayoutRowMajor, w.TransposeNo, w.TransposeNo,
                             m, n, k, alpha, a, 0, a.leaddim, b, 0, b.leaddim,
                             beta, out, 0, out.leaddim, qptr, None)

--- a/pyfr/backends/opencl/gimmik.py
+++ b/pyfr/backends/opencl/gimmik.py
@@ -37,6 +37,6 @@ class OpenCLGiMMiKKernels(OpenCLKernelProvider):
 
         class MulKernel(Kernel):
             def run(self, queue):
-                fun.exec_async(queue.cmd_q, (b.ncol,), None)
+                fun.exec_async(queue, (b.ncol,), None)
 
         return MulKernel(mats=[b, out])

--- a/pyfr/backends/opencl/gimmik.py
+++ b/pyfr/backends/opencl/gimmik.py
@@ -3,8 +3,8 @@
 from gimmik import generate_mm
 import numpy as np
 
-from pyfr.backends.base import Kernel, NotSuitableError
-from pyfr.backends.opencl.provider import OpenCLKernelProvider
+from pyfr.backends.base import NotSuitableError
+from pyfr.backends.opencl.provider import OpenCLKernel, OpenCLKernelProvider
 
 
 class OpenCLGiMMiKKernels(OpenCLKernelProvider):
@@ -32,11 +32,12 @@ class OpenCLGiMMiKKernels(OpenCLKernelProvider):
                           n=b.ncol, ldb=b.leaddim, ldc=out.leaddim)
 
         # Build
-        fun = self._build_kernel('gimmik_mm', src, [np.intp, np.intp])
+        fun = self._build_kernel('gimmik_mm', src, 'PP')
+        fun.set_dims((b.ncol,))
         fun.set_args(b, out)
 
-        class MulKernel(Kernel):
-            def run(self, queue):
-                fun.exec_async(queue, (b.ncol,), None)
+        class MulKernel(OpenCLKernel):
+            def run(self, queue, wait_for=None, ret_evt=False):
+                return fun.exec_async(queue, wait_for, ret_evt)
 
         return MulKernel(mats=[b, out])

--- a/pyfr/backends/opencl/packing.py
+++ b/pyfr/backends/opencl/packing.py
@@ -24,10 +24,10 @@ class OpenCLPackingKernels(OpenCLKernelProvider):
         class PackXchgViewKernel(Kernel):
             def run(self, queue):
                 # Pack
-                kern.exec_async(queue.cmd_q, (v.n,), None)
+                kern.exec_async(queue, (v.n,), None)
 
                 # Copy the packed buffer to the host
-                cl.memcpy_async(queue.cmd_q, m.hdata, m.data, m.nbytes)
+                cl.memcpy_async(queue, m.hdata, m.data, m.nbytes)
 
         return PackXchgViewKernel(mats=[mv])
 
@@ -36,6 +36,6 @@ class OpenCLPackingKernels(OpenCLKernelProvider):
 
         class UnpackXchgMatrixKernel(Kernel):
             def run(self, queue):
-                cl.memcpy_async(queue.cmd_q, mv.data, mv.hdata, mv.nbytes)
+                cl.memcpy_async(queue, mv.data, mv.hdata, mv.nbytes)
 
         return UnpackXchgMatrixKernel(mats=[mv])

--- a/pyfr/backends/opencl/packing.py
+++ b/pyfr/backends/opencl/packing.py
@@ -2,8 +2,7 @@
 
 import numpy as np
 
-from pyfr.backends.base import Kernel
-from pyfr.backends.opencl.provider import OpenCLKernelProvider
+from pyfr.backends.opencl.provider import OpenCLKernel, OpenCLKernelProvider
 
 
 class OpenCLPackingKernels(OpenCLKernelProvider):
@@ -18,24 +17,24 @@ class OpenCLPackingKernels(OpenCLKernelProvider):
 
         # Build
         kern = self._build_kernel('pack_view', src, [np.int32]*3 + [np.intp]*4)
+        kern.set_dims((v.n,))
         kern.set_args(v.n, v.nvrow, v.nvcol, v.basedata, v.mapping,
                       v.rstrides or 0, m)
 
-        class PackXchgViewKernel(Kernel):
-            def run(self, queue):
-                # Pack
-                kern.exec_async(queue, (v.n,), None)
-
-                # Copy the packed buffer to the host
-                cl.memcpy_async(queue, m.hdata, m.data, m.nbytes)
+        class PackXchgViewKernel(OpenCLKernel):
+            def run(self, queue, wait_for=None, ret_evt=False):
+                pevt = kern.exec_async(queue, wait_for, True)
+                return cl.memcpy_async(queue, m.hdata, m.data, m.nbytes,
+                                       [pevt], ret_evt)
 
         return PackXchgViewKernel(mats=[mv])
 
     def unpack(self, mv):
         cl = self.backend.cl
 
-        class UnpackXchgMatrixKernel(Kernel):
-            def run(self, queue):
-                cl.memcpy_async(queue, mv.data, mv.hdata, mv.nbytes)
+        class UnpackXchgMatrixKernel(OpenCLKernel):
+            def run(self, queue, wait_for=None, ret_evt=False):
+                return cl.memcpy_async(queue, mv.data, mv.hdata, mv.nbytes,
+                                       wait_for, ret_evt)
 
         return UnpackXchgMatrixKernel(mats=[mv])

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -13,7 +13,7 @@ class OpenCLKernel(Kernel):
         pass
 
 
-class _OpenCLMetaKernelCommon(object):
+class _OpenCLMetaKernelCommon:
     def add_to_graph(self, graph, deps):
         pass
 

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -1,10 +1,39 @@
 # -*- coding: utf-8 -*-
 
 from pyfr.backends.base import (BaseKernelProvider,
-                                BasePointwiseKernelProvider, Kernel)
+                                BasePointwiseKernelProvider, Kernel,
+                                MetaKernel)
 from pyfr.backends.opencl.generator import OpenCLKernelGenerator
 from pyfr.nputil import npdtype_to_ctypestype
 from pyfr.util import memoize
+
+
+class OpenCLKernel(Kernel):
+    def add_to_graph(self, graph, deps):
+        pass
+
+
+class _OpenCLMetaKernelCommon(object):
+    def add_to_graph(self, graph, deps):
+        pass
+
+
+class OpenCLOrderedMetaKernel(_OpenCLMetaKernelCommon, MetaKernel):
+    def run(self, queue, wait_for=None, ret_evt=False):
+        for k in self.kernels[:-1]:
+            wait_for = [k.run(queue, wait_for, True)]
+
+        return self.kernels[-1].run(queue, wait_for, ret_evt)
+
+
+class OpenCLUnorderedMetaKernel(_OpenCLMetaKernelCommon, MetaKernel):
+    def run(self, queue, wait_for=None, ret_evt=False):
+        if ret_evt:
+            kevts = [k.run(queue, wait_for, True) for k in self.kernels]
+            return queue.marker(kevts)
+        else:
+            for k in self.kernels:
+                k.run(queue, wait_for, False)
 
 
 class OpenCLKernelProvider(BaseKernelProvider):
@@ -35,6 +64,8 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
             ls = (64, 4)
             gs = (dims[1] - dims[1] % -ls[0], ls[1])
 
+        fun.set_dims(gs, ls)
+
         # Process the arguments
         for i, k in enumerate(arglst):
             if isinstance(k, str):
@@ -42,13 +73,13 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
             else:
                 fun.set_arg(i, k)
 
-        class PointwiseKernel(Kernel):
+        class PointwiseKernel(OpenCLKernel):
             if rtargs:
                 def bind(self, **kwargs):
                     for i, k in rtargs:
                         fun.set_arg(i, kwargs[k])
 
-            def run(self, queue):
-                fun.exec_async(queue, gs, ls)
+            def run(self, queue, wait_for=None, ret_evt=False):
+                return fun.exec_async(queue, wait_for, ret_evt)
 
         return PointwiseKernel(*argmv)

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -43,10 +43,12 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
                 fun.set_arg(i, k)
 
         class PointwiseKernel(Kernel):
-            def run(self, queue, **kwargs):
-                for i, k in rtargs:
-                    fun.set_arg(i, kwargs[k])
+            if rtargs:
+                def bind(self, **kwargs):
+                    for i, k in rtargs:
+                        fun.set_arg(i, kwargs[k])
 
-                fun.exec_async(queue.cmd_q, gs, ls)
+            def run(self, queue):
+                fun.exec_async(queue, gs, ls)
 
         return PointwiseKernel(*argmv)

--- a/pyfr/backends/opencl/types.py
+++ b/pyfr/backends/opencl/types.py
@@ -83,6 +83,14 @@ class OpenCLXchgView(base.XchgView):
     pass
 
 
+class OpenCLOrderedMetaKernel(base.MetaKernel):
+    pass
+
+
+class OpenCLUnorderedMetaKernel(base.MetaKernel):
+    pass
+
+
 class OpenCLQueue(base.Queue):
     def __init__(self, backend):
         super().__init__(backend)

--- a/pyfr/backends/opencl/types.py
+++ b/pyfr/backends/opencl/types.py
@@ -89,29 +89,3 @@ class OpenCLOrderedMetaKernel(base.MetaKernel):
 
 class OpenCLUnorderedMetaKernel(base.MetaKernel):
     pass
-
-
-class OpenCLQueue(base.Queue):
-    def __init__(self, backend):
-        super().__init__(backend)
-
-        # OpenCL command queue
-        self.cmd_q = backend.cl.queue()
-
-    def run(self, mpireqs=[]):
-        # Start any MPI requests
-        if mpireqs:
-            self._startall(mpireqs)
-
-        # Submit the kernels to the command queue
-        for item, args, kwargs in self._items:
-            item.run(self, *args, **kwargs)
-
-        # If we started any MPI requests, wait for them
-        if mpireqs:
-            self.cmd_q.flush()
-            self._waitall(mpireqs)
-
-        # Wait for the kernels to finish and clear the queue
-        self.cmd_q.finish()
-        self._items.clear()

--- a/pyfr/backends/openmp/base.py
+++ b/pyfr/backends/openmp/base.py
@@ -34,7 +34,6 @@ class OpenMPBackend(BaseBackend):
         self.const_matrix_cls = types.OpenMPConstMatrix
         self.matrix_cls = types.OpenMPMatrix
         self.matrix_slice_cls = types.OpenMPMatrixSlice
-        self.queue_cls = types.OpenMPQueue
         self.view_cls = types.OpenMPView
         self.xchg_matrix_cls = types.OpenMPXchgMatrix
         self.xchg_view_cls = types.OpenMPXchgView
@@ -50,6 +49,19 @@ class OpenMPBackend(BaseBackend):
 
         # Pointwise kernels
         self.pointwise = self._providers[0]
+
+    def run(self, kernels, mpireqs=None):
+        # Start any MPI requests
+        if mpireqs:
+            self._startall(mpireqs)
+
+        # Run our kernels
+        for k in kernels:
+            k()
+
+        # If we started any MPI requests, wait for them
+        if mpireqs:
+            self._waitall(mpireqs)
 
     def _malloc_impl(self, nbytes):
         data = np.zeros(nbytes + self.alignb, dtype=np.uint8)

--- a/pyfr/backends/openmp/base.py
+++ b/pyfr/backends/openmp/base.py
@@ -54,27 +54,18 @@ class OpenMPBackend(BaseBackend):
         # Pointwise kernels
         self.pointwise = self._providers[0]
 
-    def run_kernels(self, kernels, mpireqs=None):
-        # Start any MPI requests
-        if mpireqs:
-            self._startall(mpireqs)
-
-        # Run our kernels
+    def run_kernels(self, kernels):
         for k in kernels:
             k.run()
 
-        # If we started any MPI requests, wait for them
-        if mpireqs:
-            self._waitall(mpireqs)
-
-    def run_graph(self, graph, mpireqs=None):
-        self.run_kernels([graph], mpireqs)
+    def run_graph(self, graph):
+        graph.run()
 
     @cached_property
     def krunner(self):
         ksrc = self.lookup.get_template('run-kernels').render()
         klib = self.compiler.build(ksrc)
-        return klib.function('run_kernels', None, [c_int, c_void_p, c_void_p])
+        return klib.function('run_kernels', None, [c_int, c_int, c_void_p])
 
     def _malloc_impl(self, nbytes):
         data = np.zeros(nbytes + self.alignb, dtype=np.uint8)

--- a/pyfr/backends/openmp/base.py
+++ b/pyfr/backends/openmp/base.py
@@ -54,11 +54,11 @@ class OpenMPBackend(BaseBackend):
         # Pointwise kernels
         self.pointwise = self._providers[0]
 
-    def run_kernels(self, kernels):
+    def run_kernels(self, kernels, wait=False):
         for k in kernels:
             k.run()
 
-    def run_graph(self, graph):
+    def run_graph(self, graph, wait=False):
         graph.run()
 
     @cached_property

--- a/pyfr/backends/openmp/base.py
+++ b/pyfr/backends/openmp/base.py
@@ -38,6 +38,8 @@ class OpenMPBackend(BaseBackend):
         self.view_cls = types.OpenMPView
         self.xchg_matrix_cls = types.OpenMPXchgMatrix
         self.xchg_view_cls = types.OpenMPXchgView
+        self.ordered_meta_kernel_cls = types.OpenMPOrderedMetaKernel
+        self.unordered_meta_kernel_cls = types.OpenMPUnorderedMetaKernel
 
         # Instantiate mandatory kernel provider classes
         kprovcls = [provider.OpenMPPointwiseKernelProvider,

--- a/pyfr/backends/openmp/blasext.py
+++ b/pyfr/backends/openmp/blasext.py
@@ -2,8 +2,7 @@
 
 import numpy as np
 
-from pyfr.backends.openmp.provider import OpenMPKernelProvider
-from pyfr.backends.base import Kernel
+from pyfr.backends.openmp.provider import OpenMPKernel, OpenMPKernelProvider
 
 
 class OpenMPBlasExtKernels(OpenMPKernelProvider):
@@ -27,14 +26,11 @@ class OpenMPBlasExtKernels(OpenMPKernelProvider):
         # Set the static arguments
         kern.set_args(nrow, nblocks, *arr)
 
-        class AxnpbyKernel(Kernel):
+        class AxnpbyKernel(OpenMPKernel):
             def bind(self, *consts):
-                kern.set_args(*consts, start=2 + nv)
+                self.kernel.set_args(*consts, start=2 + nv)
 
-            def run(self):
-                kern()
-
-        return AxnpbyKernel(mats=arr)
+        return AxnpbyKernel(mats=arr, kernel=kern)
 
     def copy(self, dst, src):
         if dst.traits != src.traits:
@@ -51,11 +47,7 @@ class OpenMPBlasExtKernels(OpenMPKernelProvider):
         kern = self._build_kernel('par_memcpy', ksrc, 'PiPiii')
         kern.set_args(dst, dbbytes, src, sbbytes, bnbytes, nblocks)
 
-        class CopyKernel(Kernel):
-            def run(self):
-                kern()
-
-        return CopyKernel(mats=[dst, src])
+        return OpenMPKernel(mats=[dst, src], kernel=kern)
 
     def reduction(self, *rs, method, norm, dt_mat=None):
         if any(r.traits != rs[0].traits for r in rs[1:]):
@@ -92,15 +84,12 @@ class OpenMPBlasExtKernels(OpenMPKernelProvider):
         # Runtime argument offset
         facoff = argt.index(dtype)
 
-        class ReductionKernel(Kernel):
+        class ReductionKernel(OpenMPKernel):
             @property
             def retval(self):
                 return reduced
 
             def bind(self, *facs):
-                rkern.set_args(*facs, start=facoff)
+                self.kernel.set_args(*facs, start=facoff)
 
-            def run(self):
-                rkern()
-
-        return ReductionKernel(mats=regs)
+        return ReductionKernel(mats=regs, kernel=rkern)

--- a/pyfr/backends/openmp/kernels/run-kernels.mako
+++ b/pyfr/backends/openmp/kernels/run-kernels.mako
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 <%inherit file='base'/>
 
-void run_kernels(int n, void (**kerns)(void *), void **kargs)
+struct kfunargs
 {
-	for (int i = 0; i < n; i++)
-		kerns[i](kargs[i]);
+    void (*fun)(void *);
+    void *args;
+};
+
+void run_kernels(int off, int n, const struct kfunargs *kfa)
+{
+    for (int i = off; i < off + n; i++)
+        kfa[i].fun(kfa[i].args);
 }

--- a/pyfr/backends/openmp/kernels/run-kernels.mako
+++ b/pyfr/backends/openmp/kernels/run-kernels.mako
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+<%inherit file='base'/>
+
+void run_kernels(int n, void (**kerns)(void *), void **kargs)
+{
+	for (int i = 0; i < n; i++)
+		kerns[i](kargs[i]);
+}

--- a/pyfr/backends/openmp/packing.py
+++ b/pyfr/backends/openmp/packing.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from pyfr.backends.base import Kernel, NullKernel
-from pyfr.backends.openmp.provider import OpenMPKernelProvider
+from pyfr.backends.openmp.provider import OpenMPKernel, OpenMPKernelProvider
 
 
 class OpenMPPackingKernels(OpenMPKernelProvider):
@@ -17,11 +17,7 @@ class OpenMPPackingKernels(OpenMPKernelProvider):
         kern = self._build_kernel('pack_view', src, 'iPPPP')
         kern.set_args(v.n, v.basedata, v.mapping, v.rstrides or 0, m)
 
-        class PackXchgViewKernel(Kernel):
-            def run(self):
-                kern()
-
-        return PackXchgViewKernel(mats=[mv])
+        return OpenMPKernel(mats=[mv], kernel=kern)
 
     def unpack(self, mv):
         return NullKernel()

--- a/pyfr/backends/openmp/packing.py
+++ b/pyfr/backends/openmp/packing.py
@@ -18,7 +18,7 @@ class OpenMPPackingKernels(OpenMPKernelProvider):
         kern.set_args(v.n, v.basedata, v.mapping, v.rstrides or 0, m)
 
         class PackXchgViewKernel(Kernel):
-            def run(self, queue):
+            def run(self):
                 kern()
 
         return PackXchgViewKernel(mats=[mv])

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -64,10 +64,12 @@ class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
                 fun.set_arg(i, k)
 
         class PointwiseKernel(Kernel):
-            def run(self, queue, **kwargs):
-                for i, k in rtargs:
-                    fun.set_arg(i, kwargs[k])
+            if rtargs:
+                def bind(self, **kwargs):
+                    for i, k in rtargs:
+                        fun.set_arg(i, kwargs[k])
 
+            def run(self):
                 fun()
 
         return PointwiseKernel(*argmv)

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -20,6 +20,8 @@ class OpenMPKernel(Kernel):
     def add_to_graph(self, graph, dnodes):
         graph.klist.append(self.kernel)
 
+        return len(graph.klist)
+
     def run(self):
         self.kernel()
 
@@ -28,6 +30,8 @@ class _OpenCLMetaKernelCommon(MetaKernel):
     def add_to_graph(self, graph, dnodes):
         for k in self.kernels:
             k.add_to_graph(graph, dnodes)
+
+        return len(graph.klist)
 
 
 class OpenMPOrderedMetaKernel(_OpenCLMetaKernelCommon): pass

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -64,6 +64,14 @@ class OpenMPView(base.View):
     pass
 
 
+class OpenMPOrderedMetaKernel(base.MetaKernel):
+    pass
+
+
+class OpenMPUnorderedMetaKernel(base.MetaKernel):
+    pass
+
+
 class OpenMPQueue(base.Queue):
     def run(self, mpireqs=[]):
         # Start any MPI requests

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -96,14 +96,12 @@ class OpenMPGraph(base.Graph):
         from mpi4py import MPI
 
         # Start all dependency-free MPI requests
-        if self.mpi_root_reqs:
-            MPI.Prequest.Startall(self.mpi_root_reqs)
+        MPI.Prequest.Startall(self.mpi_root_reqs)
 
         for i, n, reqs in self._runlist:
             self.backend.krunner(i, n, self._kfunargs)
 
-            for req in reqs:
-                req.Start()
+            MPI.Prequest.Startall(reqs)
 
         # Wait for all of the MPI requests to finish
         MPI.Prequest.Waitall(self.mpi_reqs)

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -70,21 +70,3 @@ class OpenMPOrderedMetaKernel(base.MetaKernel):
 
 class OpenMPUnorderedMetaKernel(base.MetaKernel):
     pass
-
-
-class OpenMPQueue(base.Queue):
-    def run(self, mpireqs=[]):
-        # Start any MPI requests
-        if mpireqs:
-            self._startall(mpireqs)
-
-        # Run our kernels
-        for item, args, kwargs in self._items:
-            item.run(self, *args, **kwargs)
-
-        # If we started any MPI requests, wait for them
-        if mpireqs:
-            self._waitall(mpireqs)
-
-        # Clear the queue
-        self._items.clear()

--- a/pyfr/backends/openmp/xsmm.py
+++ b/pyfr/backends/openmp/xsmm.py
@@ -113,7 +113,7 @@ class OpenMPXSMMKernels(OpenMPKernelProvider):
                             out.blocksz)
 
         class MulKernel(Kernel):
-            def run(self, queue):
+            def run(self):
                 batch_gemm()
 
         return MulKernel(mats=[b, out], misc=[self])

--- a/pyfr/backends/openmp/xsmm.py
+++ b/pyfr/backends/openmp/xsmm.py
@@ -4,8 +4,8 @@ from ctypes import cast, c_int, c_double, c_float, c_void_p
 
 import numpy as np
 
-from pyfr.backends.base import Kernel, NotSuitableError
-from pyfr.backends.openmp.provider import OpenMPKernelProvider
+from pyfr.backends.base import NotSuitableError
+from pyfr.backends.openmp.provider import OpenMPKernel, OpenMPKernelProvider
 from pyfr.ctypesutil import LibWrapper
 
 
@@ -112,8 +112,4 @@ class OpenMPXSMMKernels(OpenMPKernelProvider):
         batch_gemm.set_args(execptr, blkptr, b.nblocks, b, b.blocksz, out,
                             out.blocksz)
 
-        class MulKernel(Kernel):
-            def run(self):
-                batch_gemm()
-
-        return MulKernel(mats=[b, out], misc=[self])
+        return OpenMPKernel(mats=[b, out], misc=[self], kernel=batch_gemm)

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -193,7 +193,7 @@ class BaseCommon:
         for k in axnpby:
             k.bind(*consts)
 
-        self.backend.run(axnpby)
+        self.backend.run_kernels(axnpby)
 
     def _add(self, *args, subdims=None):
         self._addv(args[::2], args[1::2], subdims=subdims)

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -49,9 +49,6 @@ class BaseIntegrator:
         # Extract the UUID of the mesh (to be saved with solutions)
         self.mesh_uuid = mesh['mesh_uuid']
 
-        # Get a queue for subclasses to use
-        self._queue = backend.queue()
-
         # Solution cache
         self._curr_soln = None
 
@@ -192,8 +189,11 @@ class BaseCommon:
         # Get a suitable set of axnpby kernels
         axnpby = self._get_axnpby_kerns(*regidxs, subdims=subdims)
 
-        # Bind and run the axnpby kernels
-        self._queue.enqueue_and_run(axnpby, *consts)
+        # Bind the arguments
+        for k in axnpby:
+            k.bind(*consts)
+
+        self.backend.run(axnpby)
 
     def _add(self, *args, subdims=None):
         self._addv(args[::2], args[1::2], subdims=subdims)

--- a/pyfr/integrators/dual/pseudo/base.py
+++ b/pyfr/integrators/dual/pseudo/base.py
@@ -55,9 +55,6 @@ class BaseDualPseudoIntegrator(BaseCommon):
         self._regidx = list(range(self.nregs))
         self._idxcurr = 0
 
-        # Get a queue for the pseudointegrator
-        self._queue = backend.queue()
-
         # Global degree of freedom count
         self._gndofs = self._get_gndofs()
 

--- a/pyfr/integrators/dual/pseudo/multip.py
+++ b/pyfr/integrators/dual/pseudo/multip.py
@@ -216,11 +216,11 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         # Restrict the physical source term
         l1src = self.pintgs[l1]._source_regidx
         l2dst = self.pintgs[l2]._source_regidx
-        self.backend.run(self.mgproject(l1, l1src, l2, l2dst))
+        self.backend.run_kernels(self.mgproject(l1, l1src, l2, l2dst))
 
         # Project local dtau field to lower multigrid levels
         if self.pintgs[self._order].pseudo_controller_needs_lerrest:
-            self.backend.run(self.dtauproject(l1, l2))
+            self.backend.run_kernels(self.dtauproject(l1, l2))
 
         # Prevsoln is used as temporal storage at l1
         rtemp = 0 if l1idxcurr == 1 else 1
@@ -237,7 +237,7 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         mg0, mg1 = self._mg_regidx
 
         # Restrict Q and d
-        self.backend.run(
+        self.backend.run_kernels(
             self.mgproject(l1, l1idxcurr, l2, l2idxcurr) +
             self.mgproject(l1, rtemp, l2, mg1)
         )
@@ -265,7 +265,7 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         self.pintg._add(-1, self._mg_regidx[1], 1, l1idxcurr)
 
         # Prolongate the correction and store to rtemp
-        self.backend.run(self.mgproject(l1, self._mg_regidx[1], l2, rtemp))
+        self.backend.run_kernels(self.mgproject(l1, self._mg_regidx[1], l2, rtemp))
 
         # Add the correction to the end quantity at l2
         # Q^m+1  = Q^s + Delta

--- a/pyfr/integrators/dual/pseudo/multip.py
+++ b/pyfr/integrators/dual/pseudo/multip.py
@@ -153,10 +153,6 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         self.pintg.pseudostepinfo = y
 
     @property
-    def _queue(self):
-        return self.pintg._queue
-
-    @property
     def _regidx(self):
         return self.pintg._regidx
 
@@ -220,11 +216,11 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         # Restrict the physical source term
         l1src = self.pintgs[l1]._source_regidx
         l2dst = self.pintgs[l2]._source_regidx
-        self.pintg._queue.enqueue_and_run(self.mgproject(l1, l1src, l2, l2dst))
+        self.backend.run(self.mgproject(l1, l1src, l2, l2dst))
 
         # Project local dtau field to lower multigrid levels
         if self.pintgs[self._order].pseudo_controller_needs_lerrest:
-            self.pintg._queue.enqueue_and_run(self.dtauproject(l1, l2))
+            self.backend.run(self.dtauproject(l1, l2))
 
         # Prevsoln is used as temporal storage at l1
         rtemp = 0 if l1idxcurr == 1 else 1
@@ -241,9 +237,10 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         mg0, mg1 = self._mg_regidx
 
         # Restrict Q and d
-        self.pintg._queue.enqueue(self.mgproject(l1, l1idxcurr, l2, l2idxcurr))
-        self.pintg._queue.enqueue(self.mgproject(l1, rtemp, l2, mg1))
-        self.pintg._queue.run()
+        self.backend.run(
+            self.mgproject(l1, l1idxcurr, l2, l2idxcurr) +
+            self.mgproject(l1, rtemp, l2, mg1)
+        )
 
         # mg0 = R = -∇·f - dQ/dt
         self.pintg._rhs_with_dts(self.tcurr, l2idxcurr, mg0, mg_add=False)
@@ -268,9 +265,7 @@ class DualMultiPIntegrator(BaseDualPseudoIntegrator):
         self.pintg._add(-1, self._mg_regidx[1], 1, l1idxcurr)
 
         # Prolongate the correction and store to rtemp
-        self.pintg._queue.enqueue_and_run(
-            self.mgproject(l1, self._mg_regidx[1], l2, rtemp)
-        )
+        self.backend.run(self.mgproject(l1, self._mg_regidx[1], l2, rtemp))
 
         # Add the correction to the end quantity at l2
         # Q^m+1  = Q^s + Delta

--- a/pyfr/integrators/dual/pseudo/pseudocontrollers.py
+++ b/pyfr/integrators/dual/pseudo/pseudocontrollers.py
@@ -27,25 +27,29 @@ class BaseDualPseudoController(BaseDualPseudoIntegrator):
     def _resid(self, rcurr, rold, dt_fac):
         comm, rank, root = get_comm_rank_root()
 
-        # Get a reduction kern to compute the square of the maximum residual
-        resid = self._get_reduction_kerns(rcurr, rold, method='resid',
-                                          norm=self._pseudo_norm)
+        # Get a set of kernels to compute the residual
+        rkerns = self._get_reduction_kerns(rcurr, rold, method='resid',
+                                           norm=self._pseudo_norm)
 
-        # Run the kernel
-        self._queue.enqueue_and_run(resid, dt_fac)
+        # Bind the dynmaic arguments
+        for kern in rkerns:
+            kern.bind(dt_fac)
 
-        # L2 norm
+        # Run the kernels
+        self.backend.run(rkerns)
+
+        # Pseudo L2 norm
         if self._pseudo_norm == 'l2':
             # Reduce locally (element types) and globally (MPI ranks)
-            res = np.array([sum(ev) for ev in zip(*[r.retval for r in resid])])
+            res = np.array([sum(e) for e in zip(*[r.retval for r in rkerns])])
             comm.Allreduce(get_mpi('in_place'), res, op=get_mpi('sum'))
 
             # Normalise and return
             return tuple(np.sqrt(res / self._gndofs))
-        # L^∞ norm
+        # Uniform norm
         else:
             # Reduce locally (element types) and globally (MPI ranks)
-            res = np.array([max(ev) for ev in zip(*[r.retval for r in resid])])
+            res = np.array([max(e) for e in zip(*[r.retval for r in rkerns])])
             comm.Allreduce(get_mpi('in_place'), res, op=get_mpi('max'))
 
             # Normalise and return
@@ -135,7 +139,7 @@ class DualPIPseudoController(BaseDualPseudoController):
         self.backend.commit()
 
     def localerrest(self, errbank):
-        self._queue.enqueue_and_run(self.pintgkernels['localerrest', errbank])
+        self.backend.run(self.pintgkernels['localerrest', errbank])
 
     def pseudo_advance(self, tcurr):
         self.tcurr = tcurr

--- a/pyfr/integrators/dual/pseudo/pseudocontrollers.py
+++ b/pyfr/integrators/dual/pseudo/pseudocontrollers.py
@@ -36,7 +36,7 @@ class BaseDualPseudoController(BaseDualPseudoIntegrator):
             kern.bind(dt_fac)
 
         # Run the kernels
-        self.backend.run(rkerns)
+        self.backend.run_kernels(rkerns)
 
         # Pseudo L2 norm
         if self._pseudo_norm == 'l2':
@@ -139,7 +139,7 @@ class DualPIPseudoController(BaseDualPseudoController):
         self.backend.commit()
 
     def localerrest(self, errbank):
-        self.backend.run(self.pintgkernels['localerrest', errbank])
+        self.backend.run_kernels(self.pintgkernels['localerrest', errbank])
 
     def pseudo_advance(self, tcurr):
         self.tcurr = tcurr

--- a/pyfr/integrators/dual/pseudo/pseudocontrollers.py
+++ b/pyfr/integrators/dual/pseudo/pseudocontrollers.py
@@ -36,7 +36,7 @@ class BaseDualPseudoController(BaseDualPseudoIntegrator):
             kern.bind(dt_fac)
 
         # Run the kernels
-        self.backend.run_kernels(rkerns)
+        self.backend.run_kernels(rkerns, wait=True)
 
         # Pseudo L2 norm
         if self._pseudo_norm == 'l2':

--- a/pyfr/integrators/dual/pseudo/pseudosteppers.py
+++ b/pyfr/integrators/dual/pseudo/pseudosteppers.py
@@ -240,7 +240,7 @@ class DualRKVdH2RPseudoStepper(DualEmbeddedPairPseudoStepper):
     def step(self, t):
         self.npseudosteps += 1
 
-        q, rhs = self._queue, self._rhs_with_dts
+        run, rhs = self.backend.run, self._rhs_with_dts
 
         rold = self._idxcurr
         r1, r2, *rerr = set(self._pseudo_stepper_regidx) - {rold}
@@ -254,7 +254,7 @@ class DualRKVdH2RPseudoStepper(DualEmbeddedPairPseudoStepper):
             kerns = self._get_rkvdh2pseudo_kerns(i, r1, r2, rold, *rerr)
 
             # Execute
-            q.enqueue_and_run(kerns)
+            run(kerns)
 
             # Swap
             r1, r2 = r2, r1

--- a/pyfr/integrators/dual/pseudo/pseudosteppers.py
+++ b/pyfr/integrators/dual/pseudo/pseudosteppers.py
@@ -240,7 +240,7 @@ class DualRKVdH2RPseudoStepper(DualEmbeddedPairPseudoStepper):
     def step(self, t):
         self.npseudosteps += 1
 
-        run, rhs = self.backend.run, self._rhs_with_dts
+        run_kernels, rhs = self.backend.run_kernels, self._rhs_with_dts
 
         rold = self._idxcurr
         r1, r2, *rerr = set(self._pseudo_stepper_regidx) - {rold}
@@ -254,7 +254,7 @@ class DualRKVdH2RPseudoStepper(DualEmbeddedPairPseudoStepper):
             kerns = self._get_rkvdh2pseudo_kerns(i, r1, r2, rold, *rerr)
 
             # Execute
-            run(kerns)
+            run_kernels(kerns)
 
             # Swap
             r1, r2 = r2, r1

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -135,7 +135,7 @@ class StdPIController(BaseStdController):
             kern.bind(self._atol, self._rtol)
 
         # Run the kernels
-        self.backend.run(ekerns)
+        self.backend.run_kernels(ekerns)
 
         # Pseudo L2 norm
         if self._norm == 'l2':

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -126,13 +126,18 @@ class StdPIController(BaseStdController):
     def _errest(self, rcurr, rprev, rerr):
         comm, rank, root = get_comm_rank_root()
 
-        errest = self._get_reduction_kerns(rcurr, rprev, rerr, method='errest',
+        # Get a set of kernels to estimate the integration error
+        ekerns = self._get_reduction_kerns(rcurr, rprev, rerr, method='errest',
                                            norm=self._norm)
 
-        # Obtain an estimate for the squared error
-        self._queue.enqueue_and_run(errest, self._atol, self._rtol)
+        # Bind the dynamic arguments
+        for kern in ekerns:
+            kern.bind(self._atol, self._rtol)
 
-        # L2 norm
+        # Run the kernels
+        self.backend.run(ekerns)
+
+        # Pseudo L2 norm
         if self._norm == 'l2':
             # Reduce locally (element types + field variables)
             err = np.array([sum(v for e in errest for v in e.retval)])
@@ -142,7 +147,7 @@ class StdPIController(BaseStdController):
 
             # Normalise
             err = math.sqrt(float(err) / self._gndofs)
-        # L^∞ norm
+        # Uniform norm
         else:
             # Reduce locally (element types + field variables)
             err = np.array([max(v for e in errest for v in e.retval)])

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -135,7 +135,7 @@ class StdPIController(BaseStdController):
             kern.bind(self._atol, self._rtol)
 
         # Run the kernels
-        self.backend.run_kernels(ekerns)
+        self.backend.run_kernels(ekerns, wait=True)
 
         # Pseudo L2 norm
         if self._norm == 'l2':

--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -140,7 +140,7 @@ class StdPIController(BaseStdController):
         # Pseudo L2 norm
         if self._norm == 'l2':
             # Reduce locally (element types + field variables)
-            err = np.array([sum(v for e in errest for v in e.retval)])
+            err = np.array([sum(v for k in ekerns for v in k.retval)])
 
             # Reduce globally (MPI ranks)
             comm.Allreduce(get_mpi('in_place'), err, op=get_mpi('sum'))
@@ -150,7 +150,7 @@ class StdPIController(BaseStdController):
         # Uniform norm
         else:
             # Reduce locally (element types + field variables)
-            err = np.array([max(v for e in errest for v in e.retval)])
+            err = np.array([max(v for k in ekerns for v in k.retval)])
 
             # Reduce globally (MPI ranks)
             comm.Allreduce(get_mpi('in_place'), err, op=get_mpi('max'))

--- a/pyfr/integrators/std/steppers.py
+++ b/pyfr/integrators/std/steppers.py
@@ -179,7 +179,7 @@ class StdRKVdH2RStepper(BaseStdStepper):
         return 4 if self.stepper_has_errest else 2
 
     def step(self, t, dt):
-        run, rhs = self.backend.run, self.system.rhs
+        run_kernels, rhs = self.backend.run_kernels, self.system.rhs
 
         r1 = self._idxcurr
         r2, *rs = set(self._regidx) - {r1}
@@ -197,7 +197,7 @@ class StdRKVdH2RStepper(BaseStdStepper):
                 k.bind(dt=dt)
 
             # Execute
-            run(kerns)
+            run_kernels(kerns)
 
             # Swap
             r1, r2 = r2, r1

--- a/pyfr/integrators/std/steppers.py
+++ b/pyfr/integrators/std/steppers.py
@@ -179,7 +179,7 @@ class StdRKVdH2RStepper(BaseStdStepper):
         return 4 if self.stepper_has_errest else 2
 
     def step(self, t, dt):
-        q, rhs = self._queue, self.system.rhs
+        run, rhs = self.backend.run, self.system.rhs
 
         r1 = self._idxcurr
         r2, *rs = set(self._regidx) - {r1}
@@ -192,8 +192,12 @@ class StdRKVdH2RStepper(BaseStdStepper):
             # Fetch the appropriate RK accumulation kernels
             kerns = self._get_rkvdh2_kerns(i, r1, r2, *rs)
 
+            # Bind the arguments
+            for k in kerns:
+                k.bind(dt=dt)
+
             # Execute
-            q.enqueue_and_run(kerns, dt=dt)
+            run(kerns)
 
             # Swap
             r1, r2 = r2, r1

--- a/pyfr/solvers/acnavstokes/inters.py
+++ b/pyfr/solvers/acnavstokes/inters.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from pyfr.backends.base.kernels import MetaKernel
 from pyfr.solvers.baseadvecdiff import (BaseAdvectionDiffusionBCInters,
                                         BaseAdvectionDiffusionIntInters,
                                         BaseAdvectionDiffusionMPIInters)
@@ -20,9 +19,9 @@ class ACNavierStokesIntInters(BaseAdvectionDiffusionIntInters):
         self._be.pointwise.register(f'{kprefix}.intcflux')
 
         if abs(self.c['ldg-beta']) == 0.5:
-            self.kernels['copy_fpts'] = lambda: MetaKernel(
-            [ele.kernels['_copy_fpts']() for ele in elemap.values()]
-        )
+            self.kernels['copy_fpts'] = lambda: be.unordered_meta_kernel(
+                [ele.kernels['_copy_fpts']() for ele in elemap.values()]
+            )
 
         self.kernels['con_u'] = lambda: self._be.kernel(
             'intconu', tplargs=tplargs, dims=[self.ninterfpts],

--- a/pyfr/solvers/acnavstokes/inters.py
+++ b/pyfr/solvers/acnavstokes/inters.py
@@ -18,11 +18,6 @@ class ACNavierStokesIntInters(BaseAdvectionDiffusionIntInters):
         self._be.pointwise.register(f'{kprefix}.intconu')
         self._be.pointwise.register(f'{kprefix}.intcflux')
 
-        if abs(self.c['ldg-beta']) == 0.5:
-            self.kernels['copy_fpts'] = lambda: be.unordered_meta_kernel(
-                [ele.kernels['_copy_fpts']() for ele in elemap.values()]
-            )
-
         self.kernels['con_u'] = lambda: self._be.kernel(
             'intconu', tplargs=tplargs, dims=[self.ninterfpts],
             ulin=self._scal_lhs, urin=self._scal_rhs,

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from pyfr.backends.base import MetaKernel
 from pyfr.solvers.base import BaseElements
 
 
@@ -97,6 +96,6 @@ class BaseAdvectionElements(BaseElements):
                     'copy', self.scal_upts[uin], self._scal_upts_temp
                 )
 
-                return MetaKernel([mul, copy])
+                return self._be.ordered_meta_kernel([mul, copy])
 
             kernels['filter_soln'] = filter_soln

--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -38,6 +38,9 @@ class BaseAdvectionMPIInters(BaseInters):
         self._rhsrank = rhsrank
         self._rallocs = rallocs
 
+        # Name our interface so we can match kernels to MPI requests
+        self.name = 'p{rhsrank}'
+
         const_mat = self._const_mat
 
         # Generate the left hand view matrix and its dual

--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import itertools as it
 import math
 
 from pyfr.solvers.base import BaseInters
@@ -30,8 +31,8 @@ class BaseAdvectionIntInters(BaseInters):
 
 
 class BaseAdvectionMPIInters(BaseInters):
-    # Tag used for MPI
-    MPI_TAG = 2314
+    # Starting tag used for MPI
+    BASE_MPI_TAG = 2314
 
     def __init__(self, be, lhs, rhsrank, rallocs, elemap, cfg):
         super().__init__(be, lhs, elemap, cfg)
@@ -40,6 +41,9 @@ class BaseAdvectionMPIInters(BaseInters):
 
         # Name our interface so we can match kernels to MPI requests
         self.name = 'p{rhsrank}'
+
+        # MPI request tag counter
+        self._mpi_tag_counter = it.count(self.BASE_MPI_TAG)
 
         const_mat = self._const_mat
 
@@ -59,11 +63,12 @@ class BaseAdvectionMPIInters(BaseInters):
         )
 
         # Associated MPI requests
+        scal_fpts_tag = next(self._mpi_tag_counter)
         self.mpireqs['scal_fpts_send'] = lambda: self._scal_lhs.sendreq(
-            self._rhsrank, self.MPI_TAG
+            self._rhsrank, scal_fpts_tag
         )
         self.mpireqs['scal_fpts_recv'] = lambda: self._scal_rhs.recvreq(
-            self._rhsrank, self.MPI_TAG
+            self._rhsrank, scal_fpts_tag
         )
 
 

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -10,32 +10,54 @@ class BaseAdvectionSystem(BaseSystem):
         m = self._mpireqs
         k, _ = self._get_kernels(uinbank, foutbank)
 
-        def edeps(ek, *edeps): return self._ele_deps(k, ek, *edeps)
+        def deps(dk, *names): return self._kdeps(k, dk, *names)
 
         g1 = self.backend.graph()
+        g1.add_mpi_reqs(m['scal_fpts_recv'])
+
+        # Interpolate the solution to the flux points
         g1.add_all(k['eles/disu'])
+
+        # Pack and send these interpolated solutions to our neighbours
         g1.add_all(k['mpiint/scal_fpts_pack'], deps=k['eles/disu'])
+        for send, pack in zip(m['scal_fpts_send'], k['mpiint/scal_fpts_pack']):
+            g1.add_mpi_req(send, deps=[pack])
+
+        # Compute the common normal flux at our internal/boundary interfaces
+        g1.add_all(k['iint/comm_flux'],
+                   deps=k['eles/disu'] + k['mpiint/scal_fpts_pack'])
+        g1.add_all(k['bcint/comm_flux'], deps=k['eles/disu'])
+
+        # Make a copy of the solution (if used by source terms)
+        g1.add_all(k['eles/copy_soln'])
+
+        # Interpolate the solution to the quadrature points
+        g1.add_all(k['eles/qptsu'])
+
+        # Compute the transformed flux
+        for l in k['eles/tdisf_curved'] + k['eles/tdisf_linear']:
+            g1.add(l, deps=deps(l, 'eles/qptsu'))
+
+        # Compute the transformed divergence of the partially corrected flux
+        for l in k['eles/tdivtpcorf']:
+            ldeps = deps(l, 'eles/tdisf_curved', 'eles/tdisf_linear',
+                         'eles/copy_soln', 'eles/disu')
+            g1.add(l, deps=ldeps + k['mpiint/scal_fpts_pack'])
         g1.commit()
 
         g2 = self.backend.graph()
-        g2.add_all(k['iint/comm_flux'])
-        g2.add_all(k['bcint/comm_flux'])
-        g2.add_all(k['eles/copy_soln'])
-        g2.add_all(k['eles/qptsu'])
-        for l in k['eles/tdisf_curved']:
-            g2.add(l, deps=edeps(l, 'qptsu'))
-        for l in k['eles/tdisf_linear']:
-            g2.add(l, deps=edeps(l, 'qptsu'))
-        for l in k['eles/tdivtpcorf']:
-            g2.add(l, deps=edeps(l, 'tdisf_curved', 'tdisf_linear'))
+
+        # Compute the common normal flux at our MPI interfaces
+        g2.add_all(k['mpiint/scal_fpts_unpack'])
+        for l in k['mpiint/comm_flux']:
+            g2.add(l, deps=deps(l, 'mpiint/scal_fpts_unpack'))
+
+        # Compute the transformed divergence of the corrected flux
+        g2.add_all(k['eles/tdivtconf'], deps=k['mpiint/comm_flux'])
+
+        # Obtain the physical divergence of the corrected flux
+        for l in k['eles/negdivconf']:
+            g2.add(l, deps=deps(l, 'eles/tdivtconf'))
         g2.commit()
 
-        g3 = self.backend.graph()
-        g3.add_all(k['mpiint/scal_fpts_unpack'])
-        g3.add_all(k['mpiint/comm_flux'], deps=k['mpiint/scal_fpts_unpack'])
-        g3.add_all(k['eles/tdivtconf'], deps=k['mpiint/comm_flux'])
-        for l in k['eles/negdivconf']:
-            g3.add(l, deps=edeps(l, 'tdivtconf'))
-        g3.commit()
-
-        return [(g1, None), (g2, m['scal_fpts_send_recv']), (g3, None)]
+        return g1, g2

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -1,32 +1,41 @@
 # -*- coding: utf-8 -*-
 
 from pyfr.solvers.base import BaseSystem
+from pyfr.util import memoize
 
 
 class BaseAdvectionSystem(BaseSystem):
-    def rhs(self, t, uinbank, foutbank):
-        run = self.backend.run
-        kernels = self._prepare_kernels(t, uinbank, foutbank)
-        mpireqs = self._mpireqs
+    @memoize
+    def _rhs_graphs(self, uinbank, foutbank):
+        m = self._mpireqs
+        k, _ = self._get_kernels(uinbank, foutbank)
 
-        k = []
-        k += kernels['eles/disu']
-        k += kernels['mpiint/scal_fpts_pack']
-        run(k)
+        def edeps(ek, *edeps): return self._ele_deps(k, ek, *edeps)
 
-        k = []
-        k += kernels['eles/copy_soln']
-        k += kernels['eles/qptsu']
-        k += kernels['eles/tdisf_curved']
-        k += kernels['eles/tdisf_linear']
-        k += kernels['eles/tdivtpcorf']
-        k += kernels['iint/comm_flux']
-        k += kernels['bcint/comm_flux']
-        run(k, mpireqs['scal_fpts_send_recv'])
+        g1 = self.backend.graph()
+        g1.add_all(k['eles/disu'])
+        g1.add_all(k['mpiint/scal_fpts_pack'], deps=k['eles/disu'])
+        g1.commit()
 
-        k = []
-        k += kernels['mpiint/scal_fpts_unpack']
-        k += kernels['mpiint/comm_flux']
-        k += kernels['eles/tdivtconf']
-        k += kernels['eles/negdivconf']
-        run(k)
+        g2 = self.backend.graph()
+        g2.add_all(k['iint/comm_flux'])
+        g2.add_all(k['bcint/comm_flux'])
+        g2.add_all(k['eles/copy_soln'])
+        g2.add_all(k['eles/qptsu'])
+        for l in k['eles/tdisf_curved']:
+            g2.add(l, deps=edeps(l, 'qptsu'))
+        for l in k['eles/tdisf_linear']:
+            g2.add(l, deps=edeps(l, 'qptsu'))
+        for l in k['eles/tdivtpcorf']:
+            g2.add(l, deps=edeps(l, 'tdisf_curved', 'tdisf_linear'))
+        g2.commit()
+
+        g3 = self.backend.graph()
+        g3.add_all(k['mpiint/scal_fpts_unpack'])
+        g3.add_all(k['mpiint/comm_flux'], deps=k['mpiint/scal_fpts_unpack'])
+        g3.add_all(k['eles/tdivtconf'], deps=k['mpiint/comm_flux'])
+        for l in k['eles/negdivconf']:
+            g3.add(l, deps=edeps(l, 'tdivtconf'))
+        g3.commit()
+
+        return [(g1, None), (g2, m['scal_fpts_send_recv']), (g3, None)]

--- a/pyfr/solvers/baseadvecdiff/elements.py
+++ b/pyfr/solvers/baseadvecdiff/elements.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from pyfr.backends.base.kernels import MetaKernel
 from pyfr.polys import get_polybasis
 from pyfr.solvers.baseadvec import BaseAdvectionElements
 
@@ -80,7 +79,7 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
                            vfpts.slice(i*nfpts, (i + 1)*nfpts))
                     for i in range(self.ndims)]
 
-            return MetaKernel(muls)
+            return self._be.unordered_meta_kernel(muls)
 
         self.kernels['gradcoru_fpts'] = gradcoru_fpts
 
@@ -95,7 +94,7 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
                                         vqpts.slice(i*nqpts, (i + 1)*nqpts))
                         for i in range(self.ndims)]
 
-                return MetaKernel(muls)
+                return self._be.unordered_meta_kernel(muls)
 
             self.kernels['gradcoru_qpts'] = gradcoru_qpts
 

--- a/pyfr/solvers/baseadvecdiff/elements.py
+++ b/pyfr/solvers/baseadvecdiff/elements.py
@@ -31,9 +31,11 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
         # Mesh regions
         regions = self._mesh_regions
 
-        self.kernels['_copy_fpts'] = lambda: kernel(
-            'copy', self._vect_fpts.slice(0, self.nfpts), self._scal_fpts
-        )
+        if abs(self.cfg.getfloat('solver-interfaces', 'ldg-beta')) == 0.5:
+            self.kernels['copy_fpts'] = lambda: kernel(
+                'copy', self._vect_fpts.slice(0, self.nfpts), self._scal_fpts
+            )
+
         if self.basis.order > 0:
             self.kernels['tgradpcoru_upts'] = lambda uin: kernel(
                 'mul', self.opmat('M4 - M6*M0'), self.scal_upts[uin],

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -27,10 +27,11 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         g1.add_all(k['eles/copy_soln'])
 
         # Compute the common solution at our internal/boundary interfaces
-        g1.add_all(k['iint/copy_fpts'], deps=k['eles/disu'])
-        g1.add_all(k['iint/con_u'],
-                   deps=k['iint/copy_fpts'] + k['mpiint/scal_fpts_pack'])
-        g1.add_all(k['bcint/con_u'], deps=k['iint/copy_fpts'])
+        for l in k['eles/copy_fpts']:
+            g1.add(l, deps=deps(l, 'eles/disu'))
+        kdeps = k['eles/copy_fpts'] or k['eles/disu']
+        g1.add_all(k['iint/con_u'], deps=kdeps + k['mpiint/scal_fpts_pack'])
+        g1.add_all(k['bcint/con_u'], deps=kdeps)
 
         # Run the shock sensor (if enabled)
         g1.add_all(k['eles/shocksensor'])
@@ -135,9 +136,11 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
             g1.add_mpi_req(send, deps=[pack])
 
         # Compute the common solution at our internal/boundary interfaces
-        g1.add_all(k['iint/copy_fpts'], deps=k['eles/disu'])
-        g1.add_all(k['iint/con_u'], deps=k['iint/copy_fpts'])
-        g1.add_all(k['bcint/con_u'], deps=k['iint/copy_fpts'])
+        for l in k['eles/copy_fpts']:
+            g1.add(l, deps=deps(l, 'eles/disu'))
+        kdeps = k['eles/copy_fpts'] or k['eles/disu']
+        g1.add_all(k['iint/con_u'], deps=kdeps)
+        g1.add_all(k['bcint/con_u'], deps=kdeps)
 
         # Compute the transformed gradient of the partially corrected solution
         g1.add_all(k['eles/tgradpcoru_upts'])

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -10,94 +10,154 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         m = self._mpireqs
         k, _ = self._get_kernels(uinbank, foutbank)
 
-        def edeps(ek, *edeps): return self._ele_deps(k, ek, *edeps)
+        def deps(dk, *names): return self._kdeps(k, dk, *names)
 
         g1 = self.backend.graph()
+        g1.add_mpi_reqs(m['scal_fpts_recv'])
+
+        # Interpolate the solution to the flux points
         g1.add_all(k['eles/disu'])
+
+        # Pack and send these interpolated solutions to our neighbours
         g1.add_all(k['mpiint/scal_fpts_pack'], deps=k['eles/disu'])
+        for send, pack in zip(m['scal_fpts_send'], k['mpiint/scal_fpts_pack']):
+            g1.add_mpi_req(send, deps=[pack])
+
+        # Make a copy of the solution (if used by source terms)
+        g1.add_all(k['eles/copy_soln'])
+
+        # Compute the common solution at our internal/boundary interfaces
+        g1.add_all(k['iint/copy_fpts'], deps=k['eles/disu'])
+        g1.add_all(k['iint/con_u'],
+                   deps=k['iint/copy_fpts'] + k['mpiint/scal_fpts_pack'])
+        g1.add_all(k['bcint/con_u'], deps=k['iint/copy_fpts'])
+
+        # Run the shock sensor (if enabled)
+        g1.add_all(k['eles/shocksensor'])
+        g1.add_all(k['mpiint/artvisc_fpts_pack'], deps=k['eles/shocksensor'])
+
+        # Compute the transformed gradient of the partially corrected solution
+        g1.add_all(k['eles/tgradpcoru_upts'], deps=k['mpiint/scal_fpts_pack'])
         g1.commit()
 
         g2 = self.backend.graph()
-        g2.add_all(k['eles/copy_soln'])
-        g2.add_all(k['iint/copy_fpts'])
-        g2.add_all(k['iint/con_u'], deps=k['iint/copy_fpts'])
-        g2.add_all(k['bcint/con_u'], deps=k['iint/copy_fpts'])
-        g2.add_all(k['eles/shocksensor'])
-        g2.add_all(k['mpiint/artvisc_fpts_pack'], deps=k['eles/shocksensor'])
-        g2.add_all(k['eles/tgradpcoru_upts'])
+        g2.add_mpi_reqs(m['artvisc_fpts_send'] + m['artvisc_fpts_recv'])
+        g2.add_mpi_reqs(m['vect_fpts_recv'])
+
+        # Compute the common solution at our MPI interfaces
+        g2.add_all(k['mpiint/scal_fpts_unpack'])
+        for l in k['mpiint/con_u']:
+            g2.add(l, deps=deps(l, 'mpiint/scal_fpts_unpack'))
+
+        # Compute the transformed gradient of the corrected solution
+        g2.add_all(k['eles/tgradcoru_upts'], deps=k['mpiint/con_u'])
+
+        # Obtain the physical gradients at the solution points
+        for l in k['eles/gradcoru_upts_curved']:
+            g2.add(l, deps=deps(l, 'eles/tgradcoru_upts'))
+        for l in k['eles/gradcoru_upts_linear']:
+            g2.add(l, deps=deps(l, 'eles/tgradcoru_upts'))
+
+        # Interpolate these gradients to the flux points
+        for l in k['eles/gradcoru_fpts']:
+            ldeps = deps(l, 'eles/gradcoru_upts_curved',
+                         'eles/gradcoru_upts_linear')
+            g2.add(l, deps=ldeps)
+
+        # Pack and send these interpolated gradients to our neighbours
+        g2.add_all(k['mpiint/vect_fpts_pack'], deps=k['eles/gradcoru_fpts'])
+        for send, pack in zip(m['vect_fpts_send'], k['mpiint/vect_fpts_pack']):
+            g2.add_mpi_req(send, deps=[pack])
+
+        # Compute the common normal flux at our internal/boundary interfaces
+        g2.add_all(k['iint/comm_flux'],
+                   deps=k['eles/gradcoru_fpts'] + k['mpiint/vect_fpts_pack'])
+        g2.add_all(k['bcint/comm_flux'], deps=k['eles/gradcoru_fpts'])
+
+        # Interpolate the gradients to the quadrature points
+        for l in k['eles/gradcoru_qpts']:
+            ldeps = deps(l, 'eles/gradcoru_upts_curved',
+                         'eles/gradcoru_upts_linear')
+            g2.add(l, deps=ldeps + k['mpiint/vect_fpts_pack'])
+
+        # Interpolate the solution to the quadrature points
+        g2.add_all(k['eles/qptsu'])
+
+        # Compute the transformed flux
+        for l in k['eles/tdisf_curved'] + k['eles/tdisf_linear']:
+            if k['eles/qptsu']:
+                ldeps = deps(l, 'eles/gradcoru_qpts', 'eles/qptsu')
+            else:
+                ldeps = deps(l, 'eles/gradcoru_fpts')
+            g2.add(l, deps=ldeps)
+
+        # Compute the transformed divergence of the partially corrected flux
+        for l in k['eles/tdivtpcorf']:
+            g2.add(l, deps=deps(l, 'eles/tdisf_curved', 'eles/tdisf_linear'))
         g2.commit()
 
         g3 = self.backend.graph()
-        g3.add_all(k['mpiint/scal_fpts_unpack'])
-        g3.add_all(k['mpiint/con_u'], deps=k['mpiint/scal_fpts_unpack'])
-        g3.add_all(k['eles/tgradcoru_upts'], deps=k['mpiint/con_u'])
-        for l in k['eles/gradcoru_upts_curved']:
-            g3.add(l, deps=edeps(l, 'tgradcoru_upts'))
-        for l in k['eles/gradcoru_upts_linear']:
-            g3.add(l, deps=edeps(l, 'tgradcoru_upts'))
-        for l in k['eles/gradcoru_fpts']:
-            deps = edeps(l, 'gradcoru_upts_curved', 'gradcoru_upts_linear')
-            g3.add(l, deps=deps)
-        g3.add_all(k['mpiint/vect_fpts_pack'], deps=k['eles/gradcoru_fpts'])
+
+        # Compute the common normal flux at our MPI interfaces
+        g3.add_all(k['mpiint/artvisc_fpts_unpack'])
+        g3.add_all(k['mpiint/vect_fpts_unpack'])
+        for l in k['mpiint/comm_flux']:
+            ldeps = deps(l, 'mpiint/artvisc_fpts_unpack',
+                         'mpiint/vect_fpts_unpack')
+            g3.add(l, deps=ldeps)
+
+        # Compute the transformed divergence of the corrected flux
+        g3.add_all(k['eles/tdivtconf'], deps=k['mpiint/comm_flux'])
+
+        # Obtain the physical divergence of the corrected flux
+        for l in k['eles/negdivconf']:
+            g3.add(l, deps=deps(l, 'eles/tdivtconf'))
         g3.commit()
 
-        g4 = self.backend.graph()
-        g4.add_all(k['mpiint/artvisc_fpts_unpack'])
-        g4.add_all(k['iint/comm_flux'])
-        g4.add_all(k['bcint/comm_flux'])
-        g4.add_all(k['eles/gradcoru_qpts'])
-        g4.add_all(k['eles/qptsu'])
-        for l in k['eles/tdisf_curved']:
-            g4.add(l, deps=edeps(l, 'gradcoru_qpts', 'qptsu'))
-        for l in k['eles/tdisf_linear']:
-            g4.add(l, deps=edeps(l, 'gradcoru_qpts', 'qptsu'))
-        for l in k['eles/tdivtpcorf']:
-            g4.add(l, deps=edeps(l, 'tdisf_curved', 'tdisf_linear'))
-        g4.commit()
-
-        g5 = self.backend.graph()
-        g5.add_all(k['mpiint/vect_fpts_unpack'])
-        g5.add_all(k['mpiint/comm_flux'], deps=k['mpiint/vect_fpts_unpack'])
-        g5.add_all(k['eles/tdivtconf'], deps=k['mpiint/comm_flux'])
-        for l in k['eles/negdivconf']:
-            g5.add(l, deps=edeps(l, 'tdivtconf'))
-        g5.commit()
-
-        return [
-            (g1, None),
-            (g2, m['scal_fpts_send_recv']),
-            (g3, m['artvisc_fpts_send_recv']),
-            (g4, m['vect_fpts_send_recv']),
-            (g5, None)
-        ]
+        return g1, g2, g3
 
     @memoize
     def _compute_grads_graph(self, uinbank):
         m = self._mpireqs
         k, _ = self._get_kernels(uinbank, None)
 
-        def edeps(ek, *edeps): return self._ele_deps(k, ek, *edeps)
+        def deps(dk, *names): return self._kdeps(k, dk, *names)
 
         g1 = self.backend.graph()
+        g1.add_mpi_reqs(m['scal_fpts_recv'])
+
+        # Interpolate the solution to the flux points
         g1.add_all(k['eles/disu'])
+
+        # Pack and send these interpolated solutions to our neighbours
         g1.add_all(k['mpiint/scal_fpts_pack'], deps=k['eles/disu'])
+        for send, pack in zip(m['scal_fpts_send'], k['mpiint/scal_fpts_pack']):
+            g1.add_mpi_req(send, deps=[pack])
+
+        # Compute the common solution at our internal/boundary interfaces
+        g1.add_all(k['iint/copy_fpts'], deps=k['eles/disu'])
+        g1.add_all(k['iint/con_u'], deps=k['iint/copy_fpts'])
+        g1.add_all(k['bcint/con_u'], deps=k['iint/copy_fpts'])
+
+        # Compute the transformed gradient of the partially corrected solution
+        g1.add_all(k['eles/tgradpcoru_upts'])
         g1.commit()
 
         g2 = self.backend.graph()
-        g2.add_all(k['iint/copy_fpts'])
-        g2.add_all(k['iint/con_u'], deps=k['iint/copy_fpts'])
-        g2.add_all(k['bcint/con_u'], deps=k['iint/copy_fpts'])
-        g2.add_all(k['eles/tgradpcoru_upts'])
+
+        # Compute the common solution at our MPI interfaces
+        g2.add_all(k['mpiint/scal_fpts_unpack'])
+        for l in k['mpiint/con_u']:
+            g2.add(l, deps=deps(l, 'mpiint/scal_fpts_unpack'))
+
+        # Compute the transformed gradient of the corrected solution
+        g2.add_all(k['eles/tgradcoru_upts'], deps=k['mpiint/con_u'])
+
+        # Obtain the physical gradients at the solution points
+        for l in k['eles/gradcoru_upts_curved']:
+            g2.add(l, deps=deps(l, 'eles/tgradcoru_upts'))
+        for l in k['eles/gradcoru_upts_linear']:
+            g2.add(l, deps=deps(l, 'eles/tgradcoru_upts'))
         g2.commit()
 
-        g3 = self.backend.graph()
-        g3.add_all(k['mpiint/scal_fpts_unpack'])
-        g3.add_all(k['mpiint/con_u'], deps=k['mpiint/scal_fpts_unpack'])
-        g3.add_all(k['eles/tgradcoru_upts'], deps=k['mpiint/con_u'])
-        for l in k['eles/gradcoru_upts_curved']:
-            g3.add(l, deps=edeps(l, 'tgradcoru_upts'))
-        for l in k['eles/gradcoru_upts_linear']:
-            g3.add(l, deps=edeps(l, 'tgradcoru_upts'))
-        g3.commit()
-
-        return [(g1, None), (g2, m['scal_fpts_send_recv']), (g3, None)]
+        return g1, g2

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -5,78 +5,73 @@ from pyfr.solvers.baseadvec import BaseAdvectionSystem
 
 class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
     def rhs(self, t, uinbank, foutbank):
-        q = self._queue
-        kernels = self._get_kernels(uinbank, foutbank)
+        run = self.backend.run
+        kernels = self._prepare_kernels(t, uinbank, foutbank)
         mpireqs = self._mpireqs
 
-        for b in self._bc_inters:
-            b.prepare(t)
+        k = []
+        k += kernels['eles/disu']
+        k += kernels['mpiint/scal_fpts_pack']
+        run(k)
 
-        q.enqueue(kernels['eles/disu'])
-        q.enqueue(kernels['mpiint/scal_fpts_pack'])
-        q.run()
+        k = []
+        k += kernels['eles/copy_soln']
+        k += kernels['iint/copy_fpts']
+        k += kernels['iint/con_u']
+        k += kernels['bcint/con_u']
+        k += kernels['eles/shocksensor']
+        k += kernels['mpiint/artvisc_fpts_pack']
+        k += kernels['eles/tgradpcoru_upts']
+        run(k, mpireqs['scal_fpts_send_recv'])
 
-        if 'eles/copy_soln' in kernels:
-            q.enqueue(kernels['eles/copy_soln'])
-        if 'iint/copy_fpts' in kernels:
-            q.enqueue(kernels['iint/copy_fpts'])
-        q.enqueue(kernels['iint/con_u'])
-        q.enqueue(kernels['bcint/con_u'], t=t)
-        if 'eles/shocksensor' in kernels:
-            q.enqueue(kernels['eles/shocksensor'])
-            q.enqueue(kernels['mpiint/artvisc_fpts_pack'])
-        q.enqueue(kernels['eles/tgradpcoru_upts'])
-        q.run(mpireqs['scal_fpts_send_recv'])
+        k = []
+        k += kernels['mpiint/scal_fpts_unpack']
+        k += kernels['mpiint/con_u']
+        k += kernels['eles/tgradcoru_upts']
+        k += kernels['eles/gradcoru_upts_curved']
+        k += kernels['eles/gradcoru_upts_linear']
+        k += kernels['eles/gradcoru_fpts']
+        k += kernels['mpiint/vect_fpts_pack']
+        run(k, mpireqs['artvisc_fpts_send_recv'])
 
-        q.enqueue(kernels['mpiint/scal_fpts_unpack'])
-        q.enqueue(kernels['mpiint/con_u'])
-        q.enqueue(kernels['eles/tgradcoru_upts'])
-        q.enqueue(kernels['eles/gradcoru_upts_curved'])
-        q.enqueue(kernels['eles/gradcoru_upts_linear'])
-        q.enqueue(kernels['eles/gradcoru_fpts'])
-        q.enqueue(kernels['mpiint/vect_fpts_pack'])
-        q.run(mpireqs['artvisc_fpts_send_recv'])
+        k = []
+        k += kernels['mpiint/artvisc_fpts_unpack']
+        k += kernels['eles/gradcoru_qpts']
+        k += kernels['eles/qptsu']
+        k += kernels['eles/tdisf_curved']
+        k += kernels['eles/tdisf_linear']
+        k += kernels['eles/tdivtpcorf']
+        k += kernels['iint/comm_flux']
+        k += kernels['bcint/comm_flux']
+        run(k, mpireqs['vect_fpts_send_recv'])
 
-        if 'eles/shockvar' in kernels:
-            q.enqueue(kernels['mpiint/artvisc_fpts_unpack'])
-        if 'eles/gradcoru_qpts' in kernels:
-            q.enqueue(kernels['eles/gradcoru_qpts'])
-            q.enqueue(kernels['eles/qptsu'])
-        q.enqueue(kernels['eles/tdisf_curved'])
-        q.enqueue(kernels['eles/tdisf_linear'])
-        q.enqueue(kernels['eles/tdivtpcorf'])
-        q.enqueue(kernels['iint/comm_flux'])
-        q.enqueue(kernels['bcint/comm_flux'], t=t)
-        q.run(mpireqs['vect_fpts_send_recv'])
-
-        q.enqueue(kernels['mpiint/vect_fpts_unpack'])
-        q.enqueue(kernels['mpiint/comm_flux'])
-        q.enqueue(kernels['eles/tdivtconf'])
-        q.enqueue(kernels['eles/negdivconf'], t=t)
-        q.run()
+        k = []
+        k += kernels['mpiint/vect_fpts_unpack']
+        k += kernels['mpiint/comm_flux']
+        k += kernels['eles/tdivtconf']
+        k += kernels['eles/negdivconf']
+        run(k)
 
     def compute_grads(self, t, uinbank):
-        q = self._queue
-        kernels = self._get_kernels(uinbank, None)
+        run = self.backend.run
+        kernels = self._prepare_kernels(t, uinbank, None)
         mpireqs = self._mpireqs
 
-        for b in self._bc_inters:
-            b.prepare(t)
+        k = []
+        k += kernels['eles/disu']
+        k += kernels['mpiint/scal_fpts_pack']
+        run(k)
 
-        q.enqueue(kernels['eles/disu'])
-        q.enqueue(kernels['mpiint/scal_fpts_pack'])
-        q.run()
+        k = []
+        k += kernels['iint/copy_fpts']
+        k += kernels['iint/con_u']
+        k += kernels['bcint/con_u']
+        k += kernels['eles/tgradpcoru_upts']
+        run(k, mpireqs['scal_fpts_send_recv'])
 
-        if 'iint/copy_fpts' in kernels:
-            q.enqueue(kernels['iint/copy_fpts'])
-        q.enqueue(kernels['iint/con_u'])
-        q.enqueue(kernels['bcint/con_u'], t=t)
-        q.enqueue(kernels['eles/tgradpcoru_upts'])
-        q.run(mpireqs['scal_fpts_send_recv'])
-
-        q.enqueue(kernels['mpiint/scal_fpts_unpack'])
-        q.enqueue(kernels['mpiint/con_u'])
-        q.enqueue(kernels['eles/tgradcoru_upts'])
-        q.enqueue(kernels['eles/gradcoru_upts_curved'])
-        q.enqueue(kernels['eles/gradcoru_upts_linear'])
-        q.run()
+        k += kernels['mpiint/scal_fpts_unpack']
+        k += kernels['mpiint/con_u']
+        k += kernels['eles/tgradcoru_upts']
+        k += kernels['eles/gradcoru_upts_curved']
+        k += kernels['eles/gradcoru_upts_linear']
+        run(k)

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -1,77 +1,103 @@
 # -*- coding: utf-8 -*-
 
 from pyfr.solvers.baseadvec import BaseAdvectionSystem
+from pyfr.util import memoize
 
 
 class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
-    def rhs(self, t, uinbank, foutbank):
-        run = self.backend.run
-        kernels = self._prepare_kernels(t, uinbank, foutbank)
-        mpireqs = self._mpireqs
+    @memoize
+    def _rhs_graphs(self, uinbank, foutbank):
+        m = self._mpireqs
+        k, _ = self._get_kernels(uinbank, foutbank)
 
-        k = []
-        k += kernels['eles/disu']
-        k += kernels['mpiint/scal_fpts_pack']
-        run(k)
+        def edeps(ek, *edeps): return self._ele_deps(k, ek, *edeps)
 
-        k = []
-        k += kernels['eles/copy_soln']
-        k += kernels['iint/copy_fpts']
-        k += kernels['iint/con_u']
-        k += kernels['bcint/con_u']
-        k += kernels['eles/shocksensor']
-        k += kernels['mpiint/artvisc_fpts_pack']
-        k += kernels['eles/tgradpcoru_upts']
-        run(k, mpireqs['scal_fpts_send_recv'])
+        g1 = self.backend.graph()
+        g1.add_all(k['eles/disu'])
+        g1.add_all(k['mpiint/scal_fpts_pack'], deps=k['eles/disu'])
+        g1.commit()
 
-        k = []
-        k += kernels['mpiint/scal_fpts_unpack']
-        k += kernels['mpiint/con_u']
-        k += kernels['eles/tgradcoru_upts']
-        k += kernels['eles/gradcoru_upts_curved']
-        k += kernels['eles/gradcoru_upts_linear']
-        k += kernels['eles/gradcoru_fpts']
-        k += kernels['mpiint/vect_fpts_pack']
-        run(k, mpireqs['artvisc_fpts_send_recv'])
+        g2 = self.backend.graph()
+        g2.add_all(k['eles/copy_soln'])
+        g2.add_all(k['iint/copy_fpts'])
+        g2.add_all(k['iint/con_u'], deps=k['iint/copy_fpts'])
+        g2.add_all(k['bcint/con_u'], deps=k['iint/copy_fpts'])
+        g2.add_all(k['eles/shocksensor'])
+        g2.add_all(k['mpiint/artvisc_fpts_pack'], deps=k['eles/shocksensor'])
+        g2.add_all(k['eles/tgradpcoru_upts'])
+        g2.commit()
 
-        k = []
-        k += kernels['mpiint/artvisc_fpts_unpack']
-        k += kernels['eles/gradcoru_qpts']
-        k += kernels['eles/qptsu']
-        k += kernels['eles/tdisf_curved']
-        k += kernels['eles/tdisf_linear']
-        k += kernels['eles/tdivtpcorf']
-        k += kernels['iint/comm_flux']
-        k += kernels['bcint/comm_flux']
-        run(k, mpireqs['vect_fpts_send_recv'])
+        g3 = self.backend.graph()
+        g3.add_all(k['mpiint/scal_fpts_unpack'])
+        g3.add_all(k['mpiint/con_u'], deps=k['mpiint/scal_fpts_unpack'])
+        g3.add_all(k['eles/tgradcoru_upts'], deps=k['mpiint/con_u'])
+        for l in k['eles/gradcoru_upts_curved']:
+            g3.add(l, deps=edeps(l, 'tgradcoru_upts'))
+        for l in k['eles/gradcoru_upts_linear']:
+            g3.add(l, deps=edeps(l, 'tgradcoru_upts'))
+        for l in k['eles/gradcoru_fpts']:
+            deps = edeps(l, 'gradcoru_upts_curved', 'gradcoru_upts_linear')
+            g3.add(l, deps=deps)
+        g3.add_all(k['mpiint/vect_fpts_pack'], deps=k['eles/gradcoru_fpts'])
+        g3.commit()
 
-        k = []
-        k += kernels['mpiint/vect_fpts_unpack']
-        k += kernels['mpiint/comm_flux']
-        k += kernels['eles/tdivtconf']
-        k += kernels['eles/negdivconf']
-        run(k)
+        g4 = self.backend.graph()
+        g4.add_all(k['mpiint/artvisc_fpts_unpack'])
+        g4.add_all(k['iint/comm_flux'])
+        g4.add_all(k['bcint/comm_flux'])
+        g4.add_all(k['eles/gradcoru_qpts'])
+        g4.add_all(k['eles/qptsu'])
+        for l in k['eles/tdisf_curved']:
+            g4.add(l, deps=edeps(l, 'gradcoru_qpts', 'qptsu'))
+        for l in k['eles/tdisf_linear']:
+            g4.add(l, deps=edeps(l, 'gradcoru_qpts', 'qptsu'))
+        for l in k['eles/tdivtpcorf']:
+            g4.add(l, deps=edeps(l, 'tdisf_curved', 'tdisf_linear'))
+        g4.commit()
 
-    def compute_grads(self, t, uinbank):
-        run = self.backend.run
-        kernels = self._prepare_kernels(t, uinbank, None)
-        mpireqs = self._mpireqs
+        g5 = self.backend.graph()
+        g5.add_all(k['mpiint/vect_fpts_unpack'])
+        g5.add_all(k['mpiint/comm_flux'], deps=k['mpiint/vect_fpts_unpack'])
+        g5.add_all(k['eles/tdivtconf'], deps=k['mpiint/comm_flux'])
+        for l in k['eles/negdivconf']:
+            g5.add(l, deps=edeps(l, 'tdivtconf'))
+        g5.commit()
 
-        k = []
-        k += kernels['eles/disu']
-        k += kernels['mpiint/scal_fpts_pack']
-        run(k)
+        return [
+            (g1, None),
+            (g2, m['scal_fpts_send_recv']),
+            (g3, m['artvisc_fpts_send_recv']),
+            (g4, m['vect_fpts_send_recv']),
+            (g5, None)
+        ]
 
-        k = []
-        k += kernels['iint/copy_fpts']
-        k += kernels['iint/con_u']
-        k += kernels['bcint/con_u']
-        k += kernels['eles/tgradpcoru_upts']
-        run(k, mpireqs['scal_fpts_send_recv'])
+    @memoize
+    def _compute_grads_graph(self, uinbank):
+        m = self._mpireqs
+        k, _ = self._get_kernels(uinbank, None)
 
-        k += kernels['mpiint/scal_fpts_unpack']
-        k += kernels['mpiint/con_u']
-        k += kernels['eles/tgradcoru_upts']
-        k += kernels['eles/gradcoru_upts_curved']
-        k += kernels['eles/gradcoru_upts_linear']
-        run(k)
+        def edeps(ek, *edeps): return self._ele_deps(k, ek, *edeps)
+
+        g1 = self.backend.graph()
+        g1.add_all(k['eles/disu'])
+        g1.add_all(k['mpiint/scal_fpts_pack'], deps=k['eles/disu'])
+        g1.commit()
+
+        g2 = self.backend.graph()
+        g2.add_all(k['iint/copy_fpts'])
+        g2.add_all(k['iint/con_u'], deps=k['iint/copy_fpts'])
+        g2.add_all(k['bcint/con_u'], deps=k['iint/copy_fpts'])
+        g2.add_all(k['eles/tgradpcoru_upts'])
+        g2.commit()
+
+        g3 = self.backend.graph()
+        g3.add_all(k['mpiint/scal_fpts_unpack'])
+        g3.add_all(k['mpiint/con_u'], deps=k['mpiint/scal_fpts_unpack'])
+        g3.add_all(k['eles/tgradcoru_upts'], deps=k['mpiint/con_u'])
+        for l in k['eles/gradcoru_upts_curved']:
+            g3.add(l, deps=edeps(l, 'tgradcoru_upts'))
+        for l in k['eles/gradcoru_upts_linear']:
+            g3.add(l, deps=edeps(l, 'tgradcoru_upts'))
+        g3.commit()
+
+        return [(g1, None), (g2, m['scal_fpts_send_recv']), (g3, None)]

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from pyfr.backends.base.kernels import MetaKernel
 from pyfr.solvers.baseadvecdiff import (BaseAdvectionDiffusionBCInters,
                                         BaseAdvectionDiffusionIntInters,
                                         BaseAdvectionDiffusionMPIInters)
@@ -28,7 +27,7 @@ class NavierStokesIntInters(TplargsMixin, BaseAdvectionDiffusionIntInters):
         be.pointwise.register('pyfr.solvers.navstokes.kernels.intcflux')
 
         if abs(self.c['ldg-beta']) == 0.5:
-            self.kernels['copy_fpts'] = lambda: MetaKernel(
+            self.kernels['copy_fpts'] = lambda: be.unordered_meta_kernel(
                 [ele.kernels['_copy_fpts']() for ele in elemap.values()]
             )
 

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -26,11 +26,6 @@ class NavierStokesIntInters(TplargsMixin, BaseAdvectionDiffusionIntInters):
         be.pointwise.register('pyfr.solvers.navstokes.kernels.intconu')
         be.pointwise.register('pyfr.solvers.navstokes.kernels.intcflux')
 
-        if abs(self.c['ldg-beta']) == 0.5:
-            self.kernels['copy_fpts'] = lambda: be.unordered_meta_kernel(
-                [ele.kernels['_copy_fpts']() for ele in elemap.values()]
-            )
-
         self.kernels['con_u'] = lambda: be.kernel(
             'intconu', tplargs=self._tplargs, dims=[self.ninterfpts],
             ulin=self._scal_lhs, urin=self._scal_rhs,


### PR DESCRIPTION
This is a WIP PR to migrate PyFR to a task graph interface for scheduling kernels.  Using a task graph opens up opportunities for reducing Python overhead (CUDA, HIP, OpenMP) and enabling parallel execution of kernels (CUDA, HIP, OpenCL).  All of this improves strong scaling.

Most of the code is in place, with the PR itself being blocked on ROCm 5 which has the required graph embedding API (until then only GiMMiK is functional on HIP).