### PR TITLE
Added command line interface to plugins

### DIFF
--- a/doc/src/cli.rst
+++ b/doc/src/cli.rst
@@ -65,3 +65,11 @@ Plugin Commands
 Plugins are able to define tools that are accessible from the command line,
 below are listed the the various options currently available.
 
+Time Average
+^^^^^^^^^^^^
+
+1. ``pyfr tavg merge`` --- merge together multiple time average files into a
+   single time average file. The averaging times are read from the file and do
+   not need to be evenly spaced in time. Example::
+
+        pyfr tavg merge avg-1.00.pyfrs avg-2.00.pyfrs avg-10.00.pyfrs merged_avg.pyfrs

--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -120,6 +120,9 @@ class Inifile:
 
         return iv
 
+    def remove_option(self, section, option):
+        self._cp.remove_option(section, option)
+
     def sections(self):
         return self._cp.sections()
 

--- a/pyfr/plugins/__init__.py
+++ b/pyfr/plugins/__init__.py
@@ -9,7 +9,7 @@ from pyfr.plugins.pseudostats import PseudoStatsPlugin
 from pyfr.plugins.residual import ResidualPlugin
 from pyfr.plugins.sampler import SamplerPlugin
 from pyfr.plugins.source import SourcePlugin
-from pyfr.plugins.tavg import TavgPlugin
+from pyfr.plugins.tavg import TavgCLIPlugin, TavgPlugin
 from pyfr.plugins.writer import WriterPlugin
 from pyfr.util import subclass_where
 

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -1,3 +1,4 @@
+import functools as ft
 import re
 import shlex
 
@@ -6,6 +7,15 @@ from pytools import prefork
 
 from pyfr.mpiutil import get_comm_rank_root
 from pyfr.regions import BoundaryRegion, ConstructiveRegion
+
+
+def cli_external(meth):
+    @ft.wraps(meth)
+    def newmeth(cls, args):
+        obj = cls(args)
+        return meth(obj)
+
+    return classmethod(newmeth)
 
 
 def init_csv(cfg, cfgsect, header, *, filekey='file', headerkey='header'):

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -1,12 +1,17 @@
+from collections import defaultdict
 import re
 
+import h5py
 import numpy as np
 
 from pyfr.inifile import Inifile
 from pyfr.mpiutil import get_comm_rank_root, mpi
 from pyfr.nputil import npeval
-from pyfr.plugins.base import BaseSolnPlugin, PostactionMixin, RegionMixin
+from pyfr.plugins.base import (BaseSolnPlugin, BaseCLIPlugin, cli_external,
+                               PostactionMixin, RegionMixin)
+from pyfr.readers import NativeReader
 from pyfr.writers.native import NativeWriter
+from pyfr.util import merge_intervals
 
 
 class TavgPlugin(PostactionMixin, RegionMixin, BaseSolnPlugin):
@@ -104,7 +109,7 @@ class TavgPlugin(PostactionMixin, RegionMixin, BaseSolnPlugin):
                 self.outfields.append(f'std-{k[4:]}')
 
             for k in cfg.items(cfgsect, prefix='fun-avg-'):
-                self.outfields.append(f'fun-std-{k[4:]}')
+                self.outfields.append(f'std-fun-{k[4:]}')
 
     def _init_gradients(self):
         # Determine what gradients, if any, are required
@@ -357,3 +362,250 @@ class TavgPlugin(PostactionMixin, RegionMixin, BaseSolnPlugin):
                     self.tstart_acc = intg.tcurr
 
                 self.tout_last = intg.tcurr
