### PR TITLE
HIP Graph Support

### DIFF
--- a/doc/src/installation.rst
+++ b/doc/src/installation.rst
@@ -115,7 +115,7 @@ required.
 CUDA Backend
 ^^^^^^^^^^^^
 
-The CUDA backend targets NVIDIA GPUs with a compute capability of 3.0
+The CUDA backend targets NVIDIA GPUs with a compute capability of 3.5
 or greater. The backend requires:
 
 #. `CUDA <https://developer.nvidia.com/cuda-downloads>`_ >= 11.4
@@ -126,7 +126,7 @@ HIP Backend
 The HIP backend targets AMD GPUs which are supported by the ROCm stack.
 The backend requires:
 
-#. `ROCm <https://docs.amd.com/>`_ >= 6.0.0
+#. `ROCm <https://docs.amd.com/>`_ >= 6.4.1
 #. `rocBLAS <https://github.com/ROCmSoftwarePlatform/rocBLAS>`_ >=
    4.0.0
 

--- a/pyfr/backends/hip/blasext.py
+++ b/pyfr/backends/hip/blasext.py
@@ -48,7 +48,7 @@ class HIPBlasExtKernels(HIPKernelProvider):
 
         class CopyKernel(HIPKernel):
             def add_to_graph(self, graph, deps):
-                pass
+                return graph.graph.add_memcpy(dst, src, dst.nbytes, deps)
 
             def run(self, stream):
                 hip.memcpy(dst, src, dst.nbytes, stream)

--- a/pyfr/backends/hip/driver.py
+++ b/pyfr/backends/hip/driver.py
@@ -137,6 +137,19 @@ class HIPWrappers(LibWrapper):
         (c_int, 'hipGraphLaunch', c_void_p, c_void_p)
     ]
 
+    def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            version = c_int()
+            self.hipRuntimeGetVersion(version)
+
+            major, rem = divmod(version.value, 10000000)
+            minor, patch = divmod(rem, 100000)
+
+            if (major, minor, patch) < (6, 4, 1):
+                raise RuntimeError(f'HIP version {major}.{minor}.{patch} '
+                                   '< 6.4.1')
+
     def _transname(self, name):
         return name.removesuffix('R0600')
 

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -109,7 +109,7 @@ class HIPGiMMiKKernels(HIPKernelProvider):
 
         class MulKernel(HIPKernel):
             def add_to_graph(self, graph, deps):
-                pass
+                return graph.graph.add_kernel(params, deps)
 
             def run(self, stream):
                 kern.exec_async(stream, params)

--- a/pyfr/backends/hip/packing.py
+++ b/pyfr/backends/hip/packing.py
@@ -32,7 +32,7 @@ class HIPPackingKernels(HIPKernelProvider):
         if self.backend.mpitype == 'hip-aware':
             class PackXchgViewKernel(HIPKernel):
                 def add_to_graph(self, graph, deps):
-                    pass
+                    return graph.graph.add_kernel(params, deps)
 
                 def run(self, stream):
                     kern.exec_async(stream, params)
@@ -40,7 +40,10 @@ class HIPPackingKernels(HIPKernelProvider):
         else:
             class PackXchgViewKernel(HIPKernel):
                 def add_to_graph(self, graph, deps):
-                    pass
+                    gpack = graph.graph.add_kernel(params, deps)
+                    return graph.graph.add_memcpy(
+                        m.hdata, m.data, m.nbytes, [gpack]
+                    )
 
                 def run(self, stream):
                     kern.exec_async(stream, params)
@@ -56,7 +59,8 @@ class HIPPackingKernels(HIPKernelProvider):
         else:
             class UnpackXchgMatrixKernel(HIPKernel):
                 def add_to_graph(self, graph, deps):
-                    pass
+                    return graph.graph.add_memcpy(mv.data, mv.hdata, mv.nbytes,
+                                                  deps)
 
                 def run(self, stream):
                     hip.memcpy(mv.data, mv.hdata, mv.nbytes, stream)

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -22,12 +22,16 @@ class HIPKernel(Kernel):
 
 class HIPOrderedMetaKernel(BaseOrderedMetaKernel):
     def add_to_graph(self, graph, dnodes):
-        pass
+        for k in self.kernels:
+            dnodes = [k.add_to_graph(graph, dnodes)]
 
+        return dnodes[0]
 
 class HIPUnorderedMetaKernel(BaseUnorderedMetaKernel):
     def add_to_graph(self, graph, dnodes):
-        pass
+        nodes = [k.add_to_graph(graph, dnodes) for k in self.kernels]
+
+        return graph.graph.add_empty(nodes)
 
 
 class HIPKernelProvider(BaseKernelProvider):
@@ -88,8 +92,19 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
                     for i, k in rtargs:
                         params.set_arg(i, kwargs[k])
 
+                    # Notify any graphs we're in about our new parameters
+                    for graph, gnode in self.gnodes.items():
+                        graph.stale_kparams[gnode] = params
+
             def add_to_graph(self, graph, deps):
-                pass
+                gnode = graph.graph.add_kernel(params, deps)
+
+                # If our parameters can change then we need to keep a
+                # (weak) reference to the graph so we can notify it
+                if rtargs:
+                    self.gnodes[graph] = gnode
+
+                return gnode
 
             def run(self, stream):
                 fun.exec_async(stream, params)


### PR DESCRIPTION
This PR adds full support for HIP graphs, bringing the HIP backend on par with the CUDA backend.  However, whereas for simple test cases overhead decreased by a factor of ~2 when moving to graphs, for HIP overhead increases by ~2.  The performance impact for non-trivial cases still needs to be assessed, however.