### PR TITLE
Respecting dependencies when inserting a cache blocking group into the run order for the OpenMP backend

### DIFF
--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -185,12 +185,13 @@ class OpenMPGraph(base.Graph):
         gdeps = []
         for k in kerns:
             gdeps = gdeps + [dep for dep in self.kdeps[k] if dep not in kerns]
-        gid = None
+ 
         if gdeps:
             lk = max(self.knodes[dep] for dep in gdeps)
             gid = min(self.knodes[k] for k in kerns if self.knodes[k] > lk) - 1
         else:
             gid = min(self.knodes[k] for k in kerns) - 1
+
         self.kins[gid] = groups
         
         # Sanity check that other dependencies haven't been violated

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -182,12 +182,22 @@ class OpenMPGraph(base.Graph):
             groups.append(rargs)
 
         # Arrange for the groupings to be inserted into the final run list
-        group_deps = [dep for k in kerns for dep in self.kdeps[k]]
+        group_deps = [dep for k in kerns for dep in self.kdeps[k] if dep not in kerns]
+        group_kins_ind = None
         if group_deps:
             max_dep_ind = max(self.knodes[dep] for dep in group_deps)
-            self.kins[min(self.knodes[k] for k in kerns if self.knodes[k] > max_dep_ind) - 1] = groups
+            group_kins_ind = min(self.knodes[k] for k in kerns if self.knodes[k] > max_dep_ind) - 1
+            self.kins[group_kins_ind] = groups
         else:
-            self.kins[min(self.knodes[k] for k in kerns) - 1] = groups
+            group_kins_ind = min(self.knodes[k] for k in kerns) - 1
+            self.kins[group_kins_ind] = groups
+        
+        # Sanity check that other dependencies haven't been violated
+        for k in self.kdeps:
+            if k not in kerns:
+                for dep in self.kdeps[k]:
+                    if dep in kerns and self.knodes[k] < group_kins_ind:
+                        raise RuntimeError('Graph dependencies not met after grouping')
 
         # Finally, prevent grouped being added to the final run list
         for k in kerns:

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -182,18 +182,12 @@ class OpenMPGraph(base.Graph):
             groups.append(rargs)
 
         # Arrange for the groupings to be inserted into the final run list
-        gdeps = []
-        for k in kerns:
-            gdeps = gdeps + [dep for dep in self.kdeps[k] if dep not in kerns]
- 
-        if gdeps:
-            lk = max(self.knodes[dep] for dep in gdeps)
-            gid = min(self.knodes[k] for k in kerns if self.knodes[k] > lk) - 1
-        else:
-            gid = min(self.knodes[k] for k in kerns) - 1
-
+        gdeps = [dep for k in kerns \
+                        for dep in self.kdeps[k] if dep not in kerns]
+        lk = max((self.knodes[dep] for dep in gdeps), default=-1)
+        gid = min(self.knodes[k] for k in kerns if self.knodes[k] > lk) - 1
         self.kins[gid] = groups
-        
+
         # Sanity check that other dependencies haven't been violated
         for k in self.kdeps:
             if k not in kerns:

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -182,7 +182,12 @@ class OpenMPGraph(base.Graph):
             groups.append(rargs)
 
         # Arrange for the groupings to be inserted into the final run list
-        self.kins[max(self.knodes[k] for k in kerns) - 1] = groups
+        group_deps = [dep for k in kerns for dep in self.kdeps[k]]
+        if group_deps:
+            max_dep_ind = max(self.knodes[dep] for dep in group_deps)
+            self.kins[min(self.knodes[k] for k in kerns if self.knodes[k] > max_dep_ind) - 1] = groups
+        else:
+            self.kins[min(self.knodes[k] for k in kerns) - 1] = groups
 
         # Finally, prevent grouped being added to the final run list
         for k in kerns:

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -182,11 +182,10 @@ class OpenMPGraph(base.Graph):
             groups.append(rargs)
 
         # Arrange for the groupings to be inserted into the final run list
-        gdeps = [dep for k in kerns \
+        gdeps = [dep for k in kerns
                         for dep in self.kdeps[k] if dep not in kerns]
         lk = max((self.knodes[dep] for dep in gdeps), default=-1)
         gid = min(self.knodes[k] for k in kerns if self.knodes[k] > lk) - 1
-        self.kins[gid] = groups
 
         # Sanity check that other dependencies haven't been violated
         for k in self.kdeps:
@@ -194,6 +193,8 @@ class OpenMPGraph(base.Graph):
                 for dep in self.kdeps[k]:
                     if dep in kerns and self.knodes[k] < gid:
                         raise RuntimeError('Graph grouping dependency error')
+
+        self.kins[gid] = groups
 
         # Finally, prevent grouped being added to the final run list
         for k in kerns:

--- a/pyfr/backends/openmp/types.py
+++ b/pyfr/backends/openmp/types.py
@@ -182,8 +182,8 @@ class OpenMPGraph(base.Graph):
             groups.append(rargs)
 
         # Arrange for the groupings to be inserted into the final run list
-        gdeps = [dep for k in kerns
-                        for dep in self.kdeps[k] if dep not in kerns]
+        gdeps = [dep for k in kerns 
+                 for dep in self.kdeps[k] if dep not in kerns]
         lk = max((self.knodes[dep] for dep in gdeps), default=-1)
         gid = min(self.knodes[k] for k in kerns if self.knodes[k] > lk) - 1
 


### PR DESCRIPTION
This pull request inserts a cache blocking group into a graph's run order while respecting dependencies. Previously, a group replaced its last running kernel in a graph's run order without checking for dependencies. Now, the position of each kernel within a group is considered, with the earliest position that doesn't violate any dependencies being selected.

I've also added a quick sanity check afterwards to check that this positioning does not violate other dependencies.