### PR TITLE
Change controller parameters for std time stepping

### DIFF
--- a/pyfr/integrators/std/controllers.py
+++ b/pyfr/integrators/std/controllers.py
@@ -105,8 +105,8 @@ class StdPIController(BaseStdController):
             raise ValueError('Invalid error norm')
 
         # PI control values
-        self._alpha = self.cfg.getfloat(sect, 'pi-alpha', 0.7)
-        self._beta = self.cfg.getfloat(sect, 'pi-beta', 0.4)
+        self._alpha = self.cfg.getfloat(sect, 'pi-alpha', 0.58)
+        self._beta = self.cfg.getfloat(sect, 'pi-beta', 0.42)
 
         # Estimate of previous error
         self._errprev = 1.0


### PR DESCRIPTION
Parameters alpha, beta are changed for the standard controller. New default for alpha is 0.58, and beta is 0.42. Previous defaults for alpha and beta were 0.7 and 0.4 respectively. I am attaching a file that compares the improvements observed by changing values of alpha, beta


[controller_benchmark.xlsx](https://github.com/PyFR/PyFR/files/9133434/controller_benchmark.xlsx)
