### PR TITLE
Fix a bug with flux anti-aliasing in Euler solver

### DIFF
--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -226,7 +226,7 @@ class BaseElements:
 
         if 'grad_upts' in sbufs and self.grad_fusion:
             self._grad_upts = valloc('grad_upts', nupts)
-        else:
+        elif self.grad_fusion:
             self._grad_upts = self._vect_upts
 
         # Allocate the storage required by the time integrator

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -46,7 +46,8 @@ class BaseSystem:
         # Get all the solution point locations for the elements
         self.ele_ploc_upts = [e.ploc_at_np('upts') for e in eles]
 
-        self.eles_vect_upts = [e._grad_upts for e in eles]
+        if hasattr(eles[0], '_vect_upts'):
+            self.eles_vect_upts = [e._vect_upts for e in eles]
 
         if hasattr(eles[0], 'entmin_int'):
             self.eles_entmin_int = [e.entmin_int for e in eles]


### PR DESCRIPTION
I was testing cache blocking in Euler solver with flux anti-aliasing and got an error.

When flux anti-aliasing is turned on with Euler solver we don't have `vect_upts` to save memory. So added a check before assigning `_grad_upts` to `_vect_upts`.

And I think `eles_vect_upts` is only used with the rhs-like gradient function, so only relevant in baseadvecdiff solvers. Simply reverted to its previous version before Will added the fused gradient operation. I think it is fine to use `_vect_upts` instead of the new `_grad_upts` to store gradient but not entirely sure. @WillTrojak, can you comment on this?