### PR TITLE
Rework boundary condition preparation.

### DIFF
--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -83,7 +83,7 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
 
         # Construct the file writer
         self._writer = NativeWriter.from_integrator(intg, basedir, basename,
-                                                    'tavg', 
+                                                    'tavg',
                                                     fpdtype=self.fpdtype)
         self._writer.set_shapes_eidxs(ershapes, erdata)
 

--- a/pyfr/solvers/base/inters.py
+++ b/pyfr/solvers/base/inters.py
@@ -42,9 +42,6 @@ class BaseInters:
         self._external_args = {}
         self._external_vals = {}
 
-    def prepare(self, system, ubank, t, kerns):
-        pass
-
     def _set_external(self, name, spec, value=None):
         self._external_args[name] = spec
 

--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -9,7 +9,7 @@ class BaseAdvectionIntersMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self._ef_enabled = (self.cfg.get('solver', 'shock-capturing') == 
+        self._ef_enabled = (self.cfg.get('solver', 'shock-capturing') ==
                             'entropy-filter' and
                             self.cfg.getint('solver', 'order'))
 
@@ -132,6 +132,10 @@ class BaseAdvectionBCInters(BaseAdvectionIntersMixin, BaseInters):
             self._entmin_lhs = self._view(lhs, 'get_entmin_bc_fpts_for_inter')
         else:
             self._entmin_lhs = None
+
+    @classmethod
+    def preparefn(cls, bciface, mesh, elemap):
+        pass
 
     def _eval_opts(self, opts, default=None):
         # Boundary conditions, much like initial conditions, can be


### PR DESCRIPTION
This somewhat reworks how prepare is handled for boundary conditions.

The new approach is based on having a class method return a callback.  This is much more flexible than what we had before as it allows for situations where a boundary might want to sample the solution at other boundary.  Porting over existing conditions should be relatively simple.