### PR TITLE
Minor bugfix in preproc graph.

### DIFF
--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -4,7 +4,8 @@ import math
 from pyfr.solvers.base import BaseInters
 from pyfr.nputil import npeval
 
-class IntersMixin:
+
+class BaseAdvectionIntersMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -12,7 +13,8 @@ class IntersMixin:
                             'entropy-filter' and
                             self.cfg.getint('solver', 'order'))
 
-class BaseAdvectionIntInters(IntersMixin, BaseInters):
+
+class BaseAdvectionIntInters(BaseAdvectionIntersMixin, BaseInters):
     def __init__(self, be, lhs, rhs, elemap, cfg):
         super().__init__(be, lhs, elemap, cfg)
 
@@ -43,7 +45,7 @@ class BaseAdvectionIntInters(IntersMixin, BaseInters):
         self._perm = self._get_perm_for_view(lhs, 'get_scal_fpts_for_inter')
 
 
-class BaseAdvectionMPIInters(IntersMixin, BaseInters):
+class BaseAdvectionMPIInters(BaseAdvectionIntersMixin, BaseInters):
     # Starting tag used for MPI
     BASE_MPI_TAG = 2314
 
@@ -105,7 +107,7 @@ class BaseAdvectionMPIInters(IntersMixin, BaseInters):
             self._entmin_lhs = self._entmin_rhs = None
 
 
-class BaseAdvectionBCInters(IntersMixin, BaseInters):
+class BaseAdvectionBCInters(BaseAdvectionIntersMixin, BaseInters):
     type = None
 
     def __init__(self, be, lhs, elemap, cfgsect, cfg):

--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -17,7 +17,8 @@ class BaseAdvectionIntInters(BaseInters):
         self._scal_rhs = self._scal_view(rhs, 'get_scal_fpts_for_inter')
 
         # Generate the additional view matrices for entropy filtering
-        if cfg.get('solver', 'shock-capturing') == 'entropy-filter':
+        if (cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
+            cfg.getint('solver', 'order') != 0):
             self._entmin_lhs = self._view(
                 lhs, 'get_entmin_int_fpts_for_inter', with_perm=False
             )
@@ -74,7 +75,8 @@ class BaseAdvectionMPIInters(BaseInters):
             self._rhsrank, scal_fpts_tag
         )
 
-        if cfg.get('solver', 'shock-capturing') == 'entropy-filter':
+        if (cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
+            cfg.getint('solver', 'order') != 0):
             self._entmin_lhs = self._xchg_view(
                 lhs, 'get_entmin_int_fpts_for_inter', with_perm=False
             )
@@ -117,7 +119,8 @@ class BaseAdvectionBCInters(BaseInters):
         # Make the simulation time available inside kernels
         self._set_external('t', 'scalar fpdtype_t')
 
-        if cfg.get('solver', 'shock-capturing') == 'entropy-filter':
+        if (cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
+            cfg.getint('solver', 'order') != 0):
             self._entmin_lhs = self._view(lhs, 'get_entmin_bc_fpts_for_inter')
         else:
             self._entmin_lhs = None

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -108,9 +108,6 @@ class BaseAdvectionSystem(BaseSystem):
         # Interpolate the solution to the flux points
         if 'eles/local_entropy' in k:
             g1.add_all(k['eles/disu'])
-            bdeps = k['eles/disu']
-        else:
-            bdeps = []
 
         # Compute local minimum entropy within element
         g1.add_all(k['eles/local_entropy'])
@@ -123,7 +120,7 @@ class BaseAdvectionSystem(BaseSystem):
         # Compute common entropy minima at internal/boundary interfaces
         g1.add_all(k['iint/comm_entropy'], deps=k['eles/local_entropy'])
         g1.add_all(k['bcint/comm_entropy'],
-                   deps=k['eles/local_entropy'] + bdeps)
+                   deps=k['eles/local_entropy'] + k['eles/disu'])
         g1.commit()
 
         if 'mpiint/comm_entropy' in k:

--- a/pyfr/solvers/baseadvec/system.py
+++ b/pyfr/solvers/baseadvec/system.py
@@ -108,6 +108,9 @@ class BaseAdvectionSystem(BaseSystem):
         # Interpolate the solution to the flux points
         if 'eles/local_entropy' in k:
             g1.add_all(k['eles/disu'])
+            bdeps = k['eles/disu']
+        else:
+            bdeps = []
 
         # Compute local minimum entropy within element
         g1.add_all(k['eles/local_entropy'])
