### PR TITLE
Elide some kernels at p = 0.

### DIFF
--- a/pyfr/solvers/aceuler/elements.py
+++ b/pyfr/solvers/aceuler/elements.py
@@ -35,6 +35,10 @@ class ACEulerElements(BaseACFluidElements, BaseAdvectionElements):
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)
 
+        # Can elide interior flux calculations at p = 0
+        if self.basis.order == 0:
+            return
+
         # Register our flux kernels
         self._be.pointwise.register('pyfr.solvers.aceuler.kernels.tflux')
         self._be.pointwise.register('pyfr.solvers.aceuler.kernels.tfluxlin')

--- a/pyfr/solvers/acnavstokes/elements.py
+++ b/pyfr/solvers/acnavstokes/elements.py
@@ -13,6 +13,10 @@ class ACNavierStokesElements(BaseACFluidElements,
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)
 
+        # Can elide interior flux calculations at p = 0
+        if self.basis.order == 0:
+            return
+
         # Register our flux kernels
         kprefix = 'pyfr.solvers.acnavstokes.kernels'
         self._be.pointwise.register(f'{kprefix}.tflux')

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -47,19 +47,19 @@ class BaseAdvectionElements(BaseElements):
             out=self._scal_fpts
         )
 
-        if fluxaa:
+        if fluxaa and self.basis.order > 0:
             kernels['qptsu'] = lambda uin: self._be.kernel(
                 'mul', self.opmat('M7'), self.scal_upts[uin],
                 out=self._scal_qpts
             )
 
         # First flux correction kernel
-        if fluxaa:
+        if fluxaa and self.basis.order > 0:
             kernels['tdivtpcorf'] = lambda fout: self._be.kernel(
                 'mul', self.opmat('(M1 - M3*M2)*M9'), self._vect_qpts,
                 out=self.scal_upts[fout]
             )
-        else:
+        elif self.basis.order > 0:
             kernels['tdivtpcorf'] = lambda fout: self._be.kernel(
                 'mul', self.opmat('M1 - M3*M2'), self._vect_upts,
                 out=self.scal_upts[fout]
@@ -68,7 +68,7 @@ class BaseAdvectionElements(BaseElements):
         # Second flux correction kernel
         kernels['tdivtconf'] = lambda fout: self._be.kernel(
             'mul', self.opmat('M3'), self._scal_fpts,
-            out=self.scal_upts[fout], beta=1.0
+            out=self.scal_upts[fout], beta=float(self.basis.order > 0)
         )
 
         # Transformed to physical divergence kernel + source term

--- a/pyfr/solvers/baseadvecdiff/elements.py
+++ b/pyfr/solvers/baseadvecdiff/elements.py
@@ -35,13 +35,14 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
         self.kernels['_copy_fpts'] = lambda: kernel(
             'copy', self._vect_fpts.slice(0, self.nfpts), self._scal_fpts
         )
-        self.kernels['tgradpcoru_upts'] = lambda uin: kernel(
-            'mul', self.opmat('M4 - M6*M0'), self.scal_upts[uin],
-            out=self._vect_upts
-        )
+        if self.basis.order > 0:
+            self.kernels['tgradpcoru_upts'] = lambda uin: kernel(
+                'mul', self.opmat('M4 - M6*M0'), self.scal_upts[uin],
+                out=self._vect_upts
+            )
         self.kernels['tgradcoru_upts'] = lambda: kernel(
             'mul', self.opmat('M6'), self._vect_fpts.slice(0, self.nfpts),
-            out=self._vect_upts, beta=1.0
+            out=self._vect_upts, beta=float(self.basis.order > 0)
         )
 
         # Template arguments for the physical gradient kernel
@@ -83,7 +84,7 @@ class BaseAdvectionDiffusionElements(BaseAdvectionElements):
 
         self.kernels['gradcoru_fpts'] = gradcoru_fpts
 
-        if 'flux' in self.antialias:
+        if 'flux' in self.antialias and self.basis.order > 0:
             def gradcoru_qpts():
                 nupts, nqpts = self.nupts, self.nqpts
                 vupts, vqpts = self._vect_upts, self._vect_qpts

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -54,6 +54,10 @@ class EulerElements(BaseFluidElements, BaseAdvectionElements):
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)
 
+        # Can elide interior flux calculations at p = 0
+        if self.basis.order == 0:
+            return
+
         # Register our flux kernels
         self._be.pointwise.register('pyfr.solvers.euler.kernels.tflux')
         self._be.pointwise.register('pyfr.solvers.euler.kernels.tfluxlin')

--- a/pyfr/solvers/navstokes/elements.py
+++ b/pyfr/solvers/navstokes/elements.py
@@ -33,6 +33,10 @@ class NavierStokesElements(BaseFluidElements, BaseAdvectionDiffusionElements):
     def set_backend(self, *args, **kwargs):
         super().set_backend(*args, **kwargs)
 
+        # Can elide interior flux calculations at p = 0
+        if self.basis.order == 0:
+            return
+
         # Register our flux kernels
         self._be.pointwise.register('pyfr.solvers.navstokes.kernels.tflux')
         self._be.pointwise.register('pyfr.solvers.navstokes.kernels.tfluxlin')


### PR DESCRIPTION
This avoids some matrix multiplication operators where A = 0, which causes issues for libxsmm.  It also results in a very slight reduction in overhead, as we now run fewer kernels at p = 0.