### PR TITLE
preproc expects a bank not array as inupt

### DIFF
--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -31,7 +31,7 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
 
         # Pre-process solution if necessary
         self.system.preproc(self.tcurr,
-                            self.system.ele_scal_upts(self._idxcurr))
+                            self._idxcurr)
 
         # Global degree of freedom count
         self._gndofs = self._get_gndofs()

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -29,9 +29,8 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
         self._regidx = list(range(self.nregs))
         self._idxcurr = 0
 
-        # Pre-process solution if necessary
-        self.system.preproc(self.tcurr,
-                            self._idxcurr)
+        # Pre-process solution
+        self.system.preproc(self.tcurr, self._idxcurr)
 
         # Global degree of freedom count
         self._gndofs = self._get_gndofs()


### PR DESCRIPTION
preproc expects a bank not array as input.

This issue was causing the `preproc` method to miss relevant kernels with it's `_get_kernel` call as the input was an array, not a bank. 

The result was most of the preprocessing kernels were not committed and a proper flow field was not being generated when the preprocessor was called, i.e. first calls of boundary conditions, boundary entropy filtering, were being computed with all zero `uin` array on the very first call. It was then corrected with the first pass of the rhs graph.

Test cases appear visually identical after change. 