### PR TITLE
Fixed issues with 1D Riemann solvers

### DIFF
--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -15,11 +15,21 @@ class FluidIntIntersMixin:
                 entmin_lhs=self._entmin_lhs, entmin_rhs=self._entmin_rhs
             )
 
+
+class TplargsMixin:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        rsolver = self.cfg.get('solver-interfaces', 'riemann-solver')
+        if self.cfg.get('solver', 'shock-capturing') == 'entropy-filter':
             self.p_min = self.cfg.getfloat('solver-entropy-filter', 'p_min',
                                            1e-6)
         else:
             self.p_min = self.cfg.getfloat('solver-interfaces', 'p_min',
                                            5*self._be.fpdtype_eps)
+
+        self._tplargs = dict(ndims=self.ndims, nvars=self.nvars,
+                             rsolver=rsolver, c=self.c, p_min=self.p_min)
 
 
 class FluidMPIIntersMixin:
@@ -35,51 +45,42 @@ class FluidMPIIntersMixin:
             )
 
 
-class EulerIntInters(FluidIntIntersMixin, BaseAdvectionIntInters):
+class EulerIntInters(TplargsMixin, FluidIntIntersMixin,
+                     BaseAdvectionIntInters):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._be.pointwise.register('pyfr.solvers.euler.kernels.intcflux')
 
-        rsolver = self.cfg.get('solver-interfaces', 'riemann-solver')
-        tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
-                       c=self.c, p_min=self.p_min)
-
         self.kernels['comm_flux'] = lambda: self._be.kernel(
-            'intcflux', tplargs=tplargs, dims=[self.ninterfpts],
+            'intcflux', tplargs=self._tplargs, dims=[self.ninterfpts],
             ul=self._scal_lhs, ur=self._scal_rhs, nl=self._pnorm_lhs
         )
 
 
-class EulerMPIInters(FluidMPIIntersMixin, BaseAdvectionMPIInters):
+class EulerMPIInters(TplargsMixin, FluidMPIIntersMixin,
+                     BaseAdvectionMPIInters):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._be.pointwise.register('pyfr.solvers.euler.kernels.mpicflux')
 
-        rsolver = self.cfg.get('solver-interfaces', 'riemann-solver')
-        tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
-                       c=self.c, p_min=self.p_min)
-
         self.kernels['comm_flux'] = lambda: self._be.kernel(
-            'mpicflux', tplargs, dims=[self.ninterfpts],
+            'mpicflux', self._tplargs, dims=[self.ninterfpts],
             ul=self._scal_lhs, ur=self._scal_rhs, nl=self._pnorm_lhs
         )
 
 
-class EulerBaseBCInters(BaseAdvectionBCInters):
+class EulerBaseBCInters(TplargsMixin, BaseAdvectionBCInters):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self._be.pointwise.register('pyfr.solvers.euler.kernels.bccflux')
 
-        rsolver = self.cfg.get('solver-interfaces', 'riemann-solver')
-        tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
-                       c=self.c, p_min=self.p_min, bctype=self.type,
-                       ninters=self.ninters)
+        self._tplargs |= dict(bctype=self.type, ninters=self.ninters)
 
         self.kernels['comm_flux'] = lambda: self._be.kernel(
-            'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
+            'bccflux', tplargs=self._tplargs, dims=[self.ninterfpts],
             extrns=self._external_args, ul=self._scal_lhs, nl=self._pnorm_lhs,
             **self._external_vals
         )
@@ -88,7 +89,7 @@ class EulerBaseBCInters(BaseAdvectionBCInters):
             self._be.pointwise.register('pyfr.solvers.euler.kernels.bccent')
 
             self.kernels['comm_entropy'] = lambda: self._be.kernel(
-                'bccent', tplargs=tplargs, dims=[self.ninterfpts],
+                'bccent', tplargs=self._tplargs, dims=[self.ninterfpts],
                 extrns=self._external_args, entmin_lhs=self._entmin_lhs,
                 nl=self._pnorm_lhs, ul=self._scal_lhs, **self._external_vals
             )

--- a/pyfr/solvers/euler/kernels/rsolvers/exact.mako
+++ b/pyfr/solvers/euler/kernels/rsolvers/exact.mako
@@ -112,8 +112,7 @@
             }
             else
             {
-                fpdtype_t cml = cl*pow(p0 / pl, ${gmrtg});
-                if (us < cml)
+                if (us < cl*pow(p0 / pl, ${gmrtg}))
                 {
                     w0[0] = rl*pow(p0 / pl, ${1 / gamma});
                     w0[1] = us;
@@ -179,8 +178,7 @@
             else
             {
                 fpdtype_t p0p = p0 / pr;
-                fpdtype_t cmr = cr*pow(p0p, ${gmrtg});
-                if (us + cmr >= 0)
+                if (us + cr*pow(p0p, ${gmrtg}) >= 0)
                 {
                     w0[0] = rr*pow(p0p, ${1 / gamma});
                     w0[1] = us;

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -14,9 +14,17 @@ class TplargsMixin:
         rsolver = self.cfg.get('solver-interfaces', 'riemann-solver')
         visc_corr = self.cfg.get('solver', 'viscosity-correction', 'none')
         shock_capturing = self.cfg.get('solver', 'shock-capturing')
+        if shock_capturing == 'entropy-filter':
+            self.p_min = self.cfg.getfloat('solver-entropy-filter', 'p_min',
+                                           1e-6)
+        else:
+            self.p_min = self.cfg.getfloat('solver-interfaces', 'p_min',
+                                           5*self._be.fpdtype_eps)
+
         self._tplargs = dict(ndims=self.ndims, nvars=self.nvars,
                              rsolver=rsolver, visc_corr=visc_corr,
-                             shock_capturing=shock_capturing, c=self.c)
+                             shock_capturing=shock_capturing, c=self.c,
+                             p_min=self.p_min)
 
 
 class NavierStokesIntInters(TplargsMixin,


### PR DESCRIPTION
Soe fixes for the recent 1D'd riemann solvers.

* Fixed issue of p_min not being set in euler BCS and Navier--Stokes interfaces
* Changed HLLC wave speed estimate back to Einfeldt from Davis as Davis caused double mach reflection to nan on single precision
* Some cleanups to the exact solver