+
+
+class TavgCLIPlugin(BaseCLIPlugin):
+    name = 'tavg'
+
+    @classmethod
+    def add_cli(cls, parser):
+        cmd = cls.name
+        cp = parser.add_parser(cmd, help=f'{cmd} --help')
+        sp = cp.add_subparsers(dest='sub_cmd')
+
+        # Merge command
+        ssp = sp.add_parser('merge', help=f'{cmd} merge --help')
+        ssp.set_defaults(process=cls.merge_cli)
+        ssp.add_argument('solns', nargs='*', help='Averages to merge')
+        ssp.add_argument('output', help='Output file name')
+
+    @cli_external
+    def merge_cli(self):
+        # Open all the solution files
+        self._prepare_files(self.args.solns)
+
+        # Initialise things needed for the merge
+        self._init_tavg_merge()
+
+        with h5py.File(self.args.output, 'w') as outf:
+            # Merge the averages and stds
+            self._merge_data(outf)
+
+            # Merge the metadata
+            self._merge_meta(outf)
+
+    def _eval_fun_exprs(self, avars):
+        # Prepare the substitution dictionary
+        subs = dict(zip(self.anames, avars.swapaxes(0, 1)))
+
+        # Evaluate the function and return
+        return np.stack([npeval(v, subs) for v in self.fexprs], axis=1)
+
+    def _eval_fun_var(self, std, avars):
+        dfexpr = []
+
+        # Evaluate the function
+        fexprs = self._eval_fun_exprs(avars)
+
+        for avi in avars.swapaxes(0, 1):
+            # Calculate step size for finite difference
+            h = self.delta_h*np.abs(avi)
+            h[np.where(h == 0)] = self.delta_h
+
+            # Calculate derivatives for functional averages
+            avi += h
+            dfexpr.append((self._eval_fun_exprs(avars) - fexprs) / h[:,None])
+            avi -= h
+
+        # Multiply by variance and take RMS value
+        fv = np.linalg.norm(np.array(dfexpr)*std.swapaxes(0, 1)[:,:,None],
+                            axis=0)
+        return fexprs, fv
+
+    def _init_tavg_merge(self):
+        self.delta_h = np.finfo(np.float64).eps**0.5
+
+        for i, (file, stats, cfg, dt) in enumerate(self.files):
+            fields = stats.get('data', 'fields').split(',')
+            cfgsect = stats.get('tavg', 'cfg-section')
+
+            # Mapping for expression to sorted list
+            aidx = [i for i, v in enumerate(fields) if v.startswith('avg-')]
+            anames = [fields[i].removeprefix('avg-') for i in aidx]
+            amap = [i for n, i in sorted(zip(anames, aidx),
+                                         key=lambda x: x[0])]
+
+            sidx = [i for i, v in enumerate(fields) if
+                    re.match(r'\bstd-(?!fun-avg-)', v)]
+            snames = [fields[i].removeprefix('std-') for i in sidx]
+            smap = [i for n, i in sorted(zip(snames, sidx),
+                                         key=lambda x: x[0])]
+
+            if i == 0:
+                self.stats, self.cfg = stats, cfg
+
+                prec = cfg.get('backend', 'precision')
+                self.dtype = np.float32() if prec == 'single' else np.float64()
+
+                self.fields = fields
+                self.cfgsect = cfgsect
+                self.region = cfg.get(cfgsect, 'region')
+                self.uuid = file['mesh_uuid']
+
+                self.idxs = [k for k in file if re.search(r'_idxs_p\d+$', k)]
+                self.dkeys = [k for k in file if
+                              re.match(r'tavg_[^\W_]+_p\d+$', k)]
+
+                self.mapping = [(amap, smap)]
+                fnames = [x.removeprefix('fun-avg-') for x in fields if
+                          x.startswith('fun-avg-')]
+                self.anames = sorted(anames)
+                self.fnames = sorted(fnames)
+
+                # Initialise std max and avg registers
+                if self.std_all:
+                    self.std_max,self.std_avg  = np.zeros((2, len(anames)))
+                    self.fstd_max, self.fstd_avg = np.zeros((2, len(fnames)))
+
+                # Build fun avg expressions
+                c = cfg.items_as('constants', float)
+                self.fexprs = [cfg.getexpr(cfgsect, f'fun-avg-{k}', subs=c)
+                               for k in fnames]
+            else:
+                self.mapping.append((amap, smap))
+
+            # Check for compatibility of files
+            if self.uuid != file['mesh_uuid']:
+                raise RuntimeError('Average files computed on different '
+                                   'meshes')
+            if self.region != cfg.get(cfgsect, 'region'):
+                raise RuntimeError('Average files computed on different '
+                                   'regions')
+
+            for k in cfg.items(cfgsect, prefix='avg-'):
+                if cfg.get(cfgsect, k) != self.cfg.get(self.cfgsect, k):
+                    raise RuntimeError('Different average field definitions')
+
+    def _merge_data(self, outf):
+        file0, stats, cfg, dt = self.files[0]
+        amap0, smap0 = self.mapping[0]
+
+        for key in self.dkeys:
+            # Initialise accumulators
+            data = file0[key]
+            avg_acc = np.zeros_like(data[:, amap0])
+            var_acc = np.zeros_like(data[:, smap0])
+
+            # Perform the rest of the accumulations
+            t = 0
+            for files, mapping in zip(self.files, self.mapping):
+                file, stats, cfg, dt = files
+                amap, smap = mapping
+                data = file[key]
+
+                if self.std_all:
+                    var_acc = ((t*var_acc + dt*data[:, smap]**2)/(t + dt) +
+                               dt/(t + dt)**2*(avg_acc - t*data[:, amap])**2)
+                avg_acc += dt*data[:, amap]
+                t += dt
+
+            # Get standard deviation
+            if self.std_all:
+                var_acc = var_acc**0.5
+                np.maximum(self.std_max, np.amax(var_acc, axis=(0, 2)),
+                           out=self.std_max)
+                self.std_avg += np.mean(var_acc, axis=(0, 2))
+
+            # Evaluate function expression and write out
+            if self.fexprs and self.std_all:
+                fun_avg, fun_std = self._eval_fun_var(var_acc, avg_acc)
+                np.maximum(self.fstd_max, np.amax(fun_std, axis=(0, 2)),
+                           out=self.fstd_max)
+                self.fstd_avg += np.mean(fun_std, axis=(0, 2))
+
+                outstack = (avg_acc, fun_avg, var_acc, fun_std)
+            elif self.fexprs:
+                fun_avg = self._eval_fun_exprs(avg_acc)
+                outstack = (avg_acc, fun_avg, var_acc)
+            else:
+                outstack = (avg_acc, var_acc)
+
+            outf[key] = np.hstack(outstack, dtype=self.dtype)
+
+    def _merge_meta(self, outf):
+        cfgsect = self.stats.get('tavg', 'cfg-section')
+        self.stats.set('tavg', 'merged-from', self.merged_from)
+        self.stats.set('tavg', 'range', self.merged_range)
+
+        # If all files have full std stats then these can be writen
+        if self.std_all:
+            self.std_avg = self.std_avg.astype(self.dtype, copy=False)
+            self.std_max = self.std_max.astype(self.dtype, copy=False)
+            for n, avg, max in zip(self.anames, self.std_avg, self.std_max):
+                self.stats.set('tavg', f'avg-std-{n}', avg)
+                self.stats.set('tavg', f'max-std-{n}', max)
+
+            for n, avg, max in zip(self.fnames, self.fstd_avg, self.fstd_max):
+                self.stats.set('tavg', f'avg-std-fun-{n}', avg)
+                self.stats.set('tavg', f'max-std-fun-{n}', max)
+        # Otherwise the std summary has to be removed
+        else:
+            self.cfg.set(cfgsect, 'std-mode', 'none')
+            for opt in self.stats.items('tavg'):
+                if opt.startswith(('avg-std', 'max-std')):
+                    self.stats.remove_option('tavg', opt)
+
+        # Write out the region index data
+        file0, stats, cfg, dt = self.files[0]
+        for k in self.idxs:
+            outf[k] = file0[k]
+
+        # Write re-ordered data fields
+        fields = [f'avg-{x}' for x in self.anames]
+        fields.extend(f'fun-avg-{x}' for x in self.fnames)
+        if self.std_all:
+            fields.extend(f'std-{x}' for x in self.anames)
+            fields.extend(f'std-fun-avg-{x}' for x in self.fnames)
+        self.stats.set('data', 'fields', ','.join(fields))
+
+        # Merge runtime stats
+        sect = 'solver-time-integrator'
+        rt_stats = defaultdict(lambda: [])
+
+        for file, stats, cfg, dt in self.files:
+            for k in self.stats.items(sect):
+                rt_stats[k].append(stats.getliteral(sect, k))
+
+        for k, v in rt_stats.items():
+            self.stats.set(sect, k, v)
+
+        # Write out
+        outf['config'] = self.cfg.tostr()
+        outf['stats'] = self.stats.tostr()
+        outf['mesh_uuid'] = self.uuid
+
+    def _prepare_files(self, filenames):
+        self.files = files = []
+        twindows, std = [], []
+        for filename in filenames:
+            f = NativeReader(filename)
+            stats, cfg = Inifile(f['stats']), Inifile(f['config'])
+            cfgsect = stats.get('tavg', 'cfg-section')
+            std.append(cfg.get(cfgsect, 'std-mode'))
+
+            twind = stats.getliteral('tavg', 'range')
+            twindows.extend(twind)
+            dt = sum(tend - tstart for tstart, tend in twind)
+
+            files.append((f, stats, cfg, dt))
+
+        self.merged_from = twindows
+        self.std_all = all(s == 'all' for s in std)
+
+        try:
+            self.merged_range = merge_intervals(twindows)
+        except ValueError:
+            raise RuntimeError('Overlapping averge time ranges in files')
+
+        self.avg_time = at = sum(t[1] - t[0] for t in self.merged_range)
+        self.files = [(*fsc, dt / at) for *fsc, dt in files]

