### PR TITLE
Fix TI having wrong magnitude if avg-u is not 1.0

### DIFF
--- a/pyfr/plugins/turbulence.py
+++ b/pyfr/plugins/turbulence.py
@@ -70,7 +70,7 @@ class TurbulencePlugin(BaseSolverPlugin):
             gamma = self.cfg.getfloat('constants', 'gamma')
             avgrho = self.cfg.getfloat(cfgsect, 'avg-rho')
             avgmach = self.cfg.getfloat(cfgsect, 'avg-mach')
-            beta2 = avgrho*(gamma - 1)*avgmach**2
+            beta2 = (avgrho/avgu)*(gamma - 1)*avgmach**2
         else:
             beta2 = 0
 


### PR DESCRIPTION
This fixes a bug that results in density fluctuations being of the wrong magnitude when avg-u is not 1.0. 
The beta2 term is set using the following: `beta2 = avgrho*(gamma - 1)*avgmach**2`
But it should actually be: `beta2 = (avgrho/avgu)*(gamma - 1)*avgmach**2`
This is from equation 31 of [https://doi.org/10.2514/1.J061046](https://doi.org/10.2514/1.J061046)

I was running a simulation with avg-u ~ 200 and the fluctuations were very big, but with this fix I am now seeing reasonable results and the measured turbulence injection is close to what I am setting in the ini file.