### PR TITLE
Disable being able to turn gradient fusion off when flux AA is off

### DIFF
--- a/pyfr/solvers/base/elements.py
+++ b/pyfr/solvers/base/elements.py
@@ -53,9 +53,8 @@ class BaseElements:
         # If we need quadrature points or not
         haveqpts = 'flux' in self.antialias
 
-        # If we are doing gradient fusion
-        self.grad_fusion = (cfg.getbool('solver', 'grad-fusion', True) and
-                            not haveqpts)
+        # Always do gradient fusion if flux anti-aliasing is off
+        self.grad_fusion = not haveqpts
 
         # Sizes
         self.nupts = basis.nupts


### PR DESCRIPTION
Currently we're getting an error if we try to turn gradient fusion off while flux AA is off. This is due to the new buffer, `_grad_upts`, introduced with gradient fusion being used in most of the kernels in place of `_vect_upts`. `_grad_upts` used to point `_vect_upts` and all was fine but this was recently changed in #400 to be able to run Euler solver with flux AA on. 

Alternative fix to the current issue would be having a `_vect_upts` buffer in `baseadvec` all the time even when flux AA is on, and have `_grad_upts` point to `_vect_upts` all the time. But this would increase memory use unnecessarily for the Euler solver when flux AA is on.

Later on I want to look into using `_grad_upts` buffer only inside `tdisf_fused` so that we can bring back the ability to turn of gradient fusion when we don't have flux AA on. I think this may simplify cache blocking in baseadvecdiff.