### PR TITLE
Variable ac-zeta

### DIFF
--- a/pyfr/solvers/aceuler/elements.py
+++ b/pyfr/solvers/aceuler/elements.py
@@ -62,12 +62,14 @@ class ACEulerElements(BaseACFluidElements, BaseAdvectionElements):
             self.kernels['tdisf_curved'] = lambda uin: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nupts, r[c]],
                 u=s(self.scal_upts[uin], c), f=s(self._vect_upts, c),
+                extrns={'ac_zeta': 'scalar fpdtype_t'},
                 smats=self.curved_smat_at('upts')
             )
         elif c in r:
             self.kernels['tdisf_curved'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nqpts, r[c]],
                 u=s(self._scal_qpts, c), f=s(self._vect_qpts, c),
+                extrns={'ac_zeta': 'scalar fpdtype_t'},
                 smats=self.curved_smat_at('qpts')
             )
 
@@ -75,11 +77,13 @@ class ACEulerElements(BaseACFluidElements, BaseAdvectionElements):
             self.kernels['tdisf_linear'] = lambda uin: self._be.kernel(
                 'tfluxlin', tplargs=tplargs, dims=[self.nupts, r[l]],
                 u=s(self.scal_upts[uin], l), f=s(self._vect_upts, l),
+                extrns={'ac_zeta': 'scalar fpdtype_t'},
                 verts=self.ploc_at('linspts', l), upts=self.upts
             )
         elif l in r:
             self.kernels['tdisf_linear'] = lambda: self._be.kernel(
                 'tfluxlin', tplargs=tplargs, dims=[self.nqpts, r[l]],
                 u=s(self._scal_qpts, l), f=s(self._vect_qpts, l),
+                extrns={'ac_zeta': 'scalar fpdtype_t'},
                 verts=self.ploc_at('linspts', l), upts=self.qpts
             )

--- a/pyfr/solvers/aceuler/inters.py
+++ b/pyfr/solvers/aceuler/inters.py
@@ -13,9 +13,11 @@ class ACEulerIntInters(BaseAdvectionIntInters):
         tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
                        c=self.c)
 
+        self._set_external('ac_zeta', 'scalar fpdtype_t')
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'intcflux', tplargs=tplargs, dims=[self.ninterfpts],
-            ul=self._scal_lhs, ur=self._scal_rhs, nl=self._pnorm_lhs
+            ul=self._scal_lhs, ur=self._scal_rhs, nl=self._pnorm_lhs,
+            extrns=self._external_args, 
         )
 
 
@@ -29,9 +31,11 @@ class ACEulerMPIInters(BaseAdvectionMPIInters):
         tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
                        c=self.c)
 
+        self._set_external('ac_zeta', 'scalar fpdtype_t')
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'mpicflux', tplargs, dims=[self.ninterfpts],
-            ul=self._scal_lhs, ur=self._scal_rhs, nl=self._pnorm_lhs
+            ul=self._scal_lhs, ur=self._scal_rhs, 
+            nl=self._pnorm_lhs, extrns=self._external_args, 
         )
 
 
@@ -45,10 +49,10 @@ class ACEulerBaseBCInters(BaseAdvectionBCInters):
         tplargs = dict(ndims=self.ndims, nvars=self.nvars, rsolver=rsolver,
                        c=self.c, bctype=self.type)
 
+        self._set_external('ac_zeta', 'scalar fpdtype_t')
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
             extrns=self._external_args, ul=self._scal_lhs, nl=self._pnorm_lhs,
-            **self._external_vals
         )
 
 

--- a/pyfr/solvers/aceuler/kernels/flux.mako
+++ b/pyfr/solvers/aceuler/kernels/flux.mako
@@ -1,6 +1,6 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 
-<%pyfr:macro name='inviscid_flux' params='s, f'>
+<%pyfr:macro name='inviscid_flux' params='s, f' externs='ac_zeta'>
    // Velocity in the indices 1 to ndims+1 of the conservative variable array
    fpdtype_t v[] = ${pyfr.array('s[{i}]', i=(1, ndims + 1))};
 
@@ -9,7 +9,7 @@
 
     // Mass flux
 % for i in range(ndims):
-    f[${i}][0] = ${c['ac-zeta']}*v[${i}];
+    f[${i}][0] = ac_zeta*v[${i}];
 % endfor
 
     // Momentum fluxes

--- a/pyfr/solvers/aceuler/kernels/rsolvers/rusanov.mako
+++ b/pyfr/solvers/aceuler/kernels/rsolvers/rusanov.mako
@@ -1,7 +1,7 @@
 <%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
 <%include file='pyfr.solvers.aceuler.kernels.flux'/>
 
