### PR TITLE
Refactoring CSV writing into a class

### DIFF
--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -10,7 +10,7 @@ from pytools import prefork
 
 from pyfr.mpiutil import get_comm_rank_root, mpi
 from pyfr.regions import parse_region_expr
-from pyfr.writers.csv import CSVWriter
+from pyfr.writers.csv import CSVStream
 
 
 def cli_external(meth):
@@ -21,14 +21,15 @@ def cli_external(meth):
     return classmethod(newmeth)
 
 
-def init_csv(cfg, cfgsect, header, *, filekey='file', headerkey='header'):
+def init_csv(cfg, cfgsect, header, *, filekey='file', headerkey='header', 
+             nflush=None):
     # Determine the file path
     fname = cfg.get(cfgsect, filekey)
 
     header = header if cfg.getbool(cfgsect, headerkey, True) else None
-    nflush = cfg.getint(cfgsect, 'flushsteps', 10)
+    nflush = cfg.getint(cfgsect, 'flushsteps', nflush or 10)
 
-    return CSVWriter(fname, header=header, nflush=nflush)
+    return CSVStream(fname, header=header, nflush=nflush)
 
 
 def open_hdf5_a(path):

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -10,6 +10,7 @@ from pytools import prefork
 
 from pyfr.mpiutil import get_comm_rank_root, mpi
 from pyfr.regions import parse_region_expr
+from pyfr.writers.csv import CSVWrapper
 
 
 def cli_external(meth):
@@ -20,23 +21,14 @@ def cli_external(meth):
     return classmethod(newmeth)
 
 
-def init_csv(cfg, cfgsect, header, *, filekey='file', headerkey='header'):
+def init_csv(cfg, cfgsect, header, *, filekey='file', headerkey='header', 
+             nflush=100):
     # Determine the file path
     fname = cfg.get(cfgsect, filekey)
 
-    # Append the '.csv' extension
-    if not fname.endswith('.csv'):
-        fname += '.csv'
+    _header = header if cfg.getbool(cfgsect, headerkey, True) else None
 
-    # Open for appending
-    outf = open(fname, 'a')
-
-    # Output a header if required
-    if outf.tell() == 0 and cfg.getbool(cfgsect, headerkey, True):
-        print(header, file=outf)
-
-    # Return the file
-    return outf
+    return CSVWrapper(fname, _header, nflush=nflush)
 
 
 def open_hdf5_a(path):

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -22,12 +22,12 @@ def cli_external(meth):
 
 
 def init_csv(cfg, cfgsect, header, *, filekey='file', headerkey='header', 
-             nflush=None):
+             nflush=10):
     # Determine the file path
     fname = cfg.get(cfgsect, filekey)
 
     header = header if cfg.getbool(cfgsect, headerkey, True) else None
-    nflush = cfg.getint(cfgsect, 'flushsteps', nflush or 10)
+    nflush = cfg.getint(cfgsect, 'flushsteps', nflush)
 
     return CSVStream(fname, header=header, nflush=nflush)
 

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -10,7 +10,7 @@ from pytools import prefork
 
 from pyfr.mpiutil import get_comm_rank_root, mpi
 from pyfr.regions import parse_region_expr
-from pyfr.writers.csv import CSVWrapper
+from pyfr.writers.csv import CSVWriter
 
 
 def cli_external(meth):
@@ -21,14 +21,14 @@ def cli_external(meth):
     return classmethod(newmeth)
 
 
-def init_csv(cfg, cfgsect, header, *, filekey='file', headerkey='header', 
-             nflush=100):
+def init_csv(cfg, cfgsect, header, *, filekey='file', headerkey='header'):
     # Determine the file path
     fname = cfg.get(cfgsect, filekey)
 
-    _header = header if cfg.getbool(cfgsect, headerkey, True) else None
+    header = header if cfg.getbool(cfgsect, headerkey, True) else None
+    nflush = cfg.getint(cfgsect, 'flushsteps', 10)
 
-    return CSVWrapper(fname, _header, nflush=nflush)
+    return CSVWriter(fname, header=header, nflush=nflush)
 
 
 def open_hdf5_a(path):

