### PR TITLE
Dynamic macros

### DIFF
--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -74,6 +74,9 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
         # Macro definitions
         tplargs['_macros'] = {}
 
+        # Dynamic macro definitions
+        tplargs['_dmacros'] = {}
+
         # External kernel arguments dictionary
         tplargs['_extrns'] = extrns
 


### PR DESCRIPTION
This PR proposes a new style of macro creation I am calling dynamic macros, `dmacros`. This allows creation of macros that utilize python data in their definition that may change from expansion to expansion. An example may be a mat vec mult in which mat is a numpy array, and we create a standard macro to use the data passed to the macro at the point of macro expansion. To do this there are a few mako quirks. Most notably, we cannot capture the output of the macro when we define the macro, as this is where all the python code is executed. Therefore we have to simply store the macro body for later capture. Second, the `@support_caller` decorator allows for `args` specification in the dmacro definition, this allows for arguments to be passed to the macro body callable. These arguments are the python variables. 

This allows for more general macros using python data, as one does not need to have consistent global names (i.e. invvdm) available to all macros, and allows for intra-kernel calculations to take place, and be passed to a macro. Here is an example `dmacro` definition:

```
<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>

<%pyfr:dmacro name='simple' params='y, x, off' args='A_matrix, B_matrix'>
    // Matrix-vector multiply: y = A_matrix @ x
    <%
    print("A_matrix is accessible:", A_matrix, flush=True)
    print("B_matrix is accessible:", B_matrix, flush=True)
    %>
    fpdtype_t test = off;
    // Test comment: A_matrix shape is ${A_matrix.shape}
    // Test comment: B_matrix shape is ${B_matrix.shape}
    y[0] = x[0];  // Dummy text
</%pyfr:dmacro>
```

And `dexpand` usage:

```
<%inherit file='base'/>
<%namespace module='pyfr.backends.base.makoutil' name='pyfr'/>
<%include file='ilp_gemm_data_simple'/>

<%
se0 = math.log10(c['s0']/order**4)
%>

<%doc>
Optimized shocksensor kernel using matrix multiplication macros.
Each backend provides its own optimized mm_gemv implementation that:
- Automatically detects and optimizes for sparsity in the inverse Vandermonde matrix
- Uses backend-specific parallelization strategies
For OpenMP: Uses ndim='1-ilp' to enable nested parallelism within elements.
For CUDA/HIP: Uses warp/wavefront cooperation for inner-loop parallelism.
</%doc>

<%pyfr:kernel name='test' ndim='1'
              blah='in fpdtype_t[${str(nupts)}][${str(nvars)}]'
              blahblah='out fpdtype_t'>
    <%
    import numpy as np
    test = np.ones((3,3))
    %>

    ## NOTE: invvdm is a tplarg passed to the kernel, test is created within the kernel
    ${pyfr.dexpand('mm_gemv_simple', 'modes', 'u_col', invvdm, test, off=1)}

</%pyfr:kernel>
```

The usage of kwargs follows the standard macro/expand where the kw is intended to be a string substituted param. 