### PR TITLE
Add better kernel rendering error capture.

### DIFF
--- a/pyfr/backends/base/makoutil.py
+++ b/pyfr/backends/base/makoutil.py
@@ -199,11 +199,6 @@ def _parse_expand_args(name, mparams, margsig, args, kwargs):
     except TypeError as e:
         raise MacroError(name, f'Invalid Python data parameters: {e}')
 
-    # Check all Python data is defined
-    for k, v in pyparams.items():
-        if isinstance(v, Undefined):
-            raise MacroError(name, f'Undefined Python data parameter "{k}"')
-
     return params, pyparams
 
 

--- a/pyfr/template.py
+++ b/pyfr/template.py
@@ -41,4 +41,4 @@ class DottedTemplateLookup(TemplateLookup):
             def render(iself, *args, **kwargs):
                 return super().render(*args, **self.dfltargs, **kwargs)
 
-        return DefaultTemplate(src, lookup=self)
+        return DefaultTemplate(src, lookup=self, strict_undefined=True)


### PR DESCRIPTION
This PR saves approximately 1000 hours of future development time by providing better errors within kernel renders. It adds the `strict_undefined=True` argument to the Mako Template so undefined Python variable access immediately raises a NameError and provides the variable name.

Further, because macros can are dynamic now, one macro expansion can render successfully, and another not. So this provides a "call path" from kernel through nested macro expansions to the final offending macro. 