### PR TITLE
Changed the name of region index datasets

### DIFF
--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -139,4 +139,4 @@ class RegionMixin:
             darr = np.unique(eidxs).astype(np.int32)
 
             self._ele_regions.append((doff, etype, darr))
-            self._ele_region_data[f'{etype}_idxs'] = darr
+            self._ele_region_data[f'idxs_{etype}'] = darr

--- a/pyfr/writers/vtk.py
+++ b/pyfr/writers/vtk.py
@@ -636,9 +636,9 @@ class VTKWriter(BaseWriter):
 
         # Handle the case of partial solution files
         if soln.shape[2] != mesh.shape[1]:
-            skpre, skpost = sk.rsplit('_', 1)
+            skpre, skele, skpart = sk.rsplit('_', 2)
 
-            mesh = mesh[:, self.soln[f'{skpre}_idxs_{skpost}'], :]
+            mesh = mesh[:, self.soln[f'{skpre}_idxs_{skele}_{skpart}'], :]
 
         # Dimensions
         nspts, neles = mesh.shape[:2]


### PR DESCRIPTION
A small change to the name of region index datasets to `{pre}_idxs_{etype}_{part}` from `{pre}_{etype}_idxs_{part}`. I think this makes a bit more sense and makes filtering the dataset keys easier.