### PR TITLE
Updated inifile.py to accept both ';' and '#' as inline comment prefix

### DIFF
--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -15,7 +15,7 @@ _sentinel = object()
 
 class Inifile:
     def __init__(self, inistr=None):
-        self._cp = cp = ConfigParser(inline_comment_prefixes=[';'])
+        self._cp = cp = ConfigParser(inline_comment_prefixes=[';', '#'])
 
         # Preserve case
         cp.optionxform = str


### PR DESCRIPTION
Modified inifile.py to include '#' as inline comment prefix:

```
def __init__(self, inistr=None):
        self._cp = cp = ConfigParser(inline_comment_prefixes=[';', '#'])
```
