### PR TITLE
Added nan dump

### DIFF
--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -1116,7 +1116,7 @@ the prismatic elements at multi-p level *order*, with
 1. ``soln-pts`` --- location of the solution points in a prismatic
    element:
 
-    ``alpha-opt~gauss-legendre-lobatto`` | 
+    ``alpha-opt~gauss-legendre-lobatto`` |
     ``williams-shunn~gauss-legendre`` |
     ``williams-shunn~gauss-legendre-lobatto``
 
@@ -1281,10 +1281,32 @@ Periodically checks the solution for NaN values. Parameterised with
 
     *int*
 
+2. ``region-dump`` --- if NaN regions should be dumped once detected:
+
+    *boolean*
+
+3. ``region-len`` --- side length of box region placed around the centriod of
+   NaN points:
+
+    *float*
+
+4. ``basedir`` --- relative path to directory where dump file will be
+   written:
+
+    *string*
+
+5. ``basename`` --- pattern of dump file name:
+
+    *string*
+
 Example::
 
     [soln-plugin-nancheck]
     nsteps = 10
+    region-dump = true
+    region-len = 0.5
+    basedir = data
+    basename = nan_dump
 
 [soln-plugin-residual]
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pyfr/plugins/nancheck.py
+++ b/pyfr/plugins/nancheck.py
@@ -1,20 +1,107 @@
 import numpy as np
 
-from pyfr.plugins.base import BaseSolnPlugin
+from pyfr.inifile import Inifile
+from pyfr.mpiutil import get_comm_rank_root, mpi
+from pyfr.plugins.base import BaseSolnPlugin, WriterMixin, region_data
+from pyfr.writers.native import NativeWriter
 
 
-class NaNCheckPlugin(BaseSolnPlugin):
+class NaNCheckPlugin(WriterMixin, BaseSolnPlugin):
     name = 'nancheck'
     systems = ['*']
     formulations = ['dual', 'std']
     dimensions = [2, 3]
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, intg, cfgsect, suffix=None):
+        super().__init__(intg, cfgsect, suffix)
+
+        self.dump = self.cfg.getbool(cfgsect, 'region-dump', False)
+        if self.dump:
+            self.rgn_len = self.cfg.getfloat(cfgsect, 'region-len')
+
+            # Base output directory and file name
+            basedir = self.cfg.getpath(self.cfgsect, 'basedir', '.', abs=True)
+            basename = self.cfg.get(self.cfgsect, 'basename')
+
+            # Construct the solution writer
+            self._writer = NativeWriter(intg, basedir, basename, 'soln')
+
+            # Output field names
+            self.fields = intg.system.elementscls.convarmap[self.ndims]
+
+            # Output data type
+            self.fpdtype = intg.backend.fpdtype
+
+            self.centroid = c = {}
+            for etype, eles in intg.system.ele_map.items():
+                c[etype] = np.mean(eles.ploc_at_np('upts'), axis=0).T
 
         self.nsteps = self.cfg.getint(self.cfgsect, 'nsteps')
 
+    def _nan_regions(self, intg):
+        comm, rank, root = get_comm_rank_root()
+
+        rgn_parts = []
+        # For each element type, get nan region centroid and make box
+        for s, etype in zip(intg.soln, self.centroid):
+            i = np.unique(np.argwhere(np.isnan(s))[:,-1])
+
+            if len(i):
+                x = np.mean(self.centroid[etype][i], axis=0)
+                x0, x1 = x - 0.5*self.rgn_len, x + 0.5*self.rgn_len
+
+                def a2s(y): return np.array2string(y, separator=',')
+                rgn_parts.append(f'box({a2s(x0)}, {a2s(x1)})')
+
+        # Construct a single region for all ranks
+        rgn_str = ' + '.join(r for r in rgn_parts)
+        rgn_str = comm.allgather(rgn_str)
+        rgn_glob = ' + '.join(r for r in rgn_str if r)
+
+        # Get region indices
+        ridxs = region_data(self.cfg, self.cfgsect, intg.system.mesh,
+                            intg.rallocs, rgn_glob)
+
+        # Generate the appropriate metadata arrays
+        ele_regions, ele_region_data = [], {}
+        for etype, eidxs in ridxs.items():
+            doff = intg.system.ele_types.index(etype)
+            ele_regions.append((doff, etype, eidxs))
+
+            if not isinstance(eidxs, slice):
+                ele_region_data[f'{etype}_idxs'] = eidxs
+
+        return ele_regions, ele_region_data
+
     def __call__(self, intg):
         if intg.nacptsteps % self.nsteps == 0:
-            if any(np.isnan(np.sum(s)) for s in intg.soln):
+            comm, rank, root = get_comm_rank_root()
+            isnan = np.array(any(np.isnan(np.sum(s)) for s in intg.soln))
+
+            comm.allreduce(isnan, isnan, op=mpi.LOR)
+
+            if self.dump and isnan:
+                ele_regions, ele_region_data = self._nan_regions(intg)
+
+                intg.collect_stats(self.stats)
+
+                # If we are the root rank then prepare the metadata
+                if rank == root:
+                    metadata = dict(intg.cfgmeta,
+                                    stats=self.stats.tostr(),
+                                    mesh_uuid=intg.mesh_uuid)
+                else:
+                    metadata = None
+
+                # Fetch and (if necessary) subset the solution
+                data = dict(ele_region_data)
+                for idx, etype, rgn in ele_regions:
+                    data[etype] = intg.soln[idx][..., rgn].astype(self.fpdtype)
+
+                # Write out the file
+                self._writer.write(data, intg.tcurr, metadata)
+
+                comm.Barrier()
+
+            if isnan and rank == root:
                 raise RuntimeError(f'NaNs detected at t = {intg.tcurr}')

--- a/pyfr/plugins/writer.py
+++ b/pyfr/plugins/writer.py
@@ -44,15 +44,12 @@ class WriterPlugin(PostactionMixin, RegionMixin, BaseSolnPlugin):
 
         comm, rank, root = get_comm_rank_root()
 
-        stats = Inifile()
-        stats.set('data', 'fields', ','.join(self.fields))
-        stats.set('data', 'prefix', 'soln')
-        intg.collect_stats(stats)
+        intg.collect_stats(self.stats)
 
         # If we are the root rank then prepare the metadata
         if rank == root:
             metadata = dict(intg.cfgmeta,
-                            stats=stats.tostr(),
+                            stats=self.stats.tostr(),
                             mesh_uuid=intg.mesh_uuid)
         else:
             metadata = None

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -130,11 +130,14 @@ class BaseSystem:
     def _load_int_inters(self, rallocs, mesh, elemap):
         key = f'con_p{rallocs.prank}'
 
-        lhs, rhs = mesh[key].astype('U4,i4,i1,i2').tolist()
-        int_inters = self.intinterscls(self.backend, lhs, rhs, elemap,
-                                       self.cfg)
+        try:
+            lhs, rhs = mesh[key].astype('U4,i4,i1,i2').tolist()
+            int_inters = [self.intinterscls(self.backend, lhs, rhs, elemap,
+                                            self.cfg)]
+        except KeyError:
+            int_inters = []
 
-        return [int_inters]
+        return int_inters
 
     def _load_mpi_inters(self, rallocs, mesh, elemap):
         lhsprank = rallocs.prank


### PR DESCRIPTION
This adds the ability to dump the solution around detected NaN points. For each partition and each element type, it will find the approximate centroid of any NaN and create a box region around it. It will then dump a single pyfrs file that contains these regions.

Identifying individual contiguous patches of NaN seemed a bit overkill, but that is an option for later if people find this method insufficient.