@@ -120,7 +123,7 @@ class BaseAdvectionSystem(BaseSystem):
         # Compute common entropy minima at internal/boundary interfaces
         g1.add_all(k['iint/comm_entropy'], deps=k['eles/local_entropy'])
         g1.add_all(k['bcint/comm_entropy'],
-                   deps=k['eles/local_entropy'] + k['eles/disu'])
+                   deps=k['eles/local_entropy'] + bdeps)
         g1.commit()
 
         if 'mpiint/comm_entropy' in k:

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -7,7 +7,8 @@ class FluidIntIntersMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.cfg.get('solver', 'shock-capturing') == 'entropy-filter':
+        if (self.cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
+            self.cfg.getint('solver', 'order') != 0):
             self._be.pointwise.register('pyfr.solvers.euler.kernels.intcent')
 
             self.kernels['comm_entropy'] = lambda: self._be.kernel(
@@ -36,7 +37,8 @@ class FluidMPIIntersMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if self.cfg.get('solver', 'shock-capturing') == 'entropy-filter':
+        if (self.cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
+            self.cfg.getint('solver', 'order') != 0):
             self._be.pointwise.register('pyfr.solvers.euler.kernels.mpicent')
 
             self.kernels['comm_entropy'] = lambda: self._be.kernel(
@@ -85,7 +87,8 @@ class EulerBaseBCInters(TplargsMixin, BaseAdvectionBCInters):
             **self._external_vals
         )
 
-        if self.cfg.get('solver', 'shock-capturing') == 'entropy-filter':
+        if (self.cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
+            self.cfg.getint('solver', 'order') != 0):
             self._be.pointwise.register('pyfr.solvers.euler.kernels.bccent')
             self._tplargs['e_func'] = self.cfg.get('solver-entropy-filter',
                                                    'e-func', 'numerical')

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -7,8 +7,7 @@ class FluidIntIntersMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if (self.cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
-            self.cfg.getint('solver', 'order') != 0):
+        if self._ef_enabled:
             self._be.pointwise.register('pyfr.solvers.euler.kernels.intcent')
 
             self.kernels['comm_entropy'] = lambda: self._be.kernel(
@@ -37,8 +36,7 @@ class FluidMPIIntersMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if (self.cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
-            self.cfg.getint('solver', 'order') != 0):
+        if self._ef_enabled:
             self._be.pointwise.register('pyfr.solvers.euler.kernels.mpicent')
 
             self.kernels['comm_entropy'] = lambda: self._be.kernel(
@@ -87,8 +85,7 @@ class EulerBaseBCInters(TplargsMixin, BaseAdvectionBCInters):
             **self._external_vals
         )
 
-        if (self.cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
-            self.cfg.getint('solver', 'order') != 0):
+        if self._ef_enabled:
             self._be.pointwise.register('pyfr.solvers.euler.kernels.bccent')
             self._tplargs['e_func'] = self.cfg.get('solver-entropy-filter',
                                                    'e-func', 'numerical')

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -98,7 +98,8 @@ class NavierStokesBaseBCInters(TplargsMixin, BaseAdvectionDiffusionBCInters):
             artviscl=self._artvisc_lhs, **self._external_vals
         )
 
-        if self.cfg.get('solver', 'shock-capturing') == 'entropy-filter':
+        if (self.cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
+            self.cfg.getint('solver', 'order') != 0):
             self._be.pointwise.register(
                 'pyfr.solvers.navstokes.kernels.bccent'
             )

--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -98,8 +98,7 @@ class NavierStokesBaseBCInters(TplargsMixin, BaseAdvectionDiffusionBCInters):
             artviscl=self._artvisc_lhs, **self._external_vals
         )
 
-        if (self.cfg.get('solver', 'shock-capturing') == 'entropy-filter' and
-            self.cfg.getint('solver', 'order') != 0):
+        if self._ef_enabled:
             self._be.pointwise.register(
                 'pyfr.solvers.navstokes.kernels.bccent'
             )


### PR DESCRIPTION
Now that the preproc graphs are running properly, there seems to be a bug with running p0 with entropy filtering enabled (even though it shouldn't do anything) due to the disu kernel not being called in preproc: `KeyError: <pyfr.backends.cuda.gimmik.CUDAGiMMiKKernels.mul.<locals>.MulKernel object at 0x0000020A8999E230>`