### PR TITLE
Add impermeable ghost state calculation for viscous walls

### DIFF
--- a/pyfr/solvers/navstokes/inters.py
+++ b/pyfr/solvers/navstokes/inters.py
@@ -112,7 +112,7 @@ class NavierStokesBaseBCInters(TplargsMixin, BaseAdvectionDiffusionBCInters):
 
 class NavierStokesNoSlpIsotWallBCInters(NavierStokesBaseBCInters):
     type = 'no-slp-isot-wall'
-    cflux_state = 'ghost'
+    cflux_state = 'ghost-imperm'
 
     def __init__(self, be, lhs, elemap, cfgsect, cfg):
         super().__init__(be, lhs, elemap, cfgsect, cfg)
@@ -124,7 +124,7 @@ class NavierStokesNoSlpIsotWallBCInters(NavierStokesBaseBCInters):
 
 class NavierStokesNoSlpAdiaWallBCInters(NavierStokesBaseBCInters):
     type = 'no-slp-adia-wall'
-    cflux_state = 'ghost'
+    cflux_state = 'ghost-imperm'
 
 
 class NavierStokesSlpAdiaWallBCInters(NavierStokesBaseBCInters):

--- a/pyfr/solvers/navstokes/kernels/bcs/ghost-imperm.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/ghost-imperm.mako
@@ -4,8 +4,6 @@
 <%include file='pyfr.solvers.euler.kernels.rsolvers.${rsolver}'/>
 <%include file='pyfr.solvers.navstokes.kernels.flux'/>
 
-<% tau = c['ldg-tau'] %>
-
 <%pyfr:macro name='bc_common_flux_state' params='ul, gradul, artviscl, nl, magnl'>
     // Viscous states
     fpdtype_t ur[${nvars}], gradur[${ndims}][${nvars}];

--- a/pyfr/solvers/navstokes/kernels/bcs/ghost-imperm.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/ghost-imperm.mako
@@ -1,0 +1,30 @@
+<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
+
+<%include file='pyfr.solvers.baseadvecdiff.kernels.artvisc'/>
+<%include file='pyfr.solvers.euler.kernels.rsolvers.${rsolver}'/>
+<%include file='pyfr.solvers.navstokes.kernels.flux'/>
+
+<% tau = c['ldg-tau'] %>
+
+<%pyfr:macro name='bc_common_flux_state' params='ul, gradul, artviscl, nl, magnl'>
+    // Viscous states
+    fpdtype_t ur[${nvars}], gradur[${ndims}][${nvars}];
+    ${pyfr.expand('bc_ldg_state', 'ul', 'nl', 'ur')};
+    ${pyfr.expand('bc_ldg_grad_state', 'ur', 'nl', 'gradul', 'gradur')};
+
+    fpdtype_t fvr[${ndims}][${nvars}] = {{0}};
+    ${pyfr.expand('viscous_flux_add', 'ur', 'gradur', 'fvr')};
+    ${pyfr.expand('artificial_viscosity_add', 'gradur', 'fvr', 'artviscl')};
+
+    // Inviscid (Riemann solve) state
+    ${pyfr.expand('bc_rsolve_state', 'ul', 'nl', 'ur')};
+
+    // Perform the Riemann solve
+    fpdtype_t ficomm[${nvars}], fvcomm;
+    ${pyfr.expand('rsolve', 'ul', 'ur', 'nl', 'ficomm')};
+
+% for i in range(nvars):
+    fvcomm = ${' + '.join(f'nl[{j}]*fvr[{j}][{i}]' for j in range(ndims))};
+    ul[${i}] = magnl*(ficomm[${i}] + fvcomm);
+% endfor
+</%pyfr:macro>

--- a/pyfr/solvers/navstokes/kernels/bcs/no-slp-adia-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/no-slp-adia-wall.mako
@@ -18,11 +18,11 @@
                      - (0.5/ul[0])*${pyfr.dot('ul[{i}]', i=(1, ndims + 1))};
 </%pyfr:macro>
 
-<%pyfr:macro name='bc_ldg_grad_state' params='ul, nl, grad_ul, grad_ur'>
-    fpdtype_t rcprho = 1.0/ul[0];
+<%pyfr:macro name='bc_ldg_grad_state' params='ur, nl, grad_ul, grad_ur'>
+    fpdtype_t rcprho = 1.0/ur[0];
 
 % if ndims == 2:
-    fpdtype_t u = rcprho*ul[1], v = rcprho*ul[2];
+    fpdtype_t u = rcprho*ur[1], v = rcprho*ur[2];
 
     fpdtype_t u_x = grad_ul[0][1] - u*grad_ul[0][0];
     fpdtype_t u_y = grad_ul[1][1] - u*grad_ul[1][0];
@@ -30,20 +30,20 @@
     fpdtype_t v_y = grad_ul[1][2] - v*grad_ul[1][0];
 
     // Compute temperature derivatives (c_v*rho*dT/d[x,y,z])