--- a/pyfr/plugins/dtstats.py
+++ b/pyfr/plugins/dtstats.py
@@ -20,9 +20,7 @@ class DtStatsPlugin(BaseSolnPlugin):
 
         # The root rank needs to open the output file
         if rank == root:
-            nflush = self.cfg.getint(self.cfgsect, 'flushsteps', 500)
-            self.csv = init_csv(self.cfg, cfgsect, 'n,t,dt,action,error', 
-                                nflush=nflush)
+            self.csv = init_csv(self.cfg, cfgsect, 'n,t,dt,action,error')
         else:
             self.csv = None
 
@@ -38,7 +36,7 @@ class DtStatsPlugin(BaseSolnPlugin):
         # If we're the root rank then output
         if self.csv:
             for s in self.stats:
-                self.csv.print(*s, sep=',')
+                self.csv.write(*s)
 
         # Reset the stats
         self.stats = []

--- a/pyfr/plugins/dtstats.py
+++ b/pyfr/plugins/dtstats.py
@@ -20,7 +20,8 @@ class DtStatsPlugin(BaseSolnPlugin):
 
         # The root rank needs to open the output file
         if rank == root:
-            self.csv = init_csv(self.cfg, cfgsect, 'n,t,dt,action,error')
+            header = 'n,t,dt,action,error'
+            self.csv = init_csv(self.cfg, cfgsect, header, nflush=500)
         else:
             self.csv = None
 
@@ -36,7 +37,7 @@ class DtStatsPlugin(BaseSolnPlugin):
         # If we're the root rank then output
         if self.csv:
             for s in self.stats:
-                self.csv.write(*s)
+                self.csv(*s)
 
         # Reset the stats
         self.stats = []

--- a/pyfr/plugins/fluidforce.py
+++ b/pyfr/plugins/fluidforce.py
@@ -124,11 +124,11 @@ class FluidForcePlugin(BaseSolnPlugin):
         return ','.join(header)
 
     def _init_csv(self):
-        self.csv = init_csv(self.cfg, self.cfgsect, self._header)
+        self.csv = init_csv(self.cfg, self.cfgsect, self._header, nflush=1)
         self._write = self._write_csv
 
     def _write_csv(self, t, forces):
-        self.csv.write(t, *forces.ravel())
+        self.csv(t, *forces.ravel())
 
     def _init_hdf5(self):
         outf = open_hdf5_a(self.cfg.get(self.cfgsect, 'file'))

--- a/pyfr/plugins/fluidforce.py
+++ b/pyfr/plugins/fluidforce.py
@@ -124,12 +124,11 @@ class FluidForcePlugin(BaseSolnPlugin):
         return ','.join(header)
 
     def _init_csv(self):
-        self.outf = init_csv(self.cfg, self.cfgsect, self._header)
+        self.csv = init_csv(self.cfg, self.cfgsect, self._header, nflush=1)
         self._write = self._write_csv
 
     def _write_csv(self, t, forces):
-        print(t, *forces.ravel(), sep=',', file=self.outf)
-        self.outf.flush()
+        self.csv.print(t, *forces.ravel(), sep=',')
 
     def _init_hdf5(self):
         outf = open_hdf5_a(self.cfg.get(self.cfgsect, 'file'))

--- a/pyfr/plugins/fluidforce.py
+++ b/pyfr/plugins/fluidforce.py
@@ -124,11 +124,11 @@ class FluidForcePlugin(BaseSolnPlugin):
         return ','.join(header)
 
     def _init_csv(self):
-        self.csv = init_csv(self.cfg, self.cfgsect, self._header, nflush=1)
+        self.csv = init_csv(self.cfg, self.cfgsect, self._header)
         self._write = self._write_csv
 
     def _write_csv(self, t, forces):
-        self.csv.print(t, *forces.ravel(), sep=',')
+        self.csv.write(t, *forces.ravel())
 
     def _init_hdf5(self):
         outf = open_hdf5_a(self.cfg.get(self.cfgsect, 'file'))

--- a/pyfr/plugins/fwh.py
+++ b/pyfr/plugins/fwh.py
@@ -85,7 +85,7 @@ class FWHPlugin(SurfaceRegionMixin, BaseSolnPlugin):
         # Initialise data file
         if rank == root:
             header = ','.join(['t', 'x', 'y', 'z'][:self.ndims + 1] + ['mag'])
