### PR TITLE
Rocblas benchmarking and algo picker

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,7 +7,7 @@ Arvind Iyer <a.iyer@imperial.ac.uk>
 Niki Loppi <n.loppi15@imperial.ac.uk>
 George Ntemos <george.ntemos11@imperial.ac.uk>
 Jin Seok Park <jin-seok.park@imperial.ac.uk>
-Will Trojak <wt247@tamu.edu>
+Will Trojak <w.trojak@ibm.com>
 Brian Vermeire <b.vermeire@imperial.ac.uk>
 Peter Vincent <p.vincent@imperial.ac.uk>
 Freddie Witherden <freddie@witherden.org>

--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -176,6 +176,11 @@ Parameterises the HIP backend with
 
      ``standard`` | ``hip-aware``
 
+3. ``rocblas-nkerns`` --- maximum number of kernel algorithms to try, defaults
+   to 2048:
+
+     *int*
+
 Example::
 
     [backend-hip]
@@ -1121,7 +1126,7 @@ the prismatic elements at multi-p level *order*, with
 1. ``soln-pts`` --- location of the solution points in a prismatic
    element:
 
-    ``alpha-opt~gauss-legendre-lobatto`` | 
+    ``alpha-opt~gauss-legendre-lobatto`` |
     ``williams-shunn~gauss-legendre`` |
     ``williams-shunn~gauss-legendre-lobatto``
 


### PR DESCRIPTION
The heuristics in the rocblas aren't great for some of the gemm kernels used by pyfr. This approach uses a beta function in the rocblas extensions that gets all feasible algorithms, benchmarks them, and returns the best one. For some sizes, the improvement can be quite large.

This has only been tested on rocm 5.7, as I don't have access to 6.0 yet.