### PR TITLE
Making sure that dt_type is always defined for reduction mako kernel

### DIFF
--- a/pyfr/backends/cuda/blasext.py
+++ b/pyfr/backends/cuda/blasext.py
@@ -76,9 +76,8 @@ class CUDABlasExtKernels(CUDAKernelProvider):
         # Empty result buffer on the host
         reduced_host = cuda.pagelocked_empty((ncola, grid[0]), fpdtype)
 
-        tplargs = dict(norm=norm, method=method)
+        tplargs = dict(norm=norm, method=method, dt_type=None)
 
-        tplargs['dt_type'] = None
         if method == 'resid':
             tplargs['dt_type'] = 'matrix' if dt_mat else 'scalar'
 

--- a/pyfr/backends/hip/blasext.py
+++ b/pyfr/backends/hip/blasext.py
@@ -76,9 +76,8 @@ class HIPBlasExtKernels(HIPKernelProvider):
         # Empty result buffer on the host
         reduced_host = hip.pagelocked_empty((ncola, grid[0]), fpdtype)
 
-        tplargs = dict(norm=norm, blocksz=block[0], method=method)
+        tplargs = dict(norm=norm, blocksz=block[0], method=method, dt_type=None)
 
-        tplargs['dt_type'] = None
         if method == 'resid':
             tplargs['dt_type'] = 'matrix' if dt_mat else 'scalar'
 

--- a/pyfr/backends/metal/blasext.py
+++ b/pyfr/backends/metal/blasext.py
@@ -74,9 +74,9 @@ class MetalBlasExtKernels(MetalKernelProvider):
         reduced_host = reduced_host.reshape(ncola, -1)
 
         # Template arguments
-        tplargs = dict(blocksz=tgrp[0], ncola=ncola, norm=norm, method=method)
+        tplargs = dict(blocksz=tgrp[0], ncola=ncola, norm=norm, method=method,
+                       dt_type=None)
 
-        tplargs['dt_type'] = None
         if method == 'resid':
             tplargs['dt_type'] = 'matrix' if dt_mat else 'scalar'
 

--- a/pyfr/backends/opencl/blasext.py
+++ b/pyfr/backends/opencl/blasext.py
@@ -65,9 +65,8 @@ class OpenCLBlasExtKernels(OpenCLKernelProvider):
         # Corresponding device memory allocation
         reduced_dev = cl.mem_alloc(reduced_host.nbytes)
 
-        tplargs = dict(norm=norm, method=method)
+        tplargs = dict(norm=norm, method=method, dt_type=None)
 
-        tplargs['dt_type'] = None
         if method == 'resid':
             tplargs['dt_type'] = 'matrix' if dt_mat else 'scalar'
 

--- a/pyfr/backends/openmp/blasext.py
+++ b/pyfr/backends/openmp/blasext.py
@@ -60,9 +60,8 @@ class OpenMPBlasExtKernels(OpenMPKernelProvider):
         nblocks, nrow, *_, fpdtype = rs[0].traits
         ncola = rs[0].ioshape[-2]
 
-        tplargs = dict(norm=norm, ncola=ncola, method=method)
+        tplargs = dict(norm=norm, ncola=ncola, method=method, dt_type=None)
 
-        tplargs['dt_type'] = None
         if method == 'resid':
             tplargs['dt_type'] = 'matrix' if dt_mat else 'scalar'
 


### PR DESCRIPTION
Currently, `dt_type` is only defined if `method == 'resid'` which trips the `strict_undefined=True` check in Mako (even if `dt_type` would never be used in that particular rendering of the template). This makes sure it always set to something (i.e. `None` when it is not relevant). Otherwise you get an error when running the 3d-triangular-aerofoil test case.