-            self.outf = init_csv(self.cfg, cfgsect, header)
+            self.csv = init_csv(self.cfg, cfgsect, header, nflush=self.nobvs)
 
         # Far field conditions
         self.incomp = intg.system.name in {'ac-euler', 'ac-navier-stokes'}
@@ -215,7 +215,4 @@ class FWHPlugin(SurfaceRegionMixin, BaseSolnPlugin):
                 comm.Reduce(mpi.IN_PLACE, o_vals, op=mpi.SUM, root=root)
 
                 for x, p in zip(self.fwh_int.obsv_pts, o_vals):
-                    print(intg.tcurr, *x, p, sep=',', file=self.outf)
-
-                # Flush to disk
-                self.outf.flush()
+                    self.csv.print(intg.tcurr, *x, p, sep=',')

--- a/pyfr/plugins/fwh.py
+++ b/pyfr/plugins/fwh.py
@@ -85,7 +85,7 @@ class FWHPlugin(SurfaceRegionMixin, BaseSolnPlugin):
         # Initialise data file
         if rank == root:
             header = ','.join(['t', 'x', 'y', 'z'][:self.ndims + 1] + ['mag'])
-            self.csv = init_csv(self.cfg, cfgsect, header, nflush=self.nobvs)
+            self.csv = init_csv(self.cfg, cfgsect, header)
 
         # Far field conditions
         self.incomp = intg.system.name in {'ac-euler', 'ac-navier-stokes'}
@@ -215,4 +215,4 @@ class FWHPlugin(SurfaceRegionMixin, BaseSolnPlugin):
                 comm.Reduce(mpi.IN_PLACE, o_vals, op=mpi.SUM, root=root)
 
                 for x, p in zip(self.fwh_int.obsv_pts, o_vals):
-                    self.csv.print(intg.tcurr, *x, p, sep=',')
+                    self.csv.write(intg.tcurr, *x, p)

--- a/pyfr/plugins/fwh.py
+++ b/pyfr/plugins/fwh.py
@@ -85,7 +85,7 @@ class FWHPlugin(SurfaceRegionMixin, BaseSolnPlugin):
         # Initialise data file
         if rank == root:
             header = ','.join(['t', 'x', 'y', 'z'][:self.ndims + 1] + ['mag'])
-            self.csv = init_csv(self.cfg, cfgsect, header)
+            self.csv = init_csv(self.cfg, cfgsect, header, nflush=self.nobvs)
 
         # Far field conditions
         self.incomp = intg.system.name in {'ac-euler', 'ac-navier-stokes'}
@@ -215,4 +215,4 @@ class FWHPlugin(SurfaceRegionMixin, BaseSolnPlugin):
                 comm.Reduce(mpi.IN_PLACE, o_vals, op=mpi.SUM, root=root)
 
                 for x, p in zip(self.fwh_int.obsv_pts, o_vals):
-                    self.csv.write(intg.tcurr, *x, p)
+                    self.csv(intg.tcurr, *x, p)

--- a/pyfr/plugins/integrate.py
+++ b/pyfr/plugins/integrate.py
@@ -71,7 +71,7 @@ class IntegratePlugin(BaseSolnPlugin):
             header = ['t', *self.cfg.items(cfgsect, prefix='int-')]
 
             # Open
-            self.csv = init_csv(self.cfg, cfgsect, ','.join(header))
+            self.csv = init_csv(self.cfg, cfgsect, ','.join(header), nflush=1)
 
         # Prepare the per element-type info list
         self.eleinfo = eleinfo = []
@@ -223,4 +223,4 @@ class IntegratePlugin(BaseSolnPlugin):
                 iintex = (self._post_func(i) for i in iintex)
 
                 # Write
-                self.csv.write(intg.tcurr, *iintex)
+                self.csv(intg.tcurr, *iintex)

--- a/pyfr/plugins/integrate.py
+++ b/pyfr/plugins/integrate.py
@@ -71,7 +71,7 @@ class IntegratePlugin(BaseSolnPlugin):
             header = ['t', *self.cfg.items(cfgsect, prefix='int-')]
 
             # Open