-<%pyfr:macro name='rsolve' params='ul, ur, n, nf'>
+<%pyfr:macro name='rsolve' params='ul, ur, n, nf' externs='ac_zeta'>
     fpdtype_t fl[${ndims}][${nvars}], fr[${ndims}][${nvars}];
 
     ${pyfr.expand('inviscid_flux', 'ul', 'fl')};
@@ -14,7 +14,7 @@
     fpdtype_t nv = 0.5*${pyfr.dot('n[{i}]', 'vl[{i}] + vr[{i}]', i=ndims)};
 
     // Estimate the wave speed
-    fpdtype_t a = fabs(nv) + sqrt(nv*nv + ${c['ac-zeta']});
+    fpdtype_t a = fabs(nv) + sqrt(nv*nv + ac_zeta);
 
     // Output
 % for i in range(nvars):

--- a/pyfr/solvers/aceuler/system.py
+++ b/pyfr/solvers/aceuler/system.py
@@ -15,7 +15,7 @@ class ACEulerSystem(BaseAdvectionSystem):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         
-        self._ac_zeta = self.cfg.getfloat('solver', 'ac-zeta')
+        self.ac_zeta = self.cfg.getfloat('solver', 'ac-zeta')
 
     def _prepare_kernels(self, t, uinbank, foutbank):
         _, binders = self._get_kernels(uinbank, foutbank)
@@ -24,12 +24,5 @@ class ACEulerSystem(BaseAdvectionSystem):
             b.prepare(t)
 
         for b in binders: 
-            b(t=t, ac_zeta=self._ac_zeta)
+            b(t=t, ac_zeta=self.ac_zeta)
 
-    @property
-    def ac_zeta(self):
-        return self._ac_zeta
-
-    @ac_zeta.setter
-    def ac_zeta(self, y):
-        self._ac_zeta = y

--- a/pyfr/solvers/aceuler/system.py
+++ b/pyfr/solvers/aceuler/system.py
@@ -11,3 +11,25 @@ class ACEulerSystem(BaseAdvectionSystem):
     intinterscls = ACEulerIntInters
     mpiinterscls = ACEulerMPIInters
     bbcinterscls = ACEulerBaseBCInters
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        self._ac_zeta = self.cfg.getfloat('solver', 'ac-zeta')
+
+    def _prepare_kernels(self, t, uinbank, foutbank):
+        _, binders = self._get_kernels(uinbank, foutbank)
+
+        for b in self._bc_inters:
+            b.prepare(t)
+
+        for b in binders: 
+            b(t=t, ac_zeta=self._ac_zeta)
+
+    @property
+    def ac_zeta(self):
+        return self._ac_zeta
+
+    @ac_zeta.setter
+    def ac_zeta(self, y):
+        self._ac_zeta = y

--- a/pyfr/solvers/acnavstokes/elements.py
+++ b/pyfr/solvers/acnavstokes/elements.py
@@ -37,12 +37,14 @@ class ACNavierStokesElements(BaseACFluidElements,
             self.kernels['tdisf_curved'] = lambda uin: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nupts, r[c]],
                 u=s(self.scal_upts[uin], c), f=s(self._vect_upts, c),
+                extrns={'ac_zeta': 'scalar fpdtype_t'},
                 smats=self.curved_smat_at('upts')
             )
         elif c in r:
             self.kernels['tdisf_curved'] = lambda: self._be.kernel(
                 'tflux', tplargs=tplargs, dims=[self.nqpts, r[c]],
                 u=s(self._scal_qpts, c), f=s(self._vect_qpts, c),
+                extrns={'ac_zeta': 'scalar fpdtype_t'},
                 smats=self.curved_smat_at('qpts')
             )
 
@@ -50,11 +52,13 @@ class ACNavierStokesElements(BaseACFluidElements,
             self.kernels['tdisf_linear'] = lambda uin: self._be.kernel(
                 'tfluxlin', tplargs=tplargs, dims=[self.nupts, r[l]],
                 u=s(self.scal_upts[uin], l), f=s(self._vect_upts, l),
+                extrns={'ac_zeta': 'scalar fpdtype_t'},
                 verts=self.ploc_at('linspts', l), upts=self.upts
             )
         elif l in r:
             self.kernels['tdisf_linear'] = lambda: self._be.kernel(
                 'tfluxlin', tplargs=tplargs, dims=[self.nqpts, r[l]],
                 u=s(self._scal_qpts, l), f=s(self._vect_qpts, l),
+                extrns={'ac_zeta': 'scalar fpdtype_t'},
                 verts=self.ploc_at('linspts', l), upts=self.qpts
             )

--- a/pyfr/solvers/acnavstokes/inters.py
+++ b/pyfr/solvers/acnavstokes/inters.py
@@ -21,11 +21,12 @@ class ACNavierStokesIntInters(BaseAdvectionDiffusionIntInters):
             ulin=self._scal_lhs, urin=self._scal_rhs,
             ulout=self._vect_lhs, urout=self._vect_rhs
         )
