### PR TITLE
Improve the stability of rocblas auto tuning.

### DIFF
--- a/pyfr/backends/hip/rocblas.py
+++ b/pyfr/backends/hip/rocblas.py
@@ -151,12 +151,12 @@ class HIPRocBLASKernels(HIPKernelProvider):
                 except RocBLASInvalidValue:
                     pass
             
+            # Restore the output matrix
+            getattr(out, 'parent', out).set(out_np)
+            
             # If all tests fail
             if best_kern is None:
                 raise RuntimeError('Unable to obtain a kernel')
-
-            # Restore the output matrix
-            getattr(out, 'parent', out).set(out_np)
 
             # Update the cache
             self._mul_cache[ckey] = algo, dt = best_kern


### PR DESCRIPTION
This PR deals with the possible invalid value error raised by the rocblas during the auto tuning process. The changes add exceptions while benchmarking and ignore invalid solutions. 