-            self.csv = init_csv(self.cfg, cfgsect, ','.join(header), nflush=1)
+            self.csv = init_csv(self.cfg, cfgsect, ','.join(header))
 
         # Prepare the per element-type info list
         self.eleinfo = eleinfo = []
@@ -223,4 +223,4 @@ class IntegratePlugin(BaseSolnPlugin):
                 iintex = (self._post_func(i) for i in iintex)
 
                 # Write
-                self.csv.print(intg.tcurr, *iintex, sep=',')
+                self.csv.write(intg.tcurr, *iintex)

--- a/pyfr/plugins/integrate.py
+++ b/pyfr/plugins/integrate.py
@@ -71,7 +71,7 @@ class IntegratePlugin(BaseSolnPlugin):
             header = ['t', *self.cfg.items(cfgsect, prefix='int-')]
 
             # Open
-            self.outf = init_csv(self.cfg, cfgsect, ','.join(header))
+            self.csv = init_csv(self.cfg, cfgsect, ','.join(header), nflush=1)
 
         # Prepare the per element-type info list
         self.eleinfo = eleinfo = []
@@ -223,7 +223,4 @@ class IntegratePlugin(BaseSolnPlugin):
                 iintex = (self._post_func(i) for i in iintex)
 
                 # Write
-                print(intg.tcurr, *iintex, sep=',', file=self.outf)
-
-                # Flush to disk
-                self.outf.flush()
+                self.csv.print(intg.tcurr, *iintex, sep=',')

--- a/pyfr/plugins/pseudostats.py
+++ b/pyfr/plugins/pseudostats.py
@@ -23,7 +23,8 @@ class PseudoStatsPlugin(BaseSolnPlugin):
 
         # The root rank needs to open the output file
         if rank == root:
-            self.csv = init_csv(self.cfg, cfgsect, 'n,t,i,' + fvars)
+            header = 'n,t,i,' + fvars
+            self.csv = init_csv(self.cfg, cfgsect, header, nflush=500)
         else:
             self.csv = None
 
@@ -40,7 +41,7 @@ class PseudoStatsPlugin(BaseSolnPlugin):
         # If we're the root rank then output
         if self.outf:
             for s in self.stats:
-                self.csv.write(*s)
+                self.csv(*s)
 
         # Reset the stats
         self.stats = []

--- a/pyfr/plugins/pseudostats.py
+++ b/pyfr/plugins/pseudostats.py
@@ -23,9 +23,7 @@ class PseudoStatsPlugin(BaseSolnPlugin):
 
         # The root rank needs to open the output file
         if rank == root:
-            nflush = self.cfg.getint(self.cfgsect, 'flushsteps', 500)
-            self.csv = init_csv(self.cfg, cfgsect, 'n,t,i,' + fvars, 
-                                nflush=nflush)
+            self.csv = init_csv(self.cfg, cfgsect, 'n,t,i,' + fvars)
         else:
             self.csv = None
 
@@ -42,7 +40,7 @@ class PseudoStatsPlugin(BaseSolnPlugin):
         # If we're the root rank then output
         if self.outf:
             for s in self.stats:
-                self.csv.print(*s, sep=',')
+                self.csv.write(*s)
 
         # Reset the stats
         self.stats = []

--- a/pyfr/plugins/pseudostats.py
+++ b/pyfr/plugins/pseudostats.py
@@ -12,8 +12,6 @@ class PseudoStatsPlugin(BaseSolnPlugin):
     def __init__(self, intg, cfgsect, prefix):
         super().__init__(intg, cfgsect, prefix)
 
-        self.flushsteps = self.cfg.getint(self.cfgsect, 'flushsteps', 500)
-
         self.count = 0
         self.stats = []
         self.tprev = intg.tcurr
@@ -25,9 +23,11 @@ class PseudoStatsPlugin(BaseSolnPlugin):
 
         # The root rank needs to open the output file
         if rank == root:
-            self.outf = init_csv(self.cfg, cfgsect, 'n,t,i,' + fvars)
+            nflush = self.cfg.getint(self.cfgsect, 'flushsteps', 500)
+            self.csv = init_csv(self.cfg, cfgsect, 'n,t,i,' + fvars, 
+                                nflush=nflush)
         else:
-            self.outf = None
+            self.csv = None
 
     def __call__(self, intg):
         # Process the sequence of pseudo-residuals
