### PR TITLE
Fix the 3rd term in Rot to output 3x3 outer product matrix in plugins/turbulence.py 

### DIFF
--- a/pyfr/plugins/turbulence.py
+++ b/pyfr/plugins/turbulence.py
@@ -89,7 +89,7 @@ class TurbulencePlugin(BaseSolverPlugin):
         self.shift = shift = np.array(centre)
         self.rot = rot = (np.cos(ran)*np.eye(3) +
                           np.sin(ran)*(np.cross(rax, np.eye(3))) +
-                          (1 - np.cos(ran))*np.outer(rax,rax))
+                          (1 - np.cos(ran))*np.outer(rax, rax))
 
         self.macro_params = {
             'ls': ls, 'avgu': avgu, 'yzdim': yzdim, 'beta1': beta1,

--- a/pyfr/plugins/turbulence.py
+++ b/pyfr/plugins/turbulence.py
@@ -89,7 +89,7 @@ class TurbulencePlugin(BaseSolverPlugin):
         self.shift = shift = np.array(centre)
         self.rot = rot = (np.cos(ran)*np.eye(3) +
                           np.sin(ran)*(np.cross(rax, np.eye(3))) +
-                          (1 - np.cos(ran))*rax @ rax.T)
+                          (1 - np.cos(ran))*np.outer(rax,rax))
 
         self.macro_params = {
             'ls': ls, 'avgu': avgu, 'yzdim': yzdim, 'beta1': beta1,


### PR DESCRIPTION
The 3rd term in Rot in plugins/turbulence.py currently outputs a scalar, which should output an outer product in the form of 3x3 matrix. This PR fixes the equation, and the simulation results are verified locally.