### PR TITLE
[WIP] Use a different partition for plugins. 

### DIFF
--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -10,14 +10,21 @@ from pyfr.cache import memoize
 from pyfr.mpiutil import get_comm_rank_root, mpi, scal_coll
 from pyfr.plugins import get_plugin
 
+from pyfr.readers.native import NativeReader, _MeshInterconnector
 
-def _common_plugin_prop(attr):
+
+def _common_plugin_prop(attr, *, edim):
     def wrapfn(fn):
         @property
         def newfn(self):
             if not (p := getattr(self, attr)):
                 t, c = time.time(), self._plugin_wtimes['common', None]
                 p = fn(self)
+
+                # Relocate if necessary, if self.needs_reloc is True
+                if self.needs_reloc:
+                    p = self.relocate_plugin_ary(p, edim=edim)
+
                 self._plugin_wtimes['common', None] = c + time.time() - t
                 setattr(self, attr, p)
 
@@ -67,6 +74,7 @@ class BaseIntegrator:
 
         # Record the total amount of time spent in each plugin
         self._plugin_wtimes = defaultdict(lambda: 0)
+        self.needs_reloc = cfg.hasopt('plugins-base', 'partition')
 
         # Abort computation
         self._abort = False
@@ -76,7 +84,34 @@ class BaseIntegrator:
         self._abort = True
         self._abort_reason = self._abort_reason or reason
 
+    def initialise_plugin_partition(self):
+
+        # If partition name given for the plugin, use this partitioning instead
+        if self.needs_reloc:
+            pname = self.cfg.get('plugins-base', 'partition')
+
+            self._plugins_mesh = NativeReader(self.system.mesh.fname, pname,
+                                     construct_con=False).mesh
+        
+            self._plugins_intercon = _MeshInterconnector(self.system.mesh.eidxs, 
+                                                self._plugins_mesh.eidxs)
+
+        else:
+            self._plugins_mesh = self.system.mesh
+            self._plugins_intercon = None
+
+    def relocate_plugin_ary(self, ary, edim):
+        if self._plugins_intercon:
+            ary = {e: s for e, s in zip(self._plugins_mesh.etypes, ary)}
+            ary_dict = self._plugins_intercon.relocate(ary, edim=edim)
+            ary = list(ary_dict.values())
+
+        return ary
+
     def _get_plugins(self, initsoln):
+
+        self.initialise_plugin_partition()
+
         plugins = []
 
         for s in self.cfg.sections():

--- a/pyfr/integrators/dual/phys/base.py
+++ b/pyfr/integrators/dual/phys/base.py
@@ -30,16 +30,16 @@ class BaseDualIntegrator(BaseIntegrator):
     def pseudostepinfo(self):
         return self.pseudointegrator.pseudostepinfo
 
-    @_common_plugin_prop('_curr_soln')
+    @_common_plugin_prop('_curr_soln', edim=2)
     def soln(self):
         return self.system.ele_scal_upts(self.pseudointegrator._idxcurr)
 
-    @_common_plugin_prop('_curr_grad_soln')
+    @_common_plugin_prop('_curr_grad_soln', edim=3)
     def grad_soln(self):
         self.system.compute_grads(self.tcurr, self.pseudointegrator._idxcurr)
         return [e.get() for e in self.system.eles_vect_upts]
 
-    @_common_plugin_prop('_curr_dt_soln')
+    @_common_plugin_prop('_curr_dt_soln', edim=2)
     def dt_soln(self):
         soln = self.soln
 

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -35,18 +35,18 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
         # Global degree of freedom count
         self._gndofs = self._get_gndofs()
 
-    @_common_plugin_prop('_curr_soln')
+    @_common_plugin_prop('_curr_soln', edim=2)
     def soln(self):
         self.system.postproc(self._idxcurr)
         return self.system.ele_scal_upts(self._idxcurr)
 
-    @_common_plugin_prop('_curr_grad_soln')
+    @_common_plugin_prop('_curr_grad_soln', edim=3)
     def grad_soln(self):
         self.system.postproc(self._idxcurr)
         self.system.compute_grads(self.tcurr, self._idxcurr)
         return [e.get() for e in self.system.eles_vect_upts]
 
-    @_common_plugin_prop('_curr_dt_soln')
+    @_common_plugin_prop('_curr_dt_soln', edim=2)
     def dt_soln(self):
         soln = self.soln
 

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -211,24 +211,39 @@ class RegionMixin:
     def __init__(self, intg, *args, **kwargs):
         super().__init__(intg, *args, **kwargs)
 
