### PR TITLE
Improve the kernel groupings in Euler and Navier-Stokes solvers.

### DIFF
--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -118,12 +118,12 @@ class OpenMPKernelFunction:
         setattr(self.kargs, f'arg{i}', getattr(v, '_as_parameter_', v))
 
         try:
-            self.subs_offsets[i] = v.ra*v.leaddim*v.itemsize
+            self.argsizes[i] = v.blocksz*v.itemsize
         except (AttributeError, IndexError):
             pass
 
         try:
-            self.argsizes[i] = v.blocksz*v.itemsize
+            self.subs_offsets[i] = v.ra*v.leaddim*v.itemsize
         except (AttributeError, IndexError):
             pass
 

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -85,6 +85,7 @@ class OpenMPKernelFunction:
         self.argnames = list(argnames)
         self.argsizes = [None]*len(argnames)
         self.nblocks = None
+        self.subs_offsets = [0]*len(argnames)
 
     @cached_property
     def runargs(self):
@@ -110,8 +111,17 @@ class OpenMPKernelFunction:
     def arg_blocksz(self, i):
         return self.argsizes[i]
 
+    def subs_off(self, i):
+        return self.subs_offsets[i]
+
     def set_arg(self, i, v):
         setattr(self.kargs, f'arg{i}', getattr(v, '_as_parameter_', v))
+
+        try:
+            self.subs_offsets[i] = v.ra*v.leaddim*v.itemsize
+        except (AttributeError, IndexError):
+            pass
+
         try:
             self.argsizes[i] = v.blocksz*v.itemsize
         except (AttributeError, IndexError):

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -137,8 +137,9 @@ class OpenMPGraph(base.Graph):
                     aidx = self.klist[j].arg_idx(aname)
                     aoff = self.klist[j].arg_off(aidx)
                     absz = self.klist[j].arg_blocksz(aidx)
+                    suboff = self.klist[j].subs_off(aidx)
 
-                    argsubs[j].append((aoff, allocsz))
+                    argsubs[j].append((aoff, allocsz + suboff))
                     argmasks[j] |= 1 << aidx
 
             allocsz += absz

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -327,9 +327,12 @@ class BaseSystem:
         return [e.get() for e in self.eles_entmin_int]
 
     def _group(self, g, kerns, subs=[]):
-        # Eliminate non-existing kernels
+        # Eliminate non-existent kernels
         kerns = [k for k in kerns if k is not None]
-        subs = [sub for sub in subs if None not in it.chain(*sub)]
+
+        # Eliminate substitutions associated with non-existent kernels
+        subs = [[(k, n) for k, n in sub if k] for sub in subs]
+        subs = [sub for sub in subs if len(sub) > 1]
 
         g.group(kerns, subs)
 

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -51,14 +51,14 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
         g1.add_all(k['eles/shocksensor'])
         g1.add_all(k['mpiint/artvisc_fpts_pack'], deps=k['eles/shocksensor'])
 
-        # Compute the transformed gradient of the partially corrected solution
-        g1.add_all(k['eles/tgradpcoru_upts'],
-                   deps=k['mpiint/scal_fpts_pack'] + k['eles/entropy_filter'])
         g1.commit()
 
         g2 = self.backend.graph()
         g2.add_mpi_reqs(m['artvisc_fpts_send'] + m['artvisc_fpts_recv'])
         g2.add_mpi_reqs(m['vect_fpts_recv'])
+
+        # Compute the transformed gradient of the partially corrected solution
+        g2.add_all(k['eles/tgradpcoru_upts'])
 
         # Compute the common solution at our MPI interfaces
         g2.add_all(k['mpiint/scal_fpts_unpack'])
@@ -71,7 +71,8 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
             g2.add(l, deps=deps(l, 'mpiint/ent_fpts_unpack'))
 
         # Compute the transformed gradient of the corrected solution
-        g2.add_all(k['eles/tgradcoru_upts'], deps=k['mpiint/con_u'])
+        for l in k['eles/tgradcoru_upts']:
+            g2.add(l, deps=deps(l, 'eles/tgradpcoru_upts') + k['mpiint/con_u'])
 
         # Obtain the physical gradients at the solution points
         for l in k['eles/gradcoru_upts']:
@@ -123,15 +124,16 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
             g2.add(l, deps=deps(l, 'eles/tdisf', 'eles/tdisf_fused'))
 
         kgroup = [
-            k['eles/tgradcoru_upts'], k['eles/gradcoru_upts'],
-            k['eles/tdisf_fused'], k['eles/gradcoru_fpts'],
-            k['eles/gradcoru_qpts'], k['eles/qptsu'],
-            k['eles/tdisf'], k['eles/tdivtpcorf']
+            k['eles/tgradpcoru_upts'], k['eles/tgradcoru_upts'],
+            k['eles/gradcoru_upts'], k['eles/tdisf_fused'],
+            k['eles/gradcoru_fpts'], k['eles/gradcoru_qpts'],
+            k['eles/qptsu'], k['eles/tdisf'], k['eles/tdivtpcorf']
         ]
         for ks in zip_longest(*kgroup):
             self._group(g2, ks, subs=[
-                [(ks[5], 'out'), (ks[6], 'u')],
-                [(ks[2], 'f'), (ks[4], 'out'), (ks[6], 'f'), (ks[7], 'b')]
+                [(ks[6], 'out'), (ks[7], 'u')],
+                [(ks[0], 'out'), (ks[1], 'out'), (ks[2], 'f'),
+                 (ks[3], 'f'), (ks[5], 'out'), (ks[7], 'f'), (ks[8], 'b')]
             ])
 
         g2.commit()

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -130,11 +130,24 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
             k['eles/qptsu'], k['eles/tdisf'], k['eles/tdivtpcorf']
         ]
         for ks in zip_longest(*kgroup):
-            self._group(g2, ks, subs=[
-                [(ks[6], 'out'), (ks[7], 'u')],
-                [(ks[0], 'out'), (ks[1], 'out'), (ks[2], 'f'),
-                 (ks[3], 'f'), (ks[5], 'out'), (ks[7], 'f'), (ks[8], 'b')]
-            ])
+            if k['eles/qpts']:
+                self._group(g2, ks, subs=[
+                    [(ks[0], 'out'), (ks[1], 'out'), (ks[2], 'gradu'),
+                     (ks[4], 'b'), (ks[5], 'b')],
+                    [(ks[6], 'out'), (ks[7], 'u')],
+                    [(ks[7], 'f'), (ks[8], 'b')],
+                ])
+            elif k['eles/tdisf_fused']:
+                self._group(g2, ks, subs=[
+                    [(ks[0], 'out'), (ks[1], 'out'),
+                     (ks[3], 'gradu'), (ks[4], 'b')],
+                    [(ks[3], 'f'), (ks[8], 'b')],
+                ])
+            else:
+                self._group(g2, ks, subs=[
+                    [(ks[0], 'out'), (ks[1], 'out'), (ks[2], 'gradu'),
+                     (ks[4], 'b'), (ks[7], 'f'), (ks[8], 'b')],
+                ])
 
         g2.commit()
 

--- a/pyfr/solvers/baseadvecdiff/system.py
+++ b/pyfr/solvers/baseadvecdiff/system.py
@@ -130,24 +130,32 @@ class BaseAdvectionDiffusionSystem(BaseAdvectionSystem):
             k['eles/qptsu'], k['eles/tdisf'], k['eles/tdivtpcorf']
         ]
         for ks in zip_longest(*kgroup):
+            # Form a substitution list based on present kernels
             if k['eles/qpts']:
-                self._group(g2, ks, subs=[
+                # Flux-AA is on
+                # Inputs to tdisf and tdivtpcorf is from quadrature points
+                subs=[
                     [(ks[0], 'out'), (ks[1], 'out'), (ks[2], 'gradu'),
                      (ks[4], 'b'), (ks[5], 'b')],
                     [(ks[6], 'out'), (ks[7], 'u')],
                     [(ks[7], 'f'), (ks[8], 'b')],
-                ])
+                ]
             elif k['eles/tdisf_fused']:
-                self._group(g2, ks, subs=[
+                # Gradient fusion indicates flux-AA is off
+                # tdisf_fused replaces tdisf and gradcoru_upts
+                subs=[
                     [(ks[0], 'out'), (ks[1], 'out'),
                      (ks[3], 'gradu'), (ks[4], 'b')],
                     [(ks[3], 'f'), (ks[8], 'b')],
-                ])
+                ]
             else:
-                self._group(g2, ks, subs=[
+                # No flux-AA, no gradient fusion
+                subs=[
                     [(ks[0], 'out'), (ks[1], 'out'), (ks[2], 'gradu'),
                      (ks[4], 'b'), (ks[7], 'f'), (ks[8], 'b')],
-                ])
+                ]
+
+            self._group(g2, ks, subs=subs)
 
         g2.commit()
 


### PR DESCRIPTION
The kernel groupings in Euler solver in PyFR v2.0.0 were chosen so that it wouldn't impact the performance in any other backend. There is a better kernel grouping possibility, but it may have an impact on scalability on all backends. This is because the best kernel grouping involves kernels from `g1` and `g2`. Thus, enabling the best kernel grouping requires moving some kernels from `g1` into `g2`, and this reduces the computation-communication overlap, potentially making the performance at scale worse for all backends.

@sambitmishra98, can you please test the scalability with the changes in this PR on the CUDA backend when you have time? I think comparison between the current develop branch and this PR up to 16 GPUs would be great. Please start with a mesh large enough to fill %80 of the memory on a single GPU, and then go up to 16 if you have that many. Based on my tests the numerical results are identical, but its a good idea to check the results in your simulations too at least in few of them.