### PR TITLE
Add linearized constraint/filter kernel for EF.

### DIFF
--- a/doc/src/systems/solver-entropy-filter.rst
+++ b/doc/src/systems/solver-entropy-filter.rst
@@ -24,9 +24,9 @@ Parameterises entropy filter for shock capturing with
 
     *int*
 
-6. ``linearise`` --- linearise constraints and filter kernel:
+6. ``formulation`` --- formulation for constraints and filter kernel:
 
-    *bool*
+    ``nonlinear`` | ``linearised``
 
 Example::
 
@@ -36,7 +36,7 @@ Example::
     e-tol = 1e-6
     e-func = physical
     niters = 2
-    linearise = False
+    formulation = nonlinear
 
 Used in the following Examples:
 

--- a/doc/src/systems/solver-entropy-filter.rst
+++ b/doc/src/systems/solver-entropy-filter.rst
@@ -24,7 +24,7 @@ Parameterises entropy filter for shock capturing with
 
     *int*
 
-6. ``linearize`` --- linearize constraints and filter kernel:
+6. ``linearise`` --- linearise constraints and filter kernel:
 
     *bool*
 
@@ -36,7 +36,7 @@ Example::
     e-tol = 1e-6
     e-func = physical
     niters = 2
-    linearize = False
+    linearise = False
 
 Used in the following Examples:
 

--- a/doc/src/systems/solver-entropy-filter.rst
+++ b/doc/src/systems/solver-entropy-filter.rst
@@ -24,6 +24,10 @@ Parameterises entropy filter for shock capturing with
 
     *int*
 
+6. ``linearize`` --- linearize constraints and filter kernel:
+
+    *bool*
+
 Example::
 
     [solver-entropy-filter]
@@ -32,6 +36,7 @@ Example::
     e-tol = 1e-6
     e-func = physical
     niters = 2
+    linearize = False
 
 Used in the following Examples:
 

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -158,8 +158,7 @@ class BaseAdvectionElements(BaseElements):
                                               initval=entmin_int)
 
             # Setup nodal/modal operator matrices
-            linearize = self.cfg.getbool('solver-entropy-filter', 'linearize',
-                                         False)
+            linearize = self.cfg.getbool('solver-entropy-filter', 'linearize')
             if linearize:
                 self.invvdm = self.vdm_ef = None
             else:

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -158,14 +158,20 @@ class BaseAdvectionElements(BaseElements):
                                               initval=entmin_int)
 
             # Setup nodal/modal operator matrices
-            self.invvdm = self._be.const_matrix(self.basis.ubasis.invvdm.T)
-            if self.basis.fpts_in_upts:
-                self.vdm_ef = self._be.const_matrix(self.basis.ubasis.vdm.T)
-                self.m0 = None
+            linearize = self.cfg.getbool('solver-entropy-filter', 'linearize',
+                                         False)
+            if linearize:
+                self.invvdm = self.vdm_ef = None
             else:
+                self.invvdm = self._be.const_matrix(self.basis.ubasis.invvdm.T)
                 vdmu = self.basis.ubasis.vdm.T
                 vdmf = self.basis.ubasis.vdm_at(self.basis.fpts).T
-                self.vdm_ef = self._be.const_matrix(np.vstack((vdmu, vdmf)))
+                vdm = vdmu if self.basis.fpts_in_upts else np.vstack((vdmu, vdmf))
+                self.vdm_ef = self._be.const_matrix(vdm)
+
+            if self.basis.fpts_in_upts:
+                self.m0 = None
+            else:
                 self.m0 = self._be.const_matrix(self.basis.m0)
         else:
             self.entmin_int = None

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -158,7 +158,7 @@ class BaseAdvectionElements(BaseElements):
                                               initval=entmin_int)
 
             # Setup nodal/modal operator matrices
-            if self.cfg.getbool('solver-entropy-filter', 'linearise'):
+            if self.cfg.getbool('solver-entropy-filter', 'linearise', False):
                 self.invvdm = self.vdm_ef = None
             else:
                 self.invvdm = self._be.const_matrix(self.basis.ubasis.invvdm.T)

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -158,8 +158,7 @@ class BaseAdvectionElements(BaseElements):
                                               initval=entmin_int)
 
             # Setup nodal/modal operator matrices