@@ -42,11 +42,7 @@ class PseudoStatsPlugin(BaseSolnPlugin):
         # If we're the root rank then output
         if self.outf:
             for s in self.stats:
-                print(*s, sep=',', file=self.outf)
-
-            # Periodically flush to disk
-            if intg.nacptsteps % self.flushsteps == 0:
-                self.outf.flush()
+                self.csv.print(*s, sep=',')
 
         # Reset the stats
         self.stats = []

--- a/pyfr/plugins/residual.py
+++ b/pyfr/plugins/residual.py
@@ -37,7 +37,7 @@ class ResidualPlugin(BaseSolnPlugin):
             header = ['t'] + first(intg.system.ele_map.values()).convars
 
             # Open
-            self.outf = init_csv(self.cfg, cfgsect, ','.join(header))
+            self.csv = init_csv(self.cfg, cfgsect, ','.join(header), nflush=1)
 
     def __call__(self, intg):
         # If an output is due this step
@@ -64,7 +64,4 @@ class ResidualPlugin(BaseSolnPlugin):
                 resid = (r**(1 / self._lp_exp) for r in resid)
 
                 # Write
-                print(intg.tcurr, *resid, sep=',', file=self.outf)
-
-                # Flush to disk
-                self.outf.flush()
+                self.csv.print(intg.tcurr, *resid, sep=',')

--- a/pyfr/plugins/residual.py
+++ b/pyfr/plugins/residual.py
@@ -37,7 +37,7 @@ class ResidualPlugin(BaseSolnPlugin):
             header = ['t'] + first(intg.system.ele_map.values()).convars
 
             # Open
-            self.csv = init_csv(self.cfg, cfgsect, ','.join(header), nflush=1)
+            self.csv = init_csv(self.cfg, cfgsect, ','.join(header))
 
     def __call__(self, intg):
         # If an output is due this step
@@ -64,4 +64,4 @@ class ResidualPlugin(BaseSolnPlugin):
                 resid = (r**(1 / self._lp_exp) for r in resid)
 
                 # Write
-                self.csv.print(intg.tcurr, *resid, sep=',')
+                self.csv.write(intg.tcurr, *resid)

--- a/pyfr/plugins/residual.py
+++ b/pyfr/plugins/residual.py
@@ -37,7 +37,7 @@ class ResidualPlugin(BaseSolnPlugin):
             header = ['t'] + first(intg.system.ele_map.values()).convars
 
             # Open
-            self.csv = init_csv(self.cfg, cfgsect, ','.join(header))
+            self.csv = init_csv(self.cfg, cfgsect, ','.join(header), nflush=1)
 
     def __call__(self, intg):
         # If an output is due this step
@@ -64,4 +64,4 @@ class ResidualPlugin(BaseSolnPlugin):
                 resid = (r**(1 / self._lp_exp) for r in resid)
 
                 # Write
-                self.csv.write(intg.tcurr, *resid)
+                self.csv(intg.tcurr, *resid)

--- a/pyfr/plugins/sampler.py
+++ b/pyfr/plugins/sampler.py
@@ -110,12 +110,13 @@ class SamplerPlugin(BaseSolnPlugin):
                     raise ValueError('Invalid file format')
 
     def _init_csv(self, intg):
-        self.csv = init_csv(self.cfg, self.cfgsect, self._header(intg))
+        self.csv = init_csv(self.cfg, self.cfgsect, self._header(intg),
+                            nflush=len(self.psampler.pts))
         self._write = self._write_csv
 
     def _write_csv(self, t, samps):
         for ploc, samp in zip(self.psampler.pts, samps):
-            self.csv.write(t, *ploc, *samp)
+            self.csv(t, *ploc, *samp)
 
     def _init_hdf5(self, intg):
         outf = open_hdf5_a(self.cfg.get(self.cfgsect, 'file'))

--- a/pyfr/plugins/sampler.py
+++ b/pyfr/plugins/sampler.py
@@ -110,15 +110,14 @@ class SamplerPlugin(BaseSolnPlugin):
                     raise ValueError('Invalid file format')
 
     def _init_csv(self, intg):