+        # If partition name given for the plugin, use this partitioning instead
+        if intg.needs_reloc:
+            self._ele_types = (list(intg._plugins_mesh.eidxs) if intg._plugins_mesh.eidxs else [])
+        else:
+            self._ele_types = intg.system.ele_types
+
+        comm, rank, root = get_comm_rank_root()
+        emap = intg.system.ele_map
+
+        nupts = {e: emap[e].nupts if e in emap else 0 for e in intg._plugins_mesh.etypes}
+        self.nupts = {e: comm.allreduce(nupts[e], op=mpi.MAX) for e in nupts}
+        
+        self.neles = {e: len(intg._plugins_mesh.eidxs[e]) if e in intg._plugins_mesh.eidxs else 0 
+                        for e in intg._plugins_mesh.etypes}
+
         # Parse the region
-        ridxs = region_data(self.cfg, self.cfgsect, intg.system.mesh)
+        ridxs = region_data(self.cfg, self.cfgsect, intg._plugins_mesh)
 
         # Generate the appropriate metadata arrays
         self._ele_regions, self._ele_region_data = [], {}
         for etype, eidxs in ridxs.items():
-            doff = intg.system.ele_types.index(etype)
+            doff = self._ele_types.index(etype)
             self._ele_regions.append((doff, etype, eidxs))
 
             # Obtain the global element numbers
-            geidxs = intg.system.mesh.eidxs[etype][eidxs]
+            geidxs = intg._plugins_mesh.eidxs[etype][eidxs]
             self._ele_region_data[etype] = geidxs
 
 
 class SurfaceRegionMixin:
     def _surf_region(self, intg):
         # Parse the region
-        sidxs = surface_data(intg.cfg, self.cfgsect, intg.system.mesh)
+        sidxs = surface_data(intg.cfg, self.cfgsect, intg._plugins_mesh)
 
         # Generate the appropriate metadata arrays
         ele_surface, ele_surface_data = [], {}

--- a/pyfr/plugins/tavg.py
+++ b/pyfr/plugins/tavg.py
@@ -79,7 +79,7 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         emap, erdata = intg.system.ele_map, self._ele_region_data
 
         # Figure out the shape of each element type in our region
