### PR TITLE
Improve plugin time accounting.

### DIFF
--- a/doc/src/performance_tuning.rst
+++ b/doc/src/performance_tuning.rst
@@ -246,6 +246,12 @@ included in all PyFR solution files.  This can be extracted as::
 
     h5dump -d /stats -b --output=stats.ini soln.pyfrs
 
+Here, the *common* field contains the amount of time spent obtaining
+properties which are not directly attributable to any specific plugin.
+Examples include fetching the solution, computing its gradient, and
+computing its time derivative.  The *other* field accounts for time
+spent in unnamed plugins such as the progress bar.
+
 Given the time steps taken by PyFR are typically much smaller than
 those associated with the underlying physics there is seldom any
 benefit to running integration and/or time average accumulation plugins

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -12,6 +12,21 @@ from pyfr.plugins import get_plugin
 from pyfr.util import memoize
 
 
+def _common_plugin_prop(attr):
+    def wrapfn(fn):
+        @property
+        def newfn(self):
+            if not (p := getattr(self, attr)):
+                t, c = time.time(), self._plugin_wtimes['common', None]
+                p = fn(self)
+                self._plugin_wtimes['common', None] = c + time.time() - t
+                setattr(self, attr, p)
+
+            return p
+        return newfn
+    return wrapfn
+
+
 class BaseIntegrator:
     def __init__(self, backend, rallocs, mesh, initsoln, cfg):
         self.backend = backend
@@ -87,17 +102,22 @@ class BaseIntegrator:
         return plugins
 
     def _run_plugins(self):
+        wtimes = self._plugin_wtimes
+
         self.backend.wait()
 
         # Fire off the plugins and tally up the runtime
         for plugin in self.plugins:
             tstart = time.time()
+            tcommon = wtimes['common', None]
 
             plugin(self)
 
+            dt = time.time() - tstart - wtimes['common', None] + tcommon
+
             pname = getattr(plugin, 'name', 'other')
             psuffix = getattr(plugin, 'suffix', None)
-            self._plugin_wtimes[pname, psuffix] += time.time() - tstart
+            wtimes[pname, psuffix] += dt
 
         # Abort if plugins request it
         self._check_abort()

--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -1,6 +1,6 @@
 import math
 
-from pyfr.integrators.base import BaseIntegrator
+from pyfr.integrators.base import BaseIntegrator, _common_plugin_prop
 from pyfr.integrators.dual.pseudo import get_pseudo_integrator
 
 
@@ -30,40 +30,29 @@ class BaseDualIntegrator(BaseIntegrator):
     def pseudostepinfo(self):
         return self.pseudointegrator.pseudostepinfo
 
-    @property
+    @_common_plugin_prop('_curr_soln')
     def soln(self):
-        if not self._curr_soln:
-            self._curr_soln = self.system.ele_scal_upts(
-                self.pseudointegrator._idxcurr
-            )
+        return self.system.ele_scal_upts(self.pseudointegrator._idxcurr)
 
-        return self._curr_soln
-
-    @property
+    @_common_plugin_prop('_curr_grad_soln')
     def grad_soln(self):
-        system = self.system
+        self.system.compute_grads(self.tcurr, self.pseudointegrator._idxcurr)
+        return [e.get() for e in self.system.eles_vect_upts]
 
-        if not self._curr_grad_soln:
-            system.compute_grads(self.tcurr, self.pseudointegrator._idxcurr)
-            self._curr_grad_soln = [e.get() for e in system.eles_vect_upts]
-
-        return self._curr_grad_soln
-
-    @property
+    @_common_plugin_prop('_curr_dt_soln')
     def dt_soln(self):
-        system = self.system
+        soln = self.soln
 
-        if not self._curr_dt_soln:
-            copy = self.soln
-            idx = self.pseudointegrator._idxcurr
-            system.rhs(self.tcurr, idx, idx)
-            self._curr_dt_soln = system.ele_scal_upts(idx)
+        idx = self.pseudointegrator._idxcurr
+        self.system.rhs(self.tcurr, idx, idx)
 
-            # Reset current register with original contents
-            for c, e in zip(copy, system.ele_banks):
-                e[idx].set(c)
+        dt_soln = self.system.ele_scal_upts(idx)
 
-        return self._curr_dt_soln
+        # Reset current register with original contents
+        for e, s in zip(self.system.ele_banks, soln):
+            e[idx].set(s)
+
+        return dt_soln
 
     def call_plugin_dt(self, dt):
         rem = math.fmod(dt, self._dt)


### PR DESCRIPTION
This PR attempts to provide more detailed accounting of plugin runtime by breaking out time spent getting common quantities such as the solution.  Currently, this is accounted to the first plugin on a given time step to request such a quantity.