### PR TITLE
Add explicit version checks to CUDA and HIP.

### DIFF
--- a/pyfr/backends/cuda/driver.py
+++ b/pyfr/backends/cuda/driver.py
@@ -130,6 +130,7 @@ class CUDAWrappers(LibWrapper):
     # Functions
     _functions = [
         (c_int, 'cuInit', c_int),
+        (c_int, 'cuDriverGetVersion', POINTER(c_int)),
         (c_int, 'cuDeviceGet', POINTER(c_int), c_int),
         (c_int, 'cuDeviceGetCount', POINTER(c_int)),
         (c_int, 'cuDeviceGetAttribute', POINTER(c_int), c_int, c_int),
@@ -184,6 +185,16 @@ class CUDAWrappers(LibWrapper):
 
     def _transname(self, name):
         return name.removesuffix('_v2')
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        version = c_int()
+        self.cuDriverGetVersion(version)
+
+        major, minor = version.value // 1000, (version.value % 1000) // 10
+        if (major, minor) < (11, 4):
+            raise RuntimeError(f'CUDA version {major}.{minor} < 11.4')
 
 
 class _CUDABase:

--- a/pyfr/backends/hip/driver.py
+++ b/pyfr/backends/hip/driver.py
@@ -163,6 +163,7 @@ class HIPWrappers(LibWrapper):
 
     # Functions
     _functions = [
+        (c_int, 'hipRuntimeGetVersion', POINTER(c_int)),
         (c_int, 'hipGetDeviceCount', POINTER(c_int)),
         (c_int, 'hipGetDeviceProperties', POINTER(HIPDevProps), c_int),
         (c_int, 'hipSetDevice', c_int),
@@ -211,6 +212,21 @@ class HIPWrappers(LibWrapper):
         (c_int, 'hipGraphExecDestroy', c_void_p),
         (c_int, 'hipGraphLaunch', c_void_p, c_void_p)
     ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        version = c_int()
+        self.hipRuntimeGetVersion(version)
+
+        major, rem = divmod(version.value, 10000000)
+        minor, patch = divmod(rem, 100000)
+
+        if (major, minor) < (5, 2):
+            raise RuntimeError(f'HIP version {major}.{minor}.{patch} < 5.2')
+
+        if major > 5:
+            raise RuntimeError(f'HIP major version {major} > 5')
 
 
 class _HIPBase:


### PR DESCRIPTION
This ensures that we do not try and run with incompatible versions of CUDA or HIP.  The major version check for HIP is needed as the device properties structure is changing with v6.