-        ershapes = {etype: (nfields, emap[etype].nupts) for etype in erdata}
+        ershapes = {etype: (nfields, self.nupts[etype]) for etype in erdata}
 
         # Construct the file writer
         self._writer = NativeWriter.from_integrator(intg, basedir, basename,
@@ -107,9 +107,9 @@ class TavgPlugin(PostactionMixin, RegionMixin, TavgMixin, BaseSolnPlugin):
         # Get the total number of solution points in the region
         ergns = self._ele_regions
         if self.cfg.get(cfgsect, 'region') == '*':
-            tpts = sum(emap[e].neles*emap[e].nupts for i, e, r in ergns)
+            tpts = sum(self.neles[e]*self.nupts[e] for i, e, r in ergns)
         else:
-            tpts = sum(len(r)*emap[e].nupts for i, e, r in ergns)
+            tpts = sum(len(r)*self.nupts[e] for i, e, r in ergns)
 
         # Reduce
         self.tpts = comm.reduce(tpts, op=mpi.SUM, root=root)

--- a/pyfr/plugins/writer.py
+++ b/pyfr/plugins/writer.py
@@ -28,7 +28,7 @@ class WriterPlugin(PostactionMixin, RegionMixin, BaseSolnPlugin):
 
         # Figure out the shape of each element type in our region
         nvars = self.nvars + self._write_grads*(self.nvars*self.ndims)
-        ershapes = {etype: (nvars, emap[etype].nupts) for etype in erdata}
+        ershapes = {etype: (nvars, self.nupts[etype]) for etype in erdata}
 
         # Construct the solution writer
         self._writer = NativeWriter.from_integrator(intg, basedir, basename,

--- a/pyfr/readers/native.py
+++ b/pyfr/readers/native.py
@@ -5,7 +5,7 @@ import h5py
 import numpy as np
 
 from pyfr.inifile import Inifile
-from pyfr.mpiutil import (Scatterer, SparseScatterer, autofree,
+from pyfr.mpiutil import (AlltoallMixin, Scatterer, SparseScatterer, autofree,
                           get_comm_rank_root)
 from pyfr.nputil import iter_struct
 
@@ -33,6 +33,192 @@ class _Mesh:
     con: list = field(default_factory=list)
     con_p: dict = field(default_factory=dict)
     bcon: dict = field(default_factory=dict)
+
+class _MeshInterconnector(AlltoallMixin):
+    """
+    Given two input mesh eidxs data from _Mesh instances, create a forward mapping 
+    from the src mesh to the dest mesh. 
+    """
+
+    def __init__(self, eidxs_src, eidxs_dest):
+
+        # Ensure all ranks have all element types data.
+        self.comm, self.rank, self.root = get_comm_rank_root()
+        
+        local_etypes = sorted(set(eidxs_src) | set(eidxs_dest))
+        all_etypes = self.comm.allgather(local_etypes)
+        self.etypes = sorted(set().union(*all_etypes))
+
+        # allgather eidxs indexed by rank
+        self.src_all  = {et: self.comm.allgather(self._as64(eidxs_src.get(et, ())))  for et in self.etypes}
+        self.dest_all = {et: self.comm.allgather(self._as64(eidxs_dest.get(et, ()))) for et in self.etypes}
+
+        self.send_idxs = {}
+        self.recv_idxs = {}
+        self.scount = {}
+        self.sdisp = {}
+        self.rcount = {}
+        self.rdisp = {}
+
+        # Prepare per-etype storage for mapping data
+        self.set_relocation_idxs()
+
+    def _as64(self, a):
+        # Get int64 indices even if the arrays for the etype are empty
+        return np.asarray(a if a is not None else (), dtype=np.int64)
+
+    def set_relocation_idxs(self):
+        comm = self.comm
+
+        for et in self.etypes:
+            src_local = np.asarray(self.src_all[et][self.rank], dtype=np.int64)
+
+            send_lists = []
+            for p in range(comm.size):
+                dest_p = np.asarray(self.dest_all[et][p], dtype=np.int64)
+                if src_local.size and dest_p.size:
+                    mask = np.isin(src_local, dest_p, assume_unique=False)
+                    sel = src_local[mask]
+                else:
+                    sel = np.empty(0, np.int64)
+                send_lists.append(sel)
+
+            sidxs  = np.concatenate(send_lists) if any(a.size for a in send_lists) else np.empty(0, np.int64)
+            scount = np.array([a.size for a in send_lists], dtype=np.int32)
+            sdisp  = self._count_to_disp(scount)
+
+            # Learn receive sizes
+            _recv_dummy, (rcount, rdisp) = self._alltoallcv(comm, sidxs, scount, sdisp)
+
+            # Exchange promised global indices once; keep for final reordering later
+            ridxs = np.empty(int(rcount.sum()), dtype=np.int64)
+            self._alltoallv(comm, (sidxs, (scount, sdisp)), (ridxs, (rcount, rdisp)))
+
+            self.send_idxs[et] = sidxs
+            self.recv_idxs[et] = ridxs
+            self.scount[et] = scount
+            self.sdisp[et]  = sdisp
+            self.rcount[et] = rcount
+            self.rdisp[et]  = rdisp
+
+            # global to local id on src
+            src_local = np.asarray(self.src_all[et][self.rank], dtype=np.int64)
+            self.src_pos = getattr(self, 'src_pos', {})
+            self.src_pos[et] = {int(g): i for i, g in enumerate(src_local)}
+
+            # recv -> local dest permutation
+            dest_local = np.asarray(self.dest_all[et][self.rank], dtype=np.int64)
+            rpos = {int(g): i for i, g in enumerate(self.recv_idxs[et])}
+            self.recv_to_dest = getattr(self, 'recv_to_dest', {})
+            self.recv_to_dest[et] = np.fromiter((rpos[int(g)] for g in dest_local),
+                                            count=dest_local.size, dtype=np.int64)
+
+            self.n_dest = getattr(self, 'n_dest', {})
+            self.n_dest[et] = int(dest_local.size)
+
+            self.ssum = getattr(self, 'ssum', {})
+            self.rsum = getattr(self, 'rsum', {})
+            self.ssum[et] = int(self.scount[et].sum())
+            self.rsum[et] = int(self.rcount[et].sum())
+
+    def relocate(self, edict_src, edim):
+        src0 = self.preproc_edict(edict_src, edim=edim)
+        dst0 = self.relocate_edict(src0)
+        return self.postproc_edict(dst0, edim=edim)
+
+    def preproc_edict(self, edict_in, *, edim):
+        comm = self.comm
+        edict0 = {}
+
+        # Local specs for dtype/trailing shape
+        specs = {}
+        for et in self.etypes:
+            ax = edim
+            Ne = len(self.src_all[et][self.rank])
+
+            a = edict_in.get(et, None)
+            if a is not None:
+                a = np.asarray(a)
+                if a.ndim <= ax:
+                    raise ValueError("[pre] r={} et={} invalid edim={} for shape={}"
+                                    .format(self.rank, et, ax, a.shape))
+                a0 = np.moveaxis(a, ax, 0) if ax else a
+                if a0.shape[0] != Ne:
+                    raise ValueError("[pre] r={} et={} mismatch rows={} vs Ne_src={}"
+                                    .format(self.rank, et, a0.shape[0], Ne))
+                edict0[et] = np.ascontiguousarray(a0)
+                specs[et] = (str(edict0[et].dtype), edict0[et].shape[1:])
+            else:
+                specs[et] = (None, None)
+
+        # Global agreement on dtype/shape; synthesize empties where needed
+        gspecs = comm.allgather(specs)
+        for et in self.etypes:
+            gdt, gtr = None, None
+            for d in gspecs:
+                dt, tr = d[et]
+                if dt is not None:
+                    if gdt is None:
+                        gdt, gtr = dt, tr
+                    elif dt != gdt or tr != gtr:
+                        raise ValueError("[pre] inconsistent dtype/shape for etype {} across ranks: {} vs {}"
+                                        .format(et, (gdt, gtr), (dt, tr)))
+
+            if gdt is None:
+                # No one provided this etype. If mapping expects traffic, bail.
+                ssum = int(self.scount.get(et, np.array([], np.int32)).sum()) if et in self.scount else 0
+                rsum = int(self.rcount.get(et, np.array([], np.int32)).sum()) if et in self.rcount else 0
+                Ne   = len(self.src_all[et][self.rank])
+                if ssum or rsum or Ne:
+                    raise ValueError("[pre] no array anywhere for etype '{}' ".format(et))
+                continue
+
+            if et not in edict0:
+                Ne = len(self.src_all[et][self.rank])
+                edict0[et] = np.empty((Ne,) + tuple(gtr), dtype=np.dtype(gdt))
+
+        return edict0
+
+    def relocate_edict(self, edict0):
+        out0 = {}
+        for et, a0 in (edict0 or {}).items():
+            if et not in self.send_idxs or et not in self.recv_to_dest:
+                raise ValueError("relocate_edict: mapping not ready for etype '{}'".format(et))
+            if a0.ndim == 0:
+                raise ValueError("relocate_edict: scalar array for etype '{}'".format(et))
+
+            gids = self.send_idxs[et]
+            pos = np.fromiter((self.src_pos[et].get(int(g), -1) for g in gids),
+                            count=self.ssum[et], dtype=np.int64)
+            if (pos < 0).any():
+                miss = [int(g) for g, p in zip(gids.tolist(), pos.tolist()) if p < 0][:8]
+                raise ValueError("[xfer] r={} et={} missing local GIDs (first few): {}"
+                                .format(self.rank, et, miss))
+
+            svals = a0[pos]
+            sc, sd = self.scount[et], self.sdisp[et]
+            rc, rd = self.rcount[et], self.rdisp[et]
+
+            rtot = int(rc.sum())
+            rvals = np.empty((rtot, *a0.shape[1:]), dtype=a0.dtype)
+            self._alltoallv(self.comm, (svals, (sc, sd)), (rvals, (rc, rd)))
+
+            pr = self.recv_to_dest[et]
+            if pr.size != self.n_dest[et]:
+                raise ValueError("[xfer] r={} et={} recv_to_dest size mismatch".format(self.rank, et))
+
+            out0[et] = rvals[pr]
+
+        return out0
+
+    def postproc_edict(self, edict0, *, edim):
+        out = {}
+        for et, a0 in (edict0 or {}).items():
+            if a0.shape[0] == 0:
+                continue
+            # Restore element axis to edim
+            out[et] = np.moveaxis(a0, 0, edim) if edim else a0
+        return out
 
 
 class NativeReader:


### PR DESCRIPTION
This PR adds an opt-in path to redistribute element-indexed data from the solver’s mesh partitioning to a separate plugin partitioning. Set partition = <name> in a plugin’s (e.g., writer or tavg) config block to load that partition for the plugin; the runtime will build an interconnector from the compute mesh to the plugin mesh and relocate array data across ranks before outputting to disk. If partition is omitted, behavior is unchanged and data is written using the compute partition. For now, ensure all writer/tavg plugins reference the same partition name.