### PR TITLE
Removed old np.bool

### DIFF
--- a/pyfr/regions.py
+++ b/pyfr/regions.py
@@ -168,7 +168,7 @@ class BoxRegion(BaseGeometricRegion):
     def pts_in_region(self, pts):
         pts = np.moveaxis(pts, -1, 0)
 
-        inside = np.ones(pts.shape[1:], dtype=np.bool)
+        inside = np.ones(pts.shape[1:], dtype=bool)
         for l, p, u in zip(self.x0, pts, self.x1):
             inside &= (l <= p) & (p <= u)
 


### PR DESCRIPTION
This is old numpy syntax and casues pyfr to fail.