### PR TITLE
provide sdata to bcs/plugins/intg with previous cfg for stale data reuse on restart

### DIFF
--- a/pyfr/__main__.py
+++ b/pyfr/__main__.py
@@ -577,9 +577,6 @@ def _process_common(args, soln, cfg):
     # If we do not have a config file then take it from the solution
     if cfg is None:
         cfg = soln.config
-    # Remove stale serialised data from soln if using a different config
-    elif soln:
-        soln.state.clear()
 
     # Create a backend
     backend = get_backend(args.backend, cfg)

--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -121,6 +121,35 @@ class Inifile:
     def remove_option(self, section, option):
         self._cp.remove_option(section, option)
 
+    def sect_eq(self, other, section):
+        if other is None:
+            return False
+
+        try:
+            sitems = dict(self._cp.items(section))
+            oitems = dict(other._cp.items(section))
+            return sitems == oitems
+        except NoSectionError:
+            return False
+
+    def sect_diff(self, other, section):
+        # No previous config, everything is new
+        if other is None:
+            return {k: (v, None)
+                    for k, v in self._cp.items(section)}
+
+        sitems = dict(self._cp.items(section))
+
+        # Section missing from other, everything is new
+        try:
+            oitems = dict(other._cp.items(section))
+        except NoSectionError:
+            return {k: (v, None) for k, v in sitems.items()}
+
+        # Return {key: (self_val, other_val)} for keys that differ
+        return {k: (sitems.get(k), oitems.get(k))
+                for k in sitems.items() ^ oitems.items()}
+
     def sections(self):
         return self._cp.sections()
 

--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -138,7 +138,7 @@ class Inifile:
         except NoSectionError:
             return {k: (v, None) for k, v in sitems.items()}
 
-        # Return {key: (self_val, other_val)} for keys that differ
+        # Return {key: (self_val, other_val)} for options that differ
         return {k: (sitems.get(k), oitems.get(k))
                 for k in sitems.items() ^ oitems.items()}
 

--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -122,9 +122,6 @@ class Inifile:
         self._cp.remove_option(section, option)
 
     def sect_eq(self, other, section):
-        if other is None:
-            return False
-
         try:
             sitems = dict(self._cp.items(section))
             oitems = dict(other._cp.items(section))
@@ -133,11 +130,6 @@ class Inifile:
             return False
 
     def sect_diff(self, other, section):
-        # No previous config, everything is new
-        if other is None:
-            return {k: (v, None)
-                    for k, v in self._cp.items(section)}
-
         sitems = dict(self._cp.items(section))
 
         # Section missing from other, everything is new

--- a/pyfr/inifile.py
+++ b/pyfr/inifile.py
@@ -140,7 +140,7 @@ class Inifile:
 
         # Return {key: (self_val, other_val)} for options that differ
         return {k: (sitems.get(k), oitems.get(k))
-                for k in sitems.items() ^ oitems.items()}
+                for k, _ in sitems.items() ^ oitems.items()}
 
     def sections(self):
         return self._cp.sections()

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -127,6 +127,7 @@ class BaseIntegrator(metaclass=RegisterMeta):
             self.triggers.restore(initsoln.state)
 
         plugins = []
+        prevcfg = initsoln.config if initsoln else None
 
         for s in self.cfg.sections():
             if (m := re.match('(soln|solver)-plugin-(.+?)(?:-(.+))?$', s)):
@@ -144,7 +145,7 @@ class BaseIntegrator(metaclass=RegisterMeta):
                 plugin = get_plugin(*args)
                 sprefix = plugin.sprefix
                 sdata = initsoln.state.get(sprefix) if initsoln else None
-                plugin.setup(sdata, self.serialiser)
+                plugin.setup(sdata, prevcfg, self.serialiser)
                 plugins.append(plugin)
 
         # Validate plugin trigger references

--- a/pyfr/integrators/explicit/controllers.py
+++ b/pyfr/integrators/explicit/controllers.py
@@ -78,9 +78,8 @@ class ExplicitPIController(PIControllerMixin, BaseExplicitController):
         # Initialise dt/errprev from restart or defaults
         if initsoln and (sd := initsoln.state.get('intg/ctrl')):
             self.dt, self._errprev = sd
-            diff = self.cfg.sect_diff(initsoln.config,
-                                      'solver-time-integrator')
-            if any(k in {'rtol'} or k.startswith('atol') for k in diff):
+            diff = self.cfg.sect_diff(initsoln.config, 'solver-time-integrator')
+            if any(k.startswith(('atol', 'rtol')) for k in diff):
                 self._errprev = 1.0
         else:
             self._errprev = 1.0

--- a/pyfr/integrators/explicit/controllers.py
+++ b/pyfr/integrators/explicit/controllers.py
@@ -78,6 +78,10 @@ class ExplicitPIController(PIControllerMixin, BaseExplicitController):
         # Initialise dt/errprev from restart or defaults
         if initsoln and (sd := initsoln.state.get('intg/ctrl')):
             self.dt, self._errprev = sd
+            diff = self.cfg.sect_diff(initsoln.config,
+                                      'solver-time-integrator')
+            if any(k in {'rtol'} or k.startswith('atol') for k in diff):
+                self._errprev = 1.0
         else:
             self._errprev = 1.0
 

