### PR TITLE
Variable not necessary

### DIFF
--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -175,8 +175,6 @@ class BaseAdvectionElements(BaseElements):
                 self.m0 = None
             else:
                 self.m0 = self._be.const_matrix(self.basis.m0)
-        else:
-            self.entmin_int = None
 
     def get_entmin_int_fpts_for_inter(self, eidx, fidx):
         return (self.entmin_int.mid,), (fidx,), (eidx,)


### PR DESCRIPTION
I don't think it is necessary to set this to none and is causing incorrect behavior downstream when entropy filtering is not being used and checks using `hasattr` are made, see: https://github.com/PyFR/PyFR/blob/52b34313755cc4160b686057229804c880339d36/pyfr/solvers/base/system.py#L65

I cannot find any logic where entorpy filtering is not being used, but the `entmin_int` variable is required to be `None`.