### PR TITLE
[WIP] Support fractional physical time stepping in dual time integrators.

### DIFF
--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import math
-
 from pyfr.integrators.base import BaseIntegrator
 from pyfr.integrators.dual.pseudo import get_pseudo_integrator
 
@@ -50,14 +48,6 @@ class BaseDualIntegrator(BaseIntegrator):
             self._curr_grad_soln = [e.get() for e in system.eles_vect_upts]
 
         return self._curr_grad_soln
-
-    def call_plugin_dt(self, dt):
-        rem = math.fmod(dt, self._dt)
-        tol = 5.0*self.dtmin
-        if rem > tol and (self._dt - rem) > tol:
-            raise ValueError('Plugin call times must be multiples of dt')
-
-        super().call_plugin_dt(dt)
 
     def collect_stats(self, stats):
         super().collect_stats(stats)

--- a/pyfr/integrators/dual/phys/controllers.py
+++ b/pyfr/integrators/dual/phys/controllers.py
@@ -15,8 +15,8 @@ class BaseDualController(BaseDualIntegrator):
             for csh in self.completed_step_handlers:
                 csh(self)
 
-    def _accept_step(self, idxcurr):
-        self.tcurr += self._dt
+    def _accept_step(self, dt, idxcurr):
+        self.tcurr += dt
         self.nacptsteps += 1
         self.nacptchain += 1
 
@@ -49,8 +49,11 @@ class DualNoneController(BaseDualController):
             raise ValueError('Advance time is in the past')
 
         while self.tcurr < t:
+            # Decide on the time step
+            dt = max(min(t - self.tcurr, self._dt), self.dtmin)
+
             # Take the physical step
-            self.step(self.tcurr, self._dt)
+            self.step(self.tcurr, dt)
 
             # We are not adaptive, so accept every step
-            self._accept_step(self.pseudointegrator._idxcurr)
+            self._accept_step(dt, self.pseudointegrator._idxcurr)

--- a/pyfr/integrators/dual/phys/steppers.py
+++ b/pyfr/integrators/dual/phys/steppers.py
@@ -29,11 +29,11 @@ class BaseDIRKStepper(BaseDualStepper):
             self.pseudointegrator.init_stage(s, sc, dt)
             self.pseudointegrator.pseudo_advance(t + dt*tc)
 
-        self._finalize_step()
+        self._finalize_step(dt)
 
-    def _finalize_step(self):
+    def _finalize_step(self, dt):
         if not self.fsal:
-            bcoeffs = [bt*self._dt for bt in self.b]
+            bcoeffs = [bt*dt for bt in self.b]
             self.pseudointegrator.obtain_solution(bcoeffs)
 
         self.pseudointegrator.store_current_soln()


### PR DESCRIPTION
With the new DIRK steppers we are no longer forced to take a fixed time step in dual time steppers for the outer physical dt.

This commit enables fractional dt when necessary, but I had convergence problems when taking a fractional step.

One possibility is that there is a bug in the current commit. Please take a look and let me know if you realize where the bug is.

Other thing is, we know that it is better to use a dt that maximizes dt/dtau ratio. In certain cases dt may get too close to the dtau, and this will definitely affect the convergence very badly. Apart from solving the bug if there is any, we need to find a solution to maintain a reasonable dt/dtau ratio when changing the timestep as the simulation goes on.