### PR TITLE
Outputting tavg files at expected times when restarting

### DIFF
--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -137,9 +137,10 @@ class BaseIntegrator:
         else:
             return f'plugins/{name}'
 
-    def call_plugin_dt(self, dt):
+    def call_plugin_dt(self, tstart, dt):
         ta = self.tlist
-        tb = deque(np.arange(self.tcurr, self.tend, dt).tolist())
+        tbegin = tstart if tstart > self.tcurr else self.tcurr
+        tb = deque(np.arange(tbegin, self.tend, dt).tolist())
 
         self.tlist = tlist = deque()
 

--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -54,13 +54,17 @@ class BaseDualIntegrator(BaseIntegrator):
 
         return dt_soln
 
-    def call_plugin_dt(self, dt):
+    def call_plugin_dt(self, tstart, dt):
         rem = math.fmod(dt, self._dt)
         tol = 5.0*self.dtmin
         if rem > tol and (self._dt - rem) > tol:
             raise ValueError('Plugin call times must be multiples of dt')
+        
+        rem_tstart = math.fmod(tstart, self._dt)
+        if rem_tstart > tol and (self._dt - rem_tstart) > tol:
+            raise ValueError('Plugin start times must be multiples of dt')
 
-        super().call_plugin_dt(dt)
+        super().call_plugin_dt(tstart, dt)
 
     def collect_stats(self, stats):
         super().collect_stats(stats)

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -116,9 +116,8 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         # Check if we are restarting and not before when tavg begins
         if intg.isrestart and intg.tcurr >= self.tstart:
             self.tout_last = intg.tcurr
-            self.init_tout_last = False
         else:
-            self.init_tout_last = True
+            self.tout_last = None
 
     def _prepare_exprs(self):
         cfg, cfgsect = self.cfg, self.cfgsect
@@ -161,10 +160,9 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
     def _init_accumex(self, intg):
         self.tstart_acc = self.prevt = intg.tcurr
 
-        if self.init_tout_last:
+        # Don't change tout_last if we are restarting past tstart
+        if self._started or self.tout_last is None:
             self.tout_last = intg.tcurr
-        else:
-            self.init_tout_last = True
 
         self.prevex = self._eval_acc_exprs(intg)
         self.accex = [np.zeros_like(p, dtype=np.float64) for p in self.prevex]

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -160,10 +160,12 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
 
     def _init_accumex(self, intg):
         self.tstart_acc = self.prevt = intg.tcurr
+
         if self.init_tout_last:
             self.tout_last = intg.tcurr
         else:
             self.init_tout_last = True
+
         self.prevex = self._eval_acc_exprs(intg)
         self.accex = [np.zeros_like(p, dtype=np.float64) for p in self.prevex]
         self.vaccex = [np.zeros_like(a) for a in self.accex]

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -98,7 +98,7 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         self.nsteps = self.cfg.getint(cfgsect, 'nsteps')
 
         # Register our output times with the integrator
-        intg.call_plugin_dt(self.dtout)
+        intg.call_plugin_dt(self.tstart, self.dtout)
 
         # Mark ourselves as not currently averaging
         self._started = False

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -113,6 +113,13 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         # Reduce
         self.tpts = comm.reduce(tpts, op=mpi.SUM, root=root)
 
+        # Check if we are restarting and not before when tavg begins
+        if intg.isrestart and intg.tcurr >= self.tstart:
+            self.tout_last = intg.tcurr
+            self.init_tout_last = False
+        else:
+            self.init_tout_last = True
+
     def _prepare_exprs(self):
         cfg, cfgsect = self.cfg, self.cfgsect
         c = self.cfg.items_as('constants', float)
@@ -152,7 +159,11 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
                            for pname in gradpnames]
 
     def _init_accumex(self, intg):
-        self.tstart_acc = self.prevt = self.tout_last = intg.tcurr
+        self.tstart_acc = self.prevt = intg.tcurr
+        if self.init_tout_last:
+            self.tout_last = intg.tcurr
+        else:
+            self.init_tout_last = True
         self.prevex = self._eval_acc_exprs(intg)
         self.accex = [np.zeros_like(p, dtype=np.float64) for p in self.prevex]
         self.vaccex = [np.zeros_like(a) for a in self.accex]

--- a/pyfr/plugins/writer.py
+++ b/pyfr/plugins/writer.py
@@ -52,7 +52,7 @@ class WriterPlugin(PostactionMixin, RegionMixin, BaseSolnPlugin):
         self.fpdtype = intg.backend.fpdtype
 
         # Register our output times with the integrator
-        intg.call_plugin_dt(self.tstart, self.dt_out)
+        intg.call_plugin_dt(intg.tcurr, self.dt_out)
 
         # If we're not restarting then make sure we write out the initial
         # solution when we are called for the first time

--- a/pyfr/plugins/writer.py
+++ b/pyfr/plugins/writer.py
@@ -52,7 +52,7 @@ class WriterPlugin(PostactionMixin, RegionMixin, BaseSolnPlugin):
         self.fpdtype = intg.backend.fpdtype
 
         # Register our output times with the integrator
-        intg.call_plugin_dt(self.dt_out)
+        intg.call_plugin_dt(self.tstart, self.dt_out)
 
         # If we're not restarting then make sure we write out the initial
         # solution when we are called for the first time


### PR DESCRIPTION
This PR is in relation to this forum post: https://pyfr.discourse.group/t/tavg-merge-and-tavg-plugin-using-adaptive-time-step/1229/5

There are 2 parts to this PR, the first part is setting `tout_last` in the tavg plugin when restarting so that the output files are written at the expected times. For example, when restarting from t=0.01 and setting dt-out=0.01 you would expect the next tavg file to be written at 0.02 but it was instead being output at 0.02 + dt. This PR fixes it (tested on the example in the forum post).

The second part is writing tavg files at the expected time when setting tstart to a number which is not a multiple of `dt-out` (or a number that doesn't fit restart_time + n * `dt-out`). E.g. setting tstart = 0.015 and dt-out=0.01. I've edited `call_plugin_dt` to now account for this by taking tstart as an input. I've not had first hand experience of the dual time stepping but from I understand the same restriction of dt-out being a multiple of dt should apply to the user specified tstart time - let me know if I have misunderstood though.