### PR TITLE
Using a topological sort to order kernels on OpenMP backend

### DIFF
--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -226,7 +226,6 @@ class OpenMPGraph(base.Graph):
 
         # Do topological sort on kernels/groups to get run order
         # Add in as many pdeps as possible without creating a cycle
-        print(self.dep_graph)
         for pdep in self.pdeps:
             self.dep_graph[pdep[0]].append(pdep[1])
             try:
@@ -236,7 +235,6 @@ class OpenMPGraph(base.Graph):
                 self.dep_graph[pdep[0]].remove(pdep[1])
         ts = TopologicalSorter(self.dep_graph)
         self.run_order = tuple(ts.static_order())
-        print(self.dep_graph)
 
         # Get MPI request idxs
         mpi_idxs = defaultdict(list)

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -227,13 +227,12 @@ class OpenMPGraph(base.Graph):
         # Do topological sort on kernels/groups to get run order
         ts = TopologicalSorter(self.dep_graph)
         self.run_order = tuple(ts.static_order())
-        # print(self.run_order)
 
         # Get MPI request idxs
         self.mpi_idxs = defaultdict(list)
         for req, deps in zip(self.mpi_reqs, self.mpi_req_deps):
             if deps:
-                ix = max([i for i, k in enumerate(self.run_order) if k in deps])
+                ix = max([i + 1 for i, k in enumerate(self.run_order) if k in deps])
                 self.mpi_idxs[ix].append(req)
 
         # Group kernels in runs separated by MPI requests


### PR DESCRIPTION
This pull request uses a topological sort to create a run list for the kernels on the OpenMP backend. This fixes an issue where dependencies between kernels might not be respected after setting a cache blocking group.

I've tested this on the AV test case I was using previously and on all cases in the PyFR test case repo with 10 MPI ranks on the OpenMP backend - they all look good. I've not touched any of the other backends but let me know if there are any further testing you'd like me to do for this pull request.