-        self.outf = init_csv(self.cfg, self.cfgsect, self._header(intg))
+        nflush = len(self.psampler.pts)
+        self.csv = init_csv(self.cfg, self.cfgsect, self._header(intg), 
+                            nflush=nflush)
         self._write = self._write_csv
 
     def _write_csv(self, t, samps):
         for ploc, samp in zip(self.psampler.pts, samps):
-            print(t, *ploc, *samp, sep=',', file=self.outf)
-
-        # Flush to disk
-        self.outf.flush()
+            self.csv.print(t, *ploc, *samp, sep=',')
 
     def _init_hdf5(self, intg):
         outf = open_hdf5_a(self.cfg.get(self.cfgsect, 'file'))

--- a/pyfr/plugins/sampler.py
+++ b/pyfr/plugins/sampler.py
@@ -110,14 +110,12 @@ class SamplerPlugin(BaseSolnPlugin):
                     raise ValueError('Invalid file format')
 
     def _init_csv(self, intg):
-        nflush = len(self.psampler.pts)
-        self.csv = init_csv(self.cfg, self.cfgsect, self._header(intg), 
-                            nflush=nflush)
+        self.csv = init_csv(self.cfg, self.cfgsect, self._header(intg))
         self._write = self._write_csv
 
     def _write_csv(self, t, samps):
         for ploc, samp in zip(self.psampler.pts, samps):
-            self.csv.print(t, *ploc, *samp, sep=',')
+            self.csv.write(t, *ploc, *samp)
 
     def _init_hdf5(self, intg):
         outf = open_hdf5_a(self.cfg.get(self.cfgsect, 'file'))

--- a/pyfr/writers/csv.py
+++ b/pyfr/writers/csv.py
@@ -1,6 +1,6 @@
 
 
-class CSVWriter:
+class CSVStream:
     def __init__(self, fname, *, header=None, nflush=100):
         # Append the '.csv' extension
         if not fname.endswith('.csv'):
@@ -16,7 +16,7 @@ class CSVWriter:
         self.nprint = 0
         self.nflush = nflush
     
-    def write(self, *args):
+    def __call__(self, *args):
         print(*args, sep=',', file=self.outf)
 
         # Check if flush needed

--- a/pyfr/writers/csv.py
+++ b/pyfr/writers/csv.py
@@ -1,0 +1,25 @@
+
+
+class CSVWrapper:
+    def __init__(self, fname, header=None, nflush=100):
+        # Append the '.csv' extension
+        if not fname.endswith('.csv'):
+            fname += '.csv'
+
+        # Open file for appending
+        self.outf = open(fname, 'a')
+
+        # Output a header if required
+        if self.outf.tell() == 0 and header:
+            print(header, file=self.outf)
+        
+        self.nprint = 0
+        self.nflush = nflush
+    
+    def print(self, *args, **kwargs):
+        print(*args, **kwargs, file=self.outf)
+
+        # Check if flush needed
+        self.nprint += 1
+        if self.nprint % self.nflush == 0:
+            self.outf.flush()

--- a/pyfr/writers/csv.py
+++ b/pyfr/writers/csv.py
@@ -1,7 +1,7 @@
 
 
-class CSVWrapper:
-    def __init__(self, fname, header=None, nflush=100):
+class CSVWriter:
+    def __init__(self, fname, *, header=None, nflush=100):
         # Append the '.csv' extension
         if not fname.endswith('.csv'):
             fname += '.csv'
@@ -16,8 +16,8 @@ class CSVWrapper:
         self.nprint = 0
         self.nflush = nflush
     
-    def print(self, *args, **kwargs):
-        print(*args, **kwargs, file=self.outf)
+    def write(self, *args):
+        print(*args, sep=',', file=self.outf)
 
         # Check if flush needed
         self.nprint += 1


### PR DESCRIPTION
This adds a `CSVWrapper` class (happy to rename if there is a better suggestion) to pyfr.writers.csv that handles some of what is in `init_csv` and also flushing to file. `init_csv` in pyfr.plugins.base now creates and returns a `CSVWrapper` class.

Let me know if there was a better way to do this or if I should also pull the `DatasetAppender` class outside of pyfr.plugins.base (I don't have any plans to use it in the mass flow controller BC, I just wasn't sure if it should live in the same place as `CSVWrapper`).