+        self._set_external('ac_zeta', 'scalar fpdtype_t')
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'intcflux', tplargs=tplargs, dims=[self.ninterfpts],
             ul=self._scal_lhs, ur=self._scal_rhs,
             gradul=self._vect_lhs, gradur=self._vect_rhs,
-            nl=self._pnorm_lhs
+            nl=self._pnorm_lhs, extrns=self._external_args, 
         )
 
 
@@ -46,11 +47,12 @@ class ACNavierStokesMPIInters(BaseAdvectionDiffusionMPIInters):
             'mpiconu', tplargs=tplargs, dims=[self.ninterfpts],
             ulin=self._scal_lhs, urin=self._scal_rhs, ulout=self._vect_lhs
         )
+        self._set_external('ac_zeta', 'scalar fpdtype_t')
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'mpicflux', tplargs=tplargs, dims=[self.ninterfpts],
             ul=self._scal_lhs, ur=self._scal_rhs,
             gradul=self._vect_lhs, gradur=self._vect_rhs,
-            nl=self._pnorm_lhs
+            nl=self._pnorm_lhs, extrns=self._external_args, 
         )
 
 
@@ -69,15 +71,16 @@ class ACNavierStokesBaseBCInters(BaseAdvectionDiffusionBCInters):
         self._be.pointwise.register('pyfr.solvers.acnavstokes.kernels.bcconu')
         self._be.pointwise.register('pyfr.solvers.acnavstokes.kernels.bccflux')
 
+        self._set_external('ac_zeta', 'scalar fpdtype_t')
         self.kernels['con_u'] = lambda: self._be.kernel(
             'bcconu', tplargs=tplargs, dims=[self.ninterfpts],
             extrns=self._external_args, ulin=self._scal_lhs,
-            ulout=self._vect_lhs, nlin=self._pnorm_lhs, **self._external_vals
+            ulout=self._vect_lhs, nlin=self._pnorm_lhs
         )
         self.kernels['comm_flux'] = lambda: self._be.kernel(
             'bccflux', tplargs=tplargs, dims=[self.ninterfpts],
             extrns=self._external_args, ul=self._scal_lhs,
-            gradul=self._vect_lhs, nl=self._pnorm_lhs, **self._external_vals
+            gradul=self._vect_lhs, nl=self._pnorm_lhs
         )
 
 

--- a/pyfr/solvers/acnavstokes/system.py
+++ b/pyfr/solvers/acnavstokes/system.py
@@ -12,3 +12,25 @@ class ACNavierStokesSystem(BaseAdvectionDiffusionSystem):
     intinterscls = ACNavierStokesIntInters
     mpiinterscls = ACNavierStokesMPIInters
     bbcinterscls = ACNavierStokesBaseBCInters
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        self._ac_zeta = self.cfg.getfloat('solver', 'ac-zeta')
+
+    def _prepare_kernels(self, t, uinbank, foutbank):
+        _, binders = self._get_kernels(uinbank, foutbank)
+
+        for b in self._bc_inters:
+            b.prepare(t)
+
+        for b in binders: 
+            b(t=t, ac_zeta=self._ac_zeta)
+
+    @property
+    def ac_zeta(self):
+        return self._ac_zeta
+
+    @ac_zeta.setter
+    def ac_zeta(self, y):
+        self._ac_zeta = y


### PR DESCRIPTION
This PR is the first step to varying ac-zeta across P-multigrid levels. I have compared csv files of `[soln-plugin-pseudostats]` for the develop version and the PR, to check if the PR works. Setting ac-zeta this way did not seem to affect the performance of the inc-cylinder-2d case from PyFR-test-cases. Let me know if we need to test its performance difference with the develop version more.

Also, I was not sure where to initialise ac-zeta, so I shifted it from `[constants]` to `[solver]`.

With this PR, we can now look into the effect of changing ac-zeta across pseudo-iterations, multi-P levels, and stages. 