### PR TITLE
Workaround for Ascent bug when running on Alps

### DIFF
--- a/pyfr/plugins/ascent.py
+++ b/pyfr/plugins/ascent.py
@@ -482,7 +482,7 @@ class _AscentRenderer:
         # Iterate over each element type in our region
         for d_str, idx, rgn, soln_op in self._ele_regions_lin:
             self.mesh_n[f'{d_str}/state/time/keyword'] = 'Time'
-            self.mesh_n[f'{d_str}/state/time/data'] = adapter.tcurr
+            self.mesh_n[f'{d_str}/state/time/data'] = str(adapter.tcurr)
 
             # Subset and transpose the solution
             csolns = soln[idx][..., rgn].swapaxes(0, 1)


### PR DESCRIPTION
Ascent throws an error when trying to write metadata to PNGs when running on Alps. I've raised an issue which has more detail on this here: https://github.com/Alpine-DAV/ascent/issues/1389 

It boils down to an issue that is occurring when it tries to convert a float (the simulation time in this case) to a string. Doing this conversion in PyFR is a workaround that prevents the error - I don't know if we want to include this fix now or wait and see what the Ascent developers say.