-            linearize = self.cfg.getbool('solver-entropy-filter', 'linearize')
-            if linearize:
+            if self.cfg.getbool('solver-entropy-filter', 'linearise'):
                 self.invvdm = self.vdm_ef = None
             else:
                 self.invvdm = self._be.const_matrix(self.basis.ubasis.invvdm.T)

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -158,14 +158,18 @@ class BaseAdvectionElements(BaseElements):
                                               initval=entmin_int)
 
             # Setup nodal/modal operator matrices
-            if self.cfg.getbool('solver-entropy-filter', 'linearise', False):
+            form = self.cfg.get('solver-entropy-filter', 'formulation',
+                                'nonlinear')
+            if form == 'linearised':
                 self.invvdm = self.vdm_ef = None
-            else:
+            elif form == 'nonlinear':
                 self.invvdm = self._be.const_matrix(self.basis.ubasis.invvdm.T)
                 vdmu = self.basis.ubasis.vdm.T
                 vdmf = self.basis.ubasis.vdm_at(self.basis.fpts).T
                 vdm = vdmu if self.basis.fpts_in_upts else np.vstack((vdmu, vdmf))
                 self.vdm_ef = self._be.const_matrix(vdm)
+            else:
+                raise ValueError('Invalid entropy filter formulation.')
 
             if self.basis.fpts_in_upts:
                 self.m0 = None

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -99,7 +99,7 @@ class BaseFluidElements:
             fpts_in_upts = self.basis.fpts_in_upts
             self.nefpts = self.nupts if fpts_in_upts else self.nupts + self.nfpts
             ub = self.basis.ubasis
-            meanwts = ub.invvdm[:,0]/np.sum(ub.invvdm[:,0])
+            meanwts = ub.invvdm[:, 0] / np.sum(ub.invvdm[:, 0])
             eftplargs = {
                 'ndims': self.ndims, 'nupts': self.nupts,
                 'nfpts': self.nfpts, 'nefpts': self.nefpts,
@@ -135,10 +135,10 @@ class BaseFluidElements:
             if efunc not in {'numerical', 'physical'}:
                 raise ValueError(f'Unknown entropy functional: {efunc}')
 
-            # Use linearized constraints/limiting kernel approach from
+            # Use linearised constraints/limiting kernel approach from
             # Ching et al. (doi:10.1016/j.jcp.2024.112881)
-            eftplargs['linearize'] = self.cfg.getbool('solver-entropy-filter',
-                                                      'linearize', False)
+            eftplargs['linearise'] = self.cfg.getbool('solver-entropy-filter',
+                                                      'linearise', False)
 
             # Precompute basis orders for filter
             ubdegs = self.basis.ubasis.degrees

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -137,8 +137,9 @@ class BaseFluidElements:
 
             # Use linearised constraints/limiting kernel approach from
             # Ching et al. (doi:10.1016/j.jcp.2024.112881)
-            eftplargs['linearise'] = self.cfg.getbool('solver-entropy-filter',
-                                                      'linearise')
+            form = self.cfg.get('solver-entropy-filter', 'formulation',
+                                'nonlinear')
+            eftplargs['linearise'] = form == 'linearised'
 
             # Precompute basis orders for filter
             ubdegs = self.basis.ubasis.degrees

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -138,7 +138,7 @@ class BaseFluidElements:
             # Use linearised constraints/limiting kernel approach from
             # Ching et al. (doi:10.1016/j.jcp.2024.112881)
             eftplargs['linearise'] = self.cfg.getbool('solver-entropy-filter',
-                                                      'linearise', False)
+                                                      'linearise')
 
             # Precompute basis orders for filter
             ubdegs = self.basis.ubasis.degrees

--- a/pyfr/solvers/euler/elements.py
+++ b/pyfr/solvers/euler/elements.py
@@ -98,12 +98,15 @@ class BaseFluidElements:
             # Template arguments
             fpts_in_upts = self.basis.fpts_in_upts
             self.nefpts = self.nupts if fpts_in_upts else self.nupts + self.nfpts
