### PR TITLE
Add kernel groupings for enabling cache blocking

### DIFF
--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -76,15 +76,7 @@ class OpenMPGraph(base.Graph):
         return kranges
 
     def _get_nblocks(self, idxs):
-        nblocks = None
-        for i in idxs:
-            n = self.klist[i].runargs.b.nblocks
-            if nblocks is None:
-                nblocks = n
-            elif n != nblocks:
-                raise RuntimeError('Incompatible block sizes')
-
-        return nblocks
+        return max(self.klist[i].runargs.b.nblocks for i in idxs)
 
     def _make_runlist(self, start, stop):
         rlist = []
@@ -118,11 +110,11 @@ class OpenMPGraph(base.Graph):
 
             # Handle compound (split) kernels
             if k.compound:
-                splits.update(k.splits)
                 ksplits = [0] + [s // blocksz for s in k.splits] + [nblocks]
+                splits.update(ksplits[1:-1])
 
                 for i, (j, ra) in enumerate(runargs.items()):
-                    gkerns[j] = (*ksplits[i:i + 1], ra.kernels[0])
+                    gkerns[j] = (*ksplits[i:i + 2], ra.kernels[0])
             else:
                 for i, (j, ra) in enumerate(runargs.items()):
                     gkerns[j] = (0, ra.nblocks, ra.kernels[0])

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -326,6 +326,13 @@ class BaseSystem:
     def get_ele_entmin_int(self):
         return [e.get() for e in self.eles_entmin_int]
 
+    def _group(self, g, kerns, subs=[]):
+        # Eliminate non-existing kernels
+        kerns = [k for k in kerns if k is not None]
+        subs = [sub for sub in subs if None not in it.chain(*sub)]
+
+        g.group(kerns, subs)
+
     def set_ele_entmin_int(self, entmin_int):
         for e, em in zip(self.eles_entmin_int, entmin_int):
             e.set(em)

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -121,6 +121,19 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         # Compute the transformed divergence of the partially corrected flux
         for l in k['eles/tdivtpcorf']:
             g2.add(l, deps=deps(l, 'eles/tdisf', 'eles/tdisf_fused'))
+
+        kgroup = [
+            k['eles/tgradcoru_upts'], k['eles/gradcoru_upts'],
+            k['eles/tdisf_fused'], k['eles/gradcoru_fpts'],
+            k['eles/gradcoru_qpts'], k['eles/qptsu'],
+            k['eles/tdisf'], k['eles/tdivtpcorf']
+        ]
+        for ks in zip_longest(*kgroup):
+            self._group(g2, ks, subs=[
+                [(ks[5], 'out'), (ks[6], 'u')],
+                [(ks[2], 'f'), (ks[4], 'out'), (ks[6], 'f'), (ks[7], 'b')]
+            ])
+
         g2.commit()
 
         g3 = self.backend.graph()

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -1,3 +1,5 @@
+from itertools import zip_longest
+
 from pyfr.solvers.baseadvec import BaseAdvectionSystem
 from pyfr.util import memoize
 
@@ -137,6 +139,11 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         # Obtain the physical divergence of the corrected flux
         for l in k['eles/negdivconf']:
             g3.add(l, deps=deps(l, 'eles/tdivtconf'))
+
+        # Group tdivtconf and negdivconf kernels
+        for k1, k2 in zip_longest(k['eles/tdivtconf'], k['eles/negdivconf']):
+            self._group(g3, [k1, k2])
+
         g3.commit()
 
         return g1, g2, g3


### PR DESCRIPTION
The ideal grouping for the Euler solver discussed in https://www.sciencedirect.com/science/article/pii/S0010465521003052 is
`tdisf + tdivptcorf + tdivtconf + negdivconf`,
however this requires moving communication kernels around.

To begin with I grouped
`tdisf + tdivptcorf` and `tdivtconf + negdivconf` separately.

Similarly, groupings for the Navier-Stokes equation described in https://arxiv.org/abs/2401.06132 require moving around some of the communication kernels. Thus, I implemented only
`tdivtconf + negdivconf`
which is a grouping in the final configuration article recommends. I'll implement the big chunk of kernels grouped together in the article as a next step.

Communication kernels arranged so that the communication and computation is overlapped as much as possible. Moving them around a little to be able to create better groupings may reduce performance in backends with no cache blocking.

I'll investigate this as well as incorporating the new kernels we have that were not included in the analyses in the two articles I mentioned.