### PR TITLE
Added optional lp norm in integrate plugin.

### DIFF
--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -1559,17 +1559,23 @@ Integrate quantities over the compuational domain. Parameterised with:
 
     *int*
 
+
 5. ``quad-pts-{etype}`` --- name of quadrature rule (optional):
 
     *string*
 
-6. ``region`` --- region to integrate, specified as either the
+6. ``norm`` --- sets the degree and calculates an :math:`L_p` norm (optional),
+    otherwise standard integration is performed:
+
+    *float* | ``inf`` | ``none``
+
+7. ``region`` --- region to integrate, specified as either the
    entire domain using ``*`` or a combination of the geometric shapes
    specified in :ref:`regions`:
 
     ``*`` | ``shape(args, ...)``
 
-7. ``int``-*name* --- expression to integrate, written as a function of
+8. ``int``-*name* --- expression to integrate, written as a function of
    the primitive variables and gradients thereof, the physical coordinates
    [x, y, [z]] and/or the physical time [t]; multiple expressions,
    each with their own *name*, may be specified:


### PR DESCRIPTION
Adds an option to the integrate plugin for setting a degree for lp norm allowing the integrate plugin to calculate lp norms.
This is particualrly useful when analysing methods where L1, L2 and Linf norms of error are widely used. Previously you could do L1, and dodge L2 doing the sqrt in post, but there was no way to do Linf.

If the option is not present then the native approach is used where the expressions are just integrated.