+            ub = self.basis.ubasis
+            meanwts = ub.invvdm[:,0]/np.sum(ub.invvdm[:,0])
             eftplargs = {
                 'ndims': self.ndims, 'nupts': self.nupts,
                 'nfpts': self.nfpts, 'nefpts': self.nefpts,
                 'nvars': self.nvars, 'nfaces': self.nfaces,
                 'c': self.cfg.items_as('constants', float),
-                'order': self.basis.order, 'fpts_in_upts': fpts_in_upts
+                'order': self.basis.order, 'fpts_in_upts': fpts_in_upts,
+                'meanwts': meanwts
             }
 
             # Check to see if running anti-aliasing
@@ -131,6 +134,11 @@ class BaseFluidElements:
             eftplargs['e_func'] = efunc
             if efunc not in {'numerical', 'physical'}:
                 raise ValueError(f'Unknown entropy functional: {efunc}')
+
+            # Use linearized constraints/limiting kernel approach from
+            # Ching et al. (doi:10.1016/j.jcp.2024.112881)
+            eftplargs['linearize'] = self.cfg.getbool('solver-entropy-filter',
+                                                      'linearize', False)
 
             # Precompute basis orders for filter
             ubdegs = self.basis.ubasis.degrees

--- a/pyfr/solvers/euler/kernels/entropyfilter.mako
+++ b/pyfr/solvers/euler/kernels/entropyfilter.mako
@@ -114,10 +114,10 @@
 
         // Apply density, pressure, and entropy limiting sequentially
         fpdtype_t alpha;
-        % for (fvar, bound) in [('d', f'{d_min}'), ('p', f'{p_min}'), ('e', f'entmin - {e_tol}')]:
+        % for (fvar, bound) in [('d', d_min), ('p', p_min), ('e', f'entmin - {e_tol}')]:
         if (${f'{fvar}min < {bound}'}) 
         {
-            alpha = (${f'{fvar}min'} - (${bound}))/(${f'{fvar}min'} - ${f'{fvar}avg'});
+            alpha = ${f'({fvar}min - ({bound}))/({fvar}min - {fvar}avg)'};
             alpha = fmin(fmax(alpha, 0.0), 1.0);
 
             % for uidx, vidx in pyfr.ndrange(nupts, 1 if fvar == 'd' else nvars):

--- a/pyfr/solvers/euler/kernels/entropyfilter.mako
+++ b/pyfr/solvers/euler/kernels/entropyfilter.mako
@@ -102,7 +102,7 @@
     // Filter if out of bounds
     if (dmin < ${d_min} || pmin < ${p_min} || emin < entmin - ${e_tol})
     {
-        % if linearize:
+        % if linearise:
         // Compute mean quantities
         fpdtype_t uavg[${nvars}], davg, pavg, eavg;
         % for vidx in range(nvars):

--- a/pyfr/solvers/euler/kernels/entropyfilter.mako
+++ b/pyfr/solvers/euler/kernels/entropyfilter.mako
@@ -115,9 +115,9 @@
         // Apply density, pressure, and entropy limiting sequentially
         fpdtype_t alpha;
         % for (fvar, bound) in [('d', d_min), ('p', p_min), ('e', f'entmin - {e_tol}')]:
-        if (${f'{fvar}min < {bound}'}) 
+        if (${fvar}min < ${bound}) 
         {
-            alpha = ${f'({fvar}min - ({bound}))/({fvar}min - {fvar}avg)'};
+            alpha = (${fvar}min - (${bound}))/(${fvar}min - ${fvar}avg);
             alpha = fmin(fmax(alpha, 0.0), 1.0);
 
             % for uidx, vidx in pyfr.ndrange(nupts, 1 if fvar == 'd' else nvars):


### PR DESCRIPTION
This PR adds the option to use the linearized formulation for the entropy filter from Ching et al. (10.1016/j.jcp.2024.112881), which linearizes the pressure/entropy constraints and uses a linear Zhang/Shu-type limiter. This avoids the root-finding problem for EF at the expense of a more dissipative limiter (which can also sometimes be beneficial for strong shocks/poor grids). 