### PR TITLE
Time averaging bug fix

### DIFF
--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -82,8 +82,8 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         ershapes = {etype: (nfields, emap[etype].nupts) for etype in erdata}
 
         # Construct the file writer
-        self._writer = NativeWriter.from_integrator(intg, basedir, 
-                                                    basename, 'tavg', 
+        self._writer = NativeWriter.from_integrator(intg, basedir, basename,
+                                                    'tavg', 
                                                     fpdtype=self.fpdtype)
         self._writer.set_shapes_eidxs(ershapes, erdata)
 

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -63,7 +63,7 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         nfields = self._prepare_exprs()
 
         # Output data type
-        fpdtype = self.cfg.get('backend', 'precision', 'single')
+        fpdtype = self.cfg.get(cfgsect, 'precision', 'single')
         if fpdtype == 'single':
             self.fpdtype = np.float32
         elif fpdtype == 'double':
@@ -82,8 +82,10 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         ershapes = {etype: (nfields, emap[etype].nupts) for etype in erdata}
 
         # Construct the file writer
-        self._writer = NativeWriter.from_integrator(intg, basedir, basename,
-                                                    'tavg')
+        self._writer = NativeWriter(intg.system.mesh, intg.cfg, 
+                                    self.fpdtype, basedir, basename, 
+                                    prefix='tavg',
+                                    isrestart=intg.isrestart)
         self._writer.set_shapes_eidxs(ershapes, erdata)
 
         # Asynchronous output options

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -82,8 +82,9 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         ershapes = {etype: (nfields, emap[etype].nupts) for etype in erdata}
 
         # Construct the file writer
-        self._writer = NativeWriter.from_integrator(intg, basedir, basename,
-                                                'tavg', fpdtype=self.fpdtype)
+        self._writer = NativeWriter.from_integrator(intg, basedir, 
+                                                    basename, 'tavg', 
+                                                    fpdtype=self.fpdtype)
         self._writer.set_shapes_eidxs(ershapes, erdata)
 
         # Asynchronous output options

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -63,7 +63,7 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         nfields = self._prepare_exprs()
 
         # Output data type
-        fpdtype = self.cfg.get(cfgsect, 'precision', 'single')
+        fpdtype = self.cfg.get('backend', 'precision', 'single')
         if fpdtype == 'single':
             self.fpdtype = np.float32
         elif fpdtype == 'double':

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -82,10 +82,8 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         ershapes = {etype: (nfields, emap[etype].nupts) for etype in erdata}
 
         # Construct the file writer
-        self._writer = NativeWriter(intg.system.mesh, intg.cfg, 
-                                    self.fpdtype, basedir, basename, 
-                                    prefix='tavg',
-                                    isrestart=intg.isrestart)
+        self._writer = NativeWriter.from_integrator(intg, basedir, basename,
+                                                'tavg', fpdtype=self.fpdtype)
         self._writer.set_shapes_eidxs(ershapes, erdata)
 
         # Asynchronous output options

--- a/pyfr/writers/native.py
+++ b/pyfr/writers/native.py
@@ -74,8 +74,10 @@ class NativeWriter:
         self._awriter = None
 
     @staticmethod
-    def from_integrator(intg, basedir, basename, prefix, *, extn='.pyfrs'):
-        return NativeWriter(intg.system.mesh, intg.cfg, intg.backend.fpdtype,
+    def from_integrator(intg, basedir, basename, prefix, *, extn='.pyfrs',
+                        fpdtype=None):
+        _ftype = intg.backend.fpdtype if fpdtype is None else fpdtype
+        return NativeWriter(intg.system.mesh, intg.cfg, _ftype,
                             basedir, basename, prefix=prefix,
                             isrestart=intg.isrestart)
 

--- a/pyfr/writers/native.py
+++ b/pyfr/writers/native.py
@@ -77,9 +77,8 @@ class NativeWriter:
     def from_integrator(intg, basedir, basename, prefix, *, extn='.pyfrs',
                         fpdtype=None):
         _ftype = fpdtype or intg.backend.fpdtype
-        return NativeWriter(intg.system.mesh, intg.cfg, _ftype,
-                            basedir, basename, prefix=prefix,
-                            isrestart=intg.isrestart)
+        return NativeWriter(intg.system.mesh, intg.cfg, _ftype, basedir, 
+                            basename, prefix=prefix, isrestart=intg.isrestart)
 
     @staticmethod
     def _get_fstype(basedir):

--- a/pyfr/writers/native.py
+++ b/pyfr/writers/native.py
@@ -76,7 +76,7 @@ class NativeWriter:
     @staticmethod
     def from_integrator(intg, basedir, basename, prefix, *, extn='.pyfrs',
                         fpdtype=None):
-        _ftype = intg.backend.fpdtype if fpdtype is None else fpdtype
+        _ftype = fpdtype or intg.backend.fpdtype
         return NativeWriter(intg.system.mesh, intg.cfg, _ftype,
                             basedir, basename, prefix=prefix,
                             isrestart=intg.isrestart)


### PR DESCRIPTION
The time average plugin was getting the output data precision from its own section in the ini file rather than the backend section. This could cause a mismatch in precision when passing data to the writer (e.g. simulation run in double precision but tavg done in single precision) which would cause half the domain to be zeroed out and the other half to have invalid data.