### PR TITLE
plugin extern binding callback plumbing

### DIFF
--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -188,11 +188,8 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
             # Process the argument list
             argb, argm, argv = self._build_arglst(dims, argn, argt, kwargs)
 
-            # Instantiate and annotate with runtime-bindable arg names
-            kern = self._instantiate_kernel(dims, fun, argb, argm, argv)
-            kern.rtnames = frozenset(k for k in argb if isinstance(k, str))
-
-            return kern
+            # Return a Kernel subclass instance
+            return self._instantiate_kernel(dims, fun, argb, argm, argv)
 
         # Attach the module to the method as an attribute
         kernel_meth._mod = mod

--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -7,7 +7,7 @@ from pyfr.cache import memoize
 
 class Kernel:
     compound = False
-    rtnames = frozenset()
+    rtnames = ()
 
     def __init__(self, mats=[], views=[], misc=[], dt=float('nan')):
         self.mats = mats

--- a/pyfr/backends/base/kernels.py
+++ b/pyfr/backends/base/kernels.py
@@ -7,6 +7,7 @@ from pyfr.cache import memoize
 
 class Kernel:
     compound = False
+    rtnames = frozenset()
 
     def __init__(self, mats=[], views=[], misc=[], dt=float('nan')):
         self.mats = mats
@@ -187,8 +188,11 @@ class BasePointwiseKernelProvider(BaseKernelProvider):
             # Process the argument list
             argb, argm, argv = self._build_arglst(dims, argn, argt, kwargs)
 
-            # Return a Kernel subclass instance
-            return self._instantiate_kernel(dims, fun, argb, argm, argv)
+            # Instantiate and annotate with runtime-bindable arg names
+            kern = self._instantiate_kernel(dims, fun, argb, argm, argv)
+            kern.rtnames = frozenset(k for k in argb if isinstance(k, str))
+
+            return kern
 
         # Attach the module to the method as an attribute
         kernel_meth._mod = mod

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -92,7 +92,7 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
 
         class PointwiseKernel(CUDAKernel):
             if rtargs:
-                rtnames = frozenset(k for _, k in rtargs)
+                rtnames = tuple(k for _, k in rtargs)
 
                 def bind(self, **kwargs):
                     for i, k in rtargs:

--- a/pyfr/backends/cuda/provider.py
+++ b/pyfr/backends/cuda/provider.py
@@ -92,6 +92,8 @@ class CUDAPointwiseKernelProvider(CUDAKernelProvider,
 
         class PointwiseKernel(CUDAKernel):
             if rtargs:
+                rtnames = frozenset(k for _, k in rtargs)
+
                 def bind(self, **kwargs):
                     for i, k in rtargs:
                         if k in kwargs:

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -88,6 +88,8 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
 
         class PointwiseKernel(HIPKernel):
             if rtargs:
+                rtnames = frozenset(k for _, k in rtargs)
+
                 def bind(self, **kwargs):
                     for i, k in rtargs:
                         if k in kwargs:

--- a/pyfr/backends/hip/provider.py
+++ b/pyfr/backends/hip/provider.py
@@ -88,7 +88,7 @@ class HIPPointwiseKernelProvider(HIPKernelProvider,
 
         class PointwiseKernel(HIPKernel):
             if rtargs:
-                rtnames = frozenset(k for _, k in rtargs)
+                rtnames = tuple(k for _, k in rtargs)
 
                 def bind(self, **kwargs):
                     for i, k in rtargs:

--- a/pyfr/backends/metal/provider.py
+++ b/pyfr/backends/metal/provider.py
@@ -151,7 +151,7 @@ class MetalPointwiseKernelProvider(MetalKernelProvider,
 
         class PointwiseKernel(MetalKernel):
             if rtargs:
-                rtnames = frozenset(k for _, k in rtargs)
+                rtnames = tuple(k for _, k in rtargs)
 
                 def bind(self, **kwargs):
                     for i, k in rtargs:

--- a/pyfr/backends/metal/provider.py
+++ b/pyfr/backends/metal/provider.py
@@ -151,6 +151,8 @@ class MetalPointwiseKernelProvider(MetalKernelProvider,
 
         class PointwiseKernel(MetalKernel):
             if rtargs:
+                rtnames = frozenset(k for _, k in rtargs)
+
                 def bind(self, **kwargs):
                     for i, k in rtargs:
                         if k in kwargs:

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -100,6 +100,8 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
 
         class PointwiseKernel(OpenCLKernel):
             if rtargs:
+                rtnames = frozenset(k for _, k in rtargs)
+
                 def bind(self, **kwargs):
                     for i, k in rtargs:
                         if k in kwargs:

--- a/pyfr/backends/opencl/provider.py
+++ b/pyfr/backends/opencl/provider.py
@@ -100,7 +100,7 @@ class OpenCLPointwiseKernelProvider(OpenCLKernelProvider,
 
         class PointwiseKernel(OpenCLKernel):
             if rtargs:
-                rtnames = frozenset(k for _, k in rtargs)
+                rtnames = tuple(k for _, k in rtargs)
 
                 def bind(self, **kwargs):
                     for i, k in rtargs:

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -183,6 +183,8 @@ class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
 
         class PointwiseKernel(OpenMPKernel):
             if rtargs:
+                rtnames = frozenset(k for _, k in rtargs)
+
                 def bind(self, **kwargs):
                     for i, k in rtargs:
                         if k in kwargs:

--- a/pyfr/backends/openmp/provider.py
+++ b/pyfr/backends/openmp/provider.py
@@ -183,7 +183,7 @@ class OpenMPPointwiseKernelProvider(OpenMPKernelProvider,
 
         class PointwiseKernel(OpenMPKernel):
             if rtargs:
-                rtnames = frozenset(k for _, k in rtargs)
+                rtnames = tuple(k for _, k in rtargs)
 
                 def bind(self, **kwargs):
                     for i, k in rtargs:

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -27,6 +27,10 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
         # Commit the sytem
         self.system.commit()
 
+        # Initial extern binding for plugins
+        for p in self.plugins:
+            p.bind_externs()
+
         # Register index list and current index
         self._regidx = list(range(self.nregs))
         self._idxcurr = 0

--- a/pyfr/integrators/std/base.py
+++ b/pyfr/integrators/std/base.py
@@ -27,10 +27,6 @@ class BaseStdIntegrator(BaseCommon, BaseIntegrator):
         # Commit the sytem
         self.system.commit()
 
-        # Initial extern binding for plugins
-        for p in self.plugins:
-            p.bind_externs()
-
         # Register index list and current index
         self._regidx = list(range(self.nregs))
         self._idxcurr = 0

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -148,6 +148,9 @@ class BasePlugin:
     def setup(self, sdata, serialiser):
         pass
 
+    def bind_externs(self):
+        pass
+
     def get_serialiser_prefix(self):
         if self.suffix:
             return f'plugins/{self.name}-{self.suffix}'
@@ -181,7 +184,7 @@ class BaseSolverPlugin(BasePlugin):
     def _extern_callback(self, kern):
         self._extern_binders.append(kern.bind)
 
-    def _bind_externs(self):
+    def bind_externs(self):
         for b in self._extern_binders:
             b(**self._extern_values)
 

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -179,9 +179,11 @@ class BaseSolverPlugin(BasePlugin):
         intg.system.register_kernel_callback(names, self._extern_callback)
 
     def _extern_callback(self, kern):
-        if kern.bind not in self._extern_binders:
-            self._extern_binders.append(kern.bind)
-            kern.bind(**self._extern_values)
+        self._extern_binders.append(kern.bind)
+
+    def _bind_externs(self):
+        for b in self._extern_binders:
+            b(**self._extern_values)
 
 
 class BaseCLIPlugin:

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -148,9 +148,6 @@ class BasePlugin:
     def setup(self, sdata, serialiser):
         pass
 
-    def bind_externs(self):
-        pass
-
     def get_serialiser_prefix(self):
         if self.suffix:
             return f'plugins/{self.name}-{self.suffix}'
@@ -183,6 +180,7 @@ class BaseSolverPlugin(BasePlugin):
 
     def _extern_callback(self, kern):
         self._extern_binders.append(kern.bind)
+        kern.bind(**self._extern_values)
 
     def bind_externs(self):
         for b in self._extern_binders:

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -172,18 +172,11 @@ class BaseSolverPlugin(BasePlugin):
     def _register_externs(self, intg, names, spec='scalar fpdtype_t'):
         self._update_extern_values()
 
-        names = frozenset(names)
-
-        # Check for extern name clashes with other plugins
-        for cb_names, _ in intg.system._kernel_callbacks:
-            if clash := names & cb_names:
-                raise ValueError(f'Extern name clash: {clash}')
-
         for eles in intg.system.ele_map.values():
             for name in names:
-                eles._set_external(name, spec)
+                eles.set_external(name, spec)
 
-        intg.system._kernel_callbacks.append((names, self._extern_callback))
+        intg.system.register_kernel_callback(names, self._extern_callback)
 
     def _extern_callback(self, kern):
         if kern.bind not in self._extern_binders:

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -172,11 +172,18 @@ class BaseSolverPlugin(BasePlugin):
     def _register_externs(self, intg, names, spec='scalar fpdtype_t'):
         self._update_extern_values()
 
+        names = frozenset(names)
+
+        # Check for extern name clashes with other plugins
+        for cb_names, _ in intg.system._kernel_callbacks:
+            if clash := names & cb_names:
+                raise ValueError(f'Extern name clash: {clash}')
+
         for eles in intg.system.ele_map.values():
             for name in names:
                 eles._set_external(name, spec)
 
-        intg.system._kernel_callbacks.append(self._extern_callback)
+        intg.system._kernel_callbacks.append((names, self._extern_callback))
 
     def _extern_callback(self, kern):
         if kern.bind not in self._extern_binders:

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -183,14 +183,6 @@ class BaseSolverPlugin(BasePlugin):
             self._extern_binders.append(kern.bind)
             kern.bind(**self._extern_values)
 
-    def _update_extern_values(self):
-        pass
-
-    def _bind_externs(self):
-        self._update_extern_values()
-        for b in self._extern_binders:
-            b(**self._extern_values)
-
 
 class BaseCLIPlugin:
     name = None

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -179,10 +179,9 @@ class BaseSolverPlugin(BasePlugin):
         intg.system._kernel_callbacks.append(self._extern_callback)
 
     def _extern_callback(self, kern):
-        if bind := getattr(kern, 'bind', None):
-            if bind not in self._extern_binders:
-                self._extern_binders.append(bind)
-                bind(**self._extern_values)
+        if kern.bind not in self._extern_binders:
+            self._extern_binders.append(kern.bind)
+            kern.bind(**self._extern_values)
 
     def _update_extern_values(self):
         pass

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -169,6 +169,9 @@ class BaseSolverPlugin(BasePlugin):
         self._extern_values = {}
         self._extern_binders = []
 
+    def _update_extern_values(self):
+        pass
+
     def _register_externs(self, intg, names, spec='scalar fpdtype_t'):
         self._update_extern_values()
 

--- a/pyfr/plugins/turbulence.py
+++ b/pyfr/plugins/turbulence.py
@@ -255,9 +255,9 @@ class TurbulencePlugin(BaseSolverPlugin):
                                     dtype=np.uint32)
             )
 
-            eles._set_external('tinit', f'in broadcast-col fpdtype_t[{nvmx}]',
+            eles.set_external('tinit', f'in broadcast-col fpdtype_t[{nvmx}]',
                                value=vs.tinit)
-            eles._set_external('state', f'in broadcast-col uint32_t[{nvmx}]',
+            eles.set_external('state', f'in broadcast-col uint32_t[{nvmx}]',
                                value=vs.state)
 
         return vortstructs

--- a/pyfr/solvers/base/inters.py
+++ b/pyfr/solvers/base/inters.py
@@ -42,7 +42,7 @@ class BaseInters:
         self._external_args = {}
         self._external_vals = {}
 
-    def _set_external(self, name, spec, value=None):
+    def set_external(self, name, spec, value=None):
         self._external_args[name] = spec
 
         if value is not None:

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -27,6 +27,9 @@ class BaseSystem:
         self.cfg = cfg
         self.nregs = nregs
 
+        # Plugin kernel-creation callbacks
+        self._kernel_callbacks = []
+
         # Conservative and physical variable names
         convars = self.elementscls.convars(mesh.ndims, cfg)
         privars = self.elementscls.privars(mesh.ndims, cfg)
@@ -239,6 +242,11 @@ class BaseSystem:
                         kernels[f'{pn}/{kn}', None, None].append(kern)
 
                         tag_kern(pn, p, kern)
+
+        for kerns in kernels.values():
+            for k in kerns:
+                for cb in self._kernel_callbacks:
+                    cb(k)
 
     def _gen_mpireqs(self, mpiint):
         self._mpireqs = mpireqs = defaultdict(list)

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -243,10 +243,10 @@ class BaseSystem:
 
                         tag_kern(pn, p, kern)
 
-        for kerns in kernels.values():
-            for k in kerns:
-                for cb in self._kernel_callbacks:
-                    cb(k)
+        bindable = [k for ks in kernels.values() for k in ks if k.rtnames]
+        for cb in self._kernel_callbacks:
+            for k in bindable:
+                cb(k)
 
     def _gen_mpireqs(self, mpiint):
         self._mpireqs = mpireqs = defaultdict(list)
@@ -269,8 +269,8 @@ class BaseSystem:
         binders, bckerns = [], defaultdict(dict)
         for kn, kerns in kernels.items():
             for k in kerns:
-                if bind := getattr(k, 'bind', None):
-                    binders.append(bind)
+                if k.rtnames:
+                    binders.append(k.bind)
 
                 if kn.startswith('bcint/'):
                     bcname = self._ktags[k].removeprefix('bcint/')

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -244,9 +244,10 @@ class BaseSystem:
                         tag_kern(pn, p, kern)
 
         bindable = [k for ks in kernels.values() for k in ks if k.rtnames]
-        for cb in self._kernel_callbacks:
+        for cb_names, cb in self._kernel_callbacks:
             for k in bindable:
-                cb(k)
+                if k.rtnames & cb_names:
+                    cb(k)
 
     def _gen_mpireqs(self, mpiint):
         self._mpireqs = mpireqs = defaultdict(list)

--- a/pyfr/solvers/baseadvec/elements.py
+++ b/pyfr/solvers/baseadvec/elements.py
@@ -48,7 +48,7 @@ class BaseAdvectionElements(BaseElements):
         self._srctplargs['src_macros'].append((mod, name))
         self._srctplargs |= tplargs
 
-    def _set_external(self, name, spec, value=None):
+    def set_external(self, name, spec, value=None):
         self._external_args[name] = spec
 
         if value is not None:

--- a/pyfr/solvers/baseadvec/inters.py
+++ b/pyfr/solvers/baseadvec/inters.py
@@ -126,7 +126,7 @@ class BaseAdvectionBCInters(BaseAdvectionIntersMixin, BaseInters):
         self._pnorm_lhs = self._const_mat(lhs, 'get_pnorms_for_inter')
 
         # Make the simulation time available inside kernels
-        self._set_external('t', 'scalar fpdtype_t')
+        self.set_external('t', 'scalar fpdtype_t')
 
         if self._ef_enabled:
             self._entmin_lhs = self._view(lhs, 'get_entmin_bc_fpts_for_inter')
@@ -170,6 +170,6 @@ class BaseAdvectionBCInters(BaseAdvectionIntersMixin, BaseInters):
             spec = f'in fpdtype_t[{self.ndims}]'
             value = self._const_mat(lhs, 'get_ploc_for_inter')
 
-            self._set_external('ploc', spec, value=value)
+            self.set_external('ploc', spec, value=value)
 
         return exprs

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -144,8 +144,8 @@ class MassFlowBCMixin:
         opts = self._eval_opts(['mass-flow-rate', 'alpha', 'eta'])
         self.target_mfr, self.alpha, self.eta = opts
 
-        self._set_external('ic', 'scalar fpdtype_t')
-        self._set_external('im', 'scalar fpdtype_t')
+        self.set_external('ic', 'scalar fpdtype_t')
+        self.set_external('im', 'scalar fpdtype_t')
 
         surf_list = [(etype, fidx, eidx) for etype, eidx, fidx in lhs]
         self.mf_int = SurfaceIntegrator(cfg, cfgsect, elemap, surf_list)


### PR DESCRIPTION
This PR adds callback infrastructure so plugins can add extrns to kernels, and provides an API for plugins to register and update bound extrn values in the `__call__`