### PR TITLE
fix error: local variable 'std_acc' referenced before assignment

### DIFF
--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -487,7 +487,8 @@ class TavgCLIPlugin(TavgMixin, BaseCLIPlugin):
             t, data = 0, file0[key].astype(np.float64)
             avg_acc = np.zeros_like(data[:, amap0])
             var_acc = np.zeros_like(data[:, smap0])
-
+            std_acc = np.zeros_like(data[:, smap0])  # Initialize std_acc
+            
             # Average the averages
             for (file, *_, dt), (amap, smap) in zip(self.files, self.mapping):
                 data = file[key].astype(np.float64)


### PR DESCRIPTION
When do pyfr tavg merge command, the current latest develop encounters error: local variable 'std_acc' referenced before assignment".  This PR is to fix that error by initializing std_acc