-    fpdtype_t Tl_x = grad_ul[0][3] - (rcprho*grad_ul[0][0]*ul[3]
+    fpdtype_t Tl_x = grad_ul[0][3] - (rcprho*grad_ul[0][0]*ur[3]
                                       + u*u_x + v*v_x);
-    fpdtype_t Tl_y = grad_ul[1][3] - (rcprho*grad_ul[1][0]*ul[3]
+    fpdtype_t Tl_y = grad_ul[1][3] - (rcprho*grad_ul[1][0]*ur[3]
                                       + u*u_y + v*v_y);
 
     // Copy all fluid-side gradients across to wall-side gradients
-    ${pyfr.expand('bc_common_grad_copy', 'ul', 'nl', 'grad_ul', 'grad_ur')};
+    ${pyfr.expand('bc_common_grad_copy', 'ur', 'nl', 'grad_ul', 'grad_ur')};
 
     // Correct copied across in-fluid temp gradients to in-wall gradients
     grad_ur[0][3] -= nl[0]*nl[0]*Tl_x + nl[0]*nl[1]*Tl_y;
     grad_ur[1][3] -= nl[1]*nl[0]*Tl_x + nl[1]*nl[1]*Tl_y;
 
 % elif ndims == 3:
-    fpdtype_t u = rcprho*ul[1], v = rcprho*ul[2], w = rcprho*ul[3];
+    fpdtype_t u = rcprho*ur[1], v = rcprho*ur[2], w = rcprho*ur[3];
 
     // Velocity derivatives (rho*grad[u,v,w])
     fpdtype_t u_x = grad_ul[0][1] - u*grad_ul[0][0];
@@ -57,15 +57,15 @@
     fpdtype_t w_z = grad_ul[2][3] - w*grad_ul[2][0];
 
     // Compute temperature derivatives (c_v*rho*dT/d[x,y,z])
-    fpdtype_t Tl_x = grad_ul[0][4] - (rcprho*grad_ul[0][0]*ul[4]
+    fpdtype_t Tl_x = grad_ul[0][4] - (rcprho*grad_ul[0][0]*ur[4]
                                       + u*u_x + v*v_x + w*w_x);
-    fpdtype_t Tl_y = grad_ul[1][4] - (rcprho*grad_ul[1][0]*ul[4]
+    fpdtype_t Tl_y = grad_ul[1][4] - (rcprho*grad_ul[1][0]*ur[4]
                                       + u*u_y + v*v_y + w*w_y);
-    fpdtype_t Tl_z = grad_ul[2][4] - (rcprho*grad_ul[2][0]*ul[4]
+    fpdtype_t Tl_z = grad_ul[2][4] - (rcprho*grad_ul[2][0]*ur[4]
                                       + u*u_z + v*v_z + w*w_z);
 
     // Copy all fluid-side gradients across to wall-side gradients
-    ${pyfr.expand('bc_common_grad_copy', 'ul', 'nl', 'grad_ul', 'grad_ur')};
+    ${pyfr.expand('bc_common_grad_copy', 'ur', 'nl', 'grad_ul', 'grad_ur')};
 
     // Correct copied across in-fluid temp gradients to in-wall gradients
     grad_ur[0][4] -= nl[0]*nl[0]*Tl_x + nl[0]*nl[1]*Tl_y + nl[0]*nl[2]*Tl_z;


### PR DESCRIPTION
This PR addresses viscous wall boundary conditions and their impermeability.

**Adiabatic No Slip Walls - Temperature Gradient**

The viscous flux is adiabatic when the normal flux calculation for the energy equation is zero. For heat conduction, this is achieved by setting the normal temperature gradient to be zero (shear stress energy is zero from zero velocity at the wall). Currently:

1. `ldg-state` (prescribing `ur` from `ul`) sensibly sets the wall solution momentum to zero, and matches density and internal energy from the fluid side. 
2. `ldg-grad-state` (prescribing `gradur` from `gradul`,`ul`) we copy all gradients from the left to the right, and then modify the total energy gradient s.t. when computing the temperature gradient in the viscous flux calculation, the normal temperature gradient is zero. This transformation, however, us done using the values of `gradul` and `ul` in the LDG Grad state routine. Critically, the temperature gradient calculation requires solution variables AND gradient variables. 
3. When the viscous flux at the wall is calculated, only the _right_ state is considered, i.e. $f_{wall} = g(ur, gradur)$. But, `gradur` was modified to yield zero normal temperature gradient based on `ul` solution values. Thus when the temperature gradient is computed in the viscous flux add routine, it does not yield zero normal temperature flux, and the impermeability of the wall BC is compromised.

**LDG Penalty term**

The next issue is the LDG penalty term $\tau(ul-ur)$. Since `ul`$\neq$`ur`, this term is non-zero, and directly adds normal flux to all variables (except density, which is the same on the left and right). This, again, compromises the impermeability of the wall boundary condition.

This PR creates a new ghost routine called `ghost-imperm` for the `no-slp-adia-wall` and `no-slp-isot-wall` boundary condition in the navier-stokes system. The difference being that `ghost-imperm` computes the temperature gradient in `ldg_grad_state` based on the previously defined `ur` and `gradul` (see L13 of `ghost-imperm`) so the values are correct in `viscous_flux_add`. Also the LDG penalty term is removed. Behavior of inlets and outlets remains the same.

I have tested the PyFR-Test-Cases that use walls and there is no significant change. The only noticeable change is in the viscous shock tube (see results below, current develop on top, new boundary condition on bottom). The issue is more apparent when the temperature gradient near the wall is very large, the velocity near the wall is non-zero, the wall normal is not aligned with a cartesian vector. 

<img width="890" alt="Screenshot 2024-12-11 at 5 06 01 PM" src="https://github.com/user-attachments/assets/548ba6f1-7ef2-4ba4-b817-3d819be9b99b" />
