### PR TITLE
Resolve Python 3.14 Metal backend segfault #508

### DIFF
--- a/pyfr/backends/metal/provider.py
+++ b/pyfr/backends/metal/provider.py
@@ -84,9 +84,9 @@ class MetalKernelProvider(BaseKernelProvider):
 
         # Obtain the corresponding compute pipeline
         cpsf, err = call_(self.backend.dev, 'newComputePipelineStateWith',
-                     descriptor=desc, error=None)
-        if cpsf is None:
-            raise RuntimeError('Unable to create compute pipeline state')
+                          descriptor=desc, error=None)
+        if err is not None:
+            raise ValueError(f'Pipeline creation error: {err}')
 
         # Classify the arguments as either pointers or scalars
         pargs, sargs = [], []

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ install_requires = [
 
 # Soft dependencies
 extras_require = {
-    'metal': ['pyobjc-framework-Metal >= 9.0']
+    'metal': ['pyobjc-framework-Metal >= 12.0']
 }
 
 # Scripts


### PR DESCRIPTION
Addresses #508.

The Metal backend crashes with a segmentation fault when attempting to run simulations on macOS. The crash occurs during compute pipeline state initialization with the error:

```
-[MTLDebugComputeCommandEncoder setComputePipelineState:]:345: failed assertion `computePipelineState is not a MTLComputePipelineState.'
```

After a bit of research, I believe PyObjC follows a convention where Objective-C methods with `error:` output parameters (typed as `NSError**`) return a tuple `(result, error)` in Python, rather than just the result. 

The method `newComputePipelineStateWithDescriptor:error:` has the signature:
```objc
- (id<MTLComputePipelineState>)newComputePipelineStateWithDescriptor:(MTLComputePipelineDescriptor*)descriptor
                                                                error:(NSError**)error;
```

In PyObjC, this returns `(pipeline_state, error)` as a tuple. The current version assigns the entire tuple to `cpsf`:
```python
# Obtain the corresponding compute pipeline
cpsf = call_(self.backend.dev, 'newComputePipelineStateWith',
             descriptor=desc, error=None)
if cpsf is None:
    raise RuntimeError('Unable to create compute pipeline state')
```

When this tuple is later passed to `setComputePipelineState_`, Metal validation correctly rejects it because it's not a `MTLComputePipelineState` object. The fix is to properly unpack the tuple return value from `newComputePipelineStateWithDescriptor_error_`:
```python
# Obtain the corresponding compute pipeline
cpsf, err = call_(self.backend.dev, 'newComputePipelineStateWith',
                  descriptor=desc, error=None)
if cpsf is None:
    raise RuntimeError('Unable to create compute pipeline state')
```

Now `cpsf` correctly receives only the pipeline state object, and `err` receives the error (which will be `None` on success or `NSError_object` on failure).

I asked GitHub Copilot to walk me through the function signatures to verify this fix. Its output is paraphrased here in case anyone would like to see:

### PyObjC Error Handling Convention

PyObjC automatically transforms Objective-C methods with output error parameters:

```python
# Method signature metadata shows:
# arg3: b'o^@' (OUTPUT parameter, null_accepted=True)
# The 'o' prefix indicates an output parameter

# All methods ending in _error_ that have NSError** parameters:
result, error = obj.someMethod_error_(arg, None)
```

This is documented in the [PyObjC documentation](https://pyobjc.readthedocs.io/en/latest/api/module-objc.html#objective-c-output-parameters). Without Metal validation enabled (`MTL_DEBUG_LAYER=1`), the crash manifests as a generic segmentation fault. The tuple being passed has the correct pipeline state as its first element, so shallow checks might not catch it before runtime.

Type Encoding Reference:
@   = object (id/NSObject*)
:   = selector (SEL)
^@  = pointer to object
o^@ = OUTPUT pointer to object (error parameter)
i   = int
f   = float
d   = double
v   = void