--- a/pyfr/readers/__init__.py
+++ b/pyfr/readers/__init__.py
@@ -1,5 +1,6 @@
 from pyfr.readers.base import BaseReader, NodalMeshAssembler
 from pyfr.readers.gmsh import GmshReader
+from pyfr.readers.native import NativeReader
 
 from pyfr.util import subclasses, subclass_where
 

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -96,6 +96,25 @@ class silence:
         os.close(self.saved_fds[1])
 
 
+def merge_intervals(ivals, tol=1e-5):
+    ivals = sorted(ivals, reverse=True)
+    mivals = [ivals.pop()]
+
+    while ivals:
+        lstart, lend = mivals[-1]
+        cstart, cend = ivals.pop()
+
+        if cstart < lend:
+            raise ValueError('Overlapping range')
+
+        if abs(cstart - lend) < tol:
+            mivals[-1] = (lstart, cend)
+        else:
+            mivals.append((cstart, cend))
+
+    return mivals
+
+
 @contextmanager
 def setenv(**kwargs):
     _env = os.environ.copy()


### PR DESCRIPTION
Plugins can now expose functions to be called from the commadn line. This is to allow for existing plugin infrastucture to be used to perform addition analysis tasks in pre- and post-processing, rather than relying on adhoc tools.

A new cli section has been added to the documentation. Currently the exposed plugin functions are:

* tavg merge --- allowing multiple time average files to be merged. 
* writer export --- this moves the export funtionality from a major command to a subcommand of the writer.