### PR TITLE
strip away string literals for declaration detection

### DIFF
--- a/pyfr/backends/base/makoutil.py
+++ b/pyfr/backends/base/makoutil.py
@@ -74,6 +74,9 @@ def _locals(body):
     # First, strip away any comments
     body = re.sub(r'//.*?\n', '', body)
 
+    # Strip away string literals
+    body = re.sub(r'"(?:[^"\\]|\\.)*"', '""', body)
+
     # Next, find all variable declaration statements
     decls = re.findall(r'(?:[A-Za-z_]\w*)\s+([A-Za-z_]\w*[^;]*?);', body)
 


### PR DESCRIPTION
There are edges cases in which print statements used for debugging will be picked up as declarations within macros, in particular when the variables are kernel args, and bogus underscores will be appended (to the string literals and print variables) and chaos ensues. This PR adds a re sub to strip away any string literals before the regex match, avoiding modifying the string as well as print arguments. The `_strip_parens` function does not help as we have already picked up things inside the printf(***).