### PR TITLE
Fixed rtd build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,8 +13,28 @@ sphinx:
 formats:
    - pdf
 
+# Configure how to build the docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+  jobs:
+    post_checkout:
+      # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+      #
+      # Cancel building pull requests when there aren't changed in the docs directory.
+      #
+      # If there are no changes (git diff exits with 0) we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- doc/ .readthedocs.yaml;
+        then
+          echo "No changes to docs/ - exiting the build.";
+          exit 183;
+        fi
+
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.8
+   version: 3.10
    install:
    - requirements: doc/requirements.txt


### PR DESCRIPTION
This fixes the readthedocs build after they added a section to the yaml on how to configure builds.