--- a/pyfr/integrators/implicit/controllers.py
+++ b/pyfr/integrators/implicit/controllers.py
@@ -238,6 +238,10 @@ class ImplicitPIController(ThroughputLimitMixin, PIControllerMixin,
         # Initialise dt/errprev from restart or defaults
         if initsoln and (sd := initsoln.state.get('intg/ctrl')):
             self.dt, self._errprev = sd[:2]
+            diff = self.cfg.sect_diff(initsoln.config,
+                                      'solver-time-integrator')
+            if any(k in {'rtol'} or k.startswith('atol') for k in diff):
+                self._errprev = 1.0
         else:
             self._errprev = 1.0
 

--- a/pyfr/integrators/implicit/controllers.py
+++ b/pyfr/integrators/implicit/controllers.py
@@ -238,9 +238,8 @@ class ImplicitPIController(ThroughputLimitMixin, PIControllerMixin,
         # Initialise dt/errprev from restart or defaults
         if initsoln and (sd := initsoln.state.get('intg/ctrl')):
             self.dt, self._errprev = sd[:2]
-            diff = self.cfg.sect_diff(initsoln.config,
-                                      'solver-time-integrator')
-            if any(k in {'rtol'} or k.startswith('atol') for k in diff):
+            diff = self.cfg.sect_diff(initsoln.config, 'solver-time-integrator')
+            if any(k.startswith(('atol', 'rtol')) for k in diff):
                 self._errprev = 1.0
         else:
             self._errprev = 1.0

--- a/pyfr/plugins/base.py
+++ b/pyfr/plugins/base.py
@@ -168,7 +168,7 @@ class BasePlugin:
     def finalise(self, intg):
         pass
 
-    def setup(self, sdata, serialiser):
+    def setup(self, sdata, prevcfg, serialiser):
         pass
 
 

--- a/pyfr/solvers/base/inters.py
+++ b/pyfr/solvers/base/inters.py
@@ -111,7 +111,7 @@ class BaseInters:
     def _vect_xchg_view(self, inter, meth):
         return self._xchg_view(inter, meth, (self.ndims, self.nvars))
 
-    def setup(self, sdata):
+    def setup(self, sdata, prevcfg):
         pass
 
     @classmethod

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -269,6 +269,8 @@ class BaseSystem:
         bcmap = {b.type: b for b in subclasses(bccls, just_leaf=True)}
         bc_inters, bc_prefns = [], {}
 
+        prevcfg = initsoln.config if initsoln else None
+
         # Iterate over all boundaries in the mesh
         for c in mesh.codec:
             if not c.startswith('bc/'):
@@ -290,7 +292,7 @@ class BaseSystem:
             if localbc:
                 bciface = bcclass(self.backend, mesh.bcon[bname], elemap,
                                   cfgsect, self.cfg, bccomm)
-                bciface.setup(sdata)
+                bciface.setup(sdata, prevcfg)
                 bc_inters.append(bciface)
             else:
                 bciface = None

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -131,9 +131,11 @@ class MassFlowBCMixin:
             self.csv = None
 
     def setup(self, sdata, prevcfg):
-        if sdata is not None and sdata[4] != 0:
-            (self.interp_c, self.interp_m, 
-            self.mf_avg, self.tprev, self.nstep_counter) = sdata
+        sect_eq = self.cfg.sect_eq(prevcfg, self.cfgsect)
+
+        if sdata is not None and sdata[4] != 0 and sect_eq:
+            (self.interp_c, self.interp_m,
+             self.mf_avg, self.tprev, self.nstep_counter) = sdata
         else:
             self.interp_c = self._eval_opts(['p'])[0]
             self.interp_m = 0.0

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -131,11 +131,13 @@ class MassFlowBCMixin:
             self.csv = None
 
     def setup(self, sdata, prevcfg):
-        sect_eq = self.cfg.sect_eq(prevcfg, self.cfgsect)
+        sect_eq = (prevcfg is not None
+                   and self.cfg.sect_eq(prevcfg, self.cfgsect))
 
         if sdata is not None and sdata[4] != 0 and sect_eq:
-            (self.interp_c, self.interp_m,
-             self.mf_avg, self.tprev, self.nstep_counter) = sdata
+            self.interp_c, self.interp_m = sdata[0], sdata[1]
+            self.mf_avg, self.tprev = sdata[2], sdata[3]
+            self.nstep_counter = sdata[4]
         else:
             self.interp_c = self._eval_opts(['p'])[0]
             self.interp_m = 0.0

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -130,7 +130,7 @@ class MassFlowBCMixin:
         else:
             self.csv = None
 
-    def setup(self, sdata):
+    def setup(self, sdata, prevcfg):
         if sdata is not None and sdata[4] != 0:
             (self.interp_c, self.interp_m, 
             self.mf_avg, self.tprev, self.nstep_counter) = sdata

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -131,8 +131,8 @@ class MassFlowBCMixin:
             self.csv = None
 
     def setup(self, sdata, prevcfg):
-        sect_eq = (prevcfg is not None
-                   and self.cfg.sect_eq(prevcfg, self.cfgsect))
+        sect_eq = (prevcfg is not None and
+                   self.cfg.sect_eq(prevcfg, self.cfgsect))
 
         if sdata is not None and sdata[4] != 0 and sect_eq:
             self.interp_c, self.interp_m = sdata[:2]

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -135,8 +135,8 @@ class MassFlowBCMixin:
                    and self.cfg.sect_eq(prevcfg, self.cfgsect))
 
         if sdata is not None and sdata[4] != 0 and sect_eq:
-            self.interp_c, self.interp_m = sdata[0], sdata[1]
-            self.mf_avg, self.tprev = sdata[2], sdata[3]
+            self.interp_c, self.interp_m = sdata[:2]
+            self.mf_avg, self.tprev = sdata[2:4]
             self.nstep_counter = sdata[4]
         else:
             self.interp_c = self._eval_opts(['p'])[0]


### PR DESCRIPTION
This PR removes the assumption of stale serialised data on restart and passes all sdata to bcs, plugins, and intg. It also passes in previous cfg (if present) to allow bcs and plugins to make decisions about what to do with this data on restart.  