### PR TITLE
Increased checks in mako params/extern macro definitions.

### DIFF
--- a/pyfr/backends/base/makoutil.py
+++ b/pyfr/backends/base/makoutil.py
@@ -98,9 +98,9 @@ def macro(context, name, params, externs=''):
     params = [p.strip() for p in params.split(',')]
     externs = [e.strip() for e in externs.split(',')] if externs else []
 
-    # Ensure no white space in params/extern variables
-    for p in params+externs:
-        if ' ' in p:
+    # Ensure no invalid characters in params/extern variables
+    for p in it.chain(params, externs):
+        if not re.match(r'[A-Za-z_]\w*$', p):
             raise ValueError(f'Invalid param "{p}" in macro "{name}"')
 
     # Capture the function body

--- a/pyfr/backends/base/makoutil.py
+++ b/pyfr/backends/base/makoutil.py
@@ -98,6 +98,11 @@ def macro(context, name, params, externs=''):
     params = [p.strip() for p in params.split(',')]
     externs = [e.strip() for e in externs.split(',')] if externs else []
 
+    # Ensure no white space in params/extern variables
+    for p in params+externs:
+        if ' ' in p:
+            raise ValueError(f'Invalid param "{p}" in macro "{name}"')
+
     # Capture the function body
     body = capture(context, context['caller'].body)
 
@@ -117,6 +122,10 @@ def macro(context, name, params, externs=''):
 def expand(context, name, /, *args, **kwargs):
     # Get the macro parameter list and the body
     mparams, mexterns, body = context['_macros'][name]
+
+    # Ensure mparams and args are the same length
+    if len(mparams) != len(args):
+        raise ValueError(f'Inconsistent macro parameter list in {name}')
 
     # Parse the parameter list
     params = dict(zip(mparams, args))


### PR DESCRIPTION
Checking for a missed comma in params list at macro definition.

If one omits a comma in the params lists, the current checks will not catch them, and the result is a reuse of variable names generated. 

This will catch white space in params list definition, and assert the lengths of a pyfr.expands' param list is equal to the length of a macros param list. 