### PR TITLE
force p=0 into the standard path

### DIFF
--- a/pyfr/shapes.py
+++ b/pyfr/shapes.py
@@ -335,7 +335,7 @@ class BaseShape:
 
     @cached_property
     def fpts_in_upts(self):
-        return np.all(np.count_nonzero(self.m0, axis=1) == 1)
+        return self.order > 0 and np.all(np.count_nonzero(self.m0, axis=1) == 1)
 
     @cached_property
     def fpts_map_upts(self):


### PR DESCRIPTION
At p=0 there is only 1 solution point, so the M0 interpolation matrix has a single column. The fpts_in_upts check (np.count_nonzero(self.m0, axis=1) == 1) trivially passes — every row has exactly 1 non-zero when there's only 1 column. This was never intended; fpts_in_upts was designed for Lobatto points at p≥1 where flux points genuinely coincide with a subset of solution points.

Once fpts_in_upts=True, PR #517 fix kicks in:

gradcoru_fpts is elided (no interpolation of gradients to flux points)
get_vect_fpts_for_inter is redirected to read from _grad_upts
But at p=0, Navier-Stokes also returns early and never registers tdisf_fused. So in the system graph at system.py:93:

ideps = k['eles/gradcoru_fpts'] or k['eles/tdisf_fused']

Both are empty. The interface viscous flux kernels (comm_flux, vect_fpts_pack) get no dependency on the gradient computation. On GPU backends where the graph executes concurrently, comm_flux reads stale/uninitialized data from _grad_upts, producing garbage viscous fluxes. 

So now we force p=0 down the standard path.