### PR TITLE
Updated invariant set definition

### DIFF
--- a/pyfr/solvers/euler/kernels/entropy.mako
+++ b/pyfr/solvers/euler/kernels/entropy.mako
@@ -10,7 +10,7 @@
 
     // Compute numerical or specific physical entropy
     % if e_func == 'numerical':
-    e = (d > 0 && p > 0) ? d*(log(p) - ${c['gamma']}*log(d)) : ${fpdtype_max};
+    e = (d > 0 && p > 0) ? log(p) - ${c['gamma']}*log(d) : ${fpdtype_max};
     % elif e_func == 'physical':
     e = (d > 0 && p > 0) ? p*pow(rcpd, ${c['gamma']}) : ${fpdtype_max};
     % endif


### PR DESCRIPTION
This pull request clarifies the definition of the invariant set with respect to entropy filtering, as well as the distinction between the entropy on a per volume bases, and the specific entropy on a per mass basis (i.e. $\rho s$ versus $s$). The new invariant set is defined as $G=\{ \rho > 0, p > 0, \chi > 0\}$, where $\chi = \rho(s-s_{0})$, and $s_0$ is the local minimum specific entropy. 

This is different from the current definition, which would define $\chi$ as $\chi=\rho s - (\rho s)_{0}$, which is not necessarily a convex function. The definition of $\chi$ above, however, is convex. (There is further confusion in the distinction between the `physical` and `numerical` definitions in PyFR as one is multiplied by density and the other is not).

This clarifies that the entropy computed in the `entropy.mako` kernel is the specific entropy, $s$.

Further, the use of this invariant set greatly reduces the sensitivity to the definition of $s$. Other valid forms of entropy such as a dimensional entropy, or the numerical entropy plus a constant create dramatically different results. With this formulation, the other valid forms of entropy are visually identical in test cases. 

This formulation is consistent with Ching et al. (https://doi.org/10.1016/j.jcp.2024.112881) and Jiang & Liu (https://doi.org/10.1016/j.jcp.2018.03.004)