### PR TITLE
Fix for metal backend in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ tests = [
 package_data = {
     'pyfr.backends.cuda.kernels': ['*.mako'],
     'pyfr.backends.hip.kernels': ['*.mako'],
+    'pyfr.backends.metal.kernels': ['*.mako'],
     'pyfr.backends.opencl.kernels': ['*.mako'],
     'pyfr.backends.openmp.kernels': ['*.mako'],
     'pyfr.integrators.dual.pseudo.kernels': ['*.mako'],


### PR DESCRIPTION
Without this the following error is thrown when installing with the setup.py:
```
...
FileNotFoundError: [Errno 2] No such file or directory: '/Users/michael-laufer/.venv/pyfr-venv/lib/python3.11/site-packages/pyfr/backends/metal/kernels/base.mako'
```