### PR TITLE
Correct pp plugin ndims and cfg clarification.

### DIFF
--- a/pyfr/plugins/cli/sampler.py
+++ b/pyfr/plugins/cli/sampler.py
@@ -301,7 +301,7 @@ class SamplerCLIPlugin(BaseCLIPlugin):
             pp_field_map = {}
             for pp in pp_plugins:
                 pp.run(adapter)
-                pp_field_map.update(pp.fields())
+                pp_field_map.update(pp.fields)
 
             extra_cols = []
             for name, arr in adapter.fields.items():

--- a/pyfr/plugins/cli/sampler.py
+++ b/pyfr/plugins/cli/sampler.py
@@ -297,7 +297,7 @@ class SamplerCLIPlugin(BaseCLIPlugin):
 
         # Run postproc plugins at the sampled points (primitive only)
         if rank == root:
-            adapter = PostProcData(soln.config, soln, samps.T, pts.T)
+            adapter = PostProcData(soln, samps.T, pts.T)
             pp_field_map = {}
             for pp in pp_plugins:
                 pp.run(adapter)

--- a/pyfr/plugins/postproc/adapters.py
+++ b/pyfr/plugins/postproc/adapters.py
@@ -7,8 +7,7 @@ from pyfr.util import subclass_where
 
 
 class PostProcData:
-    def __init__(self, cfg, soln, pris, ploc):
-        self.cfg = cfg
+    def __init__(self, soln, pris, ploc):
         self.soln = soln
         self.nvars = len(soln.fields)
         self.ndims = len(ploc)
@@ -30,8 +29,8 @@ class PostProcData:
 
 
 class BoundaryPostProcData(PostProcData):
-    def __init__(self, cfg, soln, pris, ploc, elementscls, spts, finfo):
-        super().__init__(cfg, soln, pris, ploc)
+    def __init__(self, soln, pris, ploc, elementscls, spts, finfo):
+        super().__init__(soln, pris, ploc)
 
         self._elementscls = elementscls
         self._spts = spts
@@ -40,12 +39,13 @@ class BoundaryPostProcData(PostProcData):
     @cached_property
     def _shape(self):
         return subclass_where(BaseShape, name=self._finfo.etype)(
-            len(self._spts), self.cfg
+            len(self._spts), self.soln.config
         )
 
     @cached_property
     def _eles(self):
-        return self._elementscls(type(self._shape), self._spts, self.cfg)
+        return self._elementscls(type(self._shape), self._spts,
+                                 self.soln.config)
 
     @cached_property
     def pnorm(self):

--- a/pyfr/plugins/postproc/base.py
+++ b/pyfr/plugins/postproc/base.py
@@ -10,6 +10,7 @@ class BasePostProcPlugin(BasePlugin):
     export_types = None
     needs_grads = False
     deps = []
+    fields = {}
 
     def __init__(self, ndims, cfg, export_type=None):
         cfgsect = f'postproc-plugin-{self.name}'
@@ -19,9 +20,6 @@ class BasePostProcPlugin(BasePlugin):
             if not re.fullmatch(self.export_types, export_type):
                 raise RuntimeError(f'Postproc {self.name} does not support '
                                    f'{export_type} export')
-
-    def fields(self):
-        return {}
 
     def run(self, data):
         if self.needs_grads and not data.has_grads:

--- a/pyfr/plugins/postproc/cf.py
+++ b/pyfr/plugins/postproc/cf.py
@@ -7,9 +7,7 @@ class CfPostProc(BasePostProcPlugin):
     dimensions = '3'
     export_types = 'boundary'
     deps = ['_tau_wall']
-
-    def fields(self):
-        return {'cf': ['Cf']}
+    fields = {'cf': ['Cf']}
 
     def _process(self, data):
         rho_inf = self.cfg.getfloat('constants', 'rho-inf')

--- a/pyfr/plugins/postproc/cp.py
+++ b/pyfr/plugins/postproc/cp.py
@@ -6,9 +6,7 @@ class CpPostProc(BasePostProcPlugin):
     systems = 'euler|navier-stokes'
     dimensions = '2|3'
     export_types = '.*'
-
-    def fields(self):
-        return {'cp': ['Cp']}
+    fields = {'cp': ['Cp']}
 
     def _process(self, data):
         p = data.pris[-1]

--- a/pyfr/plugins/postproc/isen_mach.py
+++ b/pyfr/plugins/postproc/isen_mach.py
@@ -8,9 +8,7 @@ class IsentropicMachPostProc(BasePostProcPlugin):
     systems = 'euler|navier-stokes'
     dimensions = '2|3'
     export_types = '.*'
-
-    def fields(self):
-        return {'isen-mach': ['Ma_is']}
+    fields = {'isen-mach': ['Ma_is']}
 
     def _process(self, data):
         p = data.pris[-1]

--- a/pyfr/plugins/postproc/mach.py
+++ b/pyfr/plugins/postproc/mach.py
@@ -8,9 +8,7 @@ class MachPostProc(BasePostProcPlugin):
     systems = 'euler|navier-stokes'
     dimensions = '2|3'
     export_types = '.*'
-
-    def fields(self):
-        return {'mach': ['Ma']}
+    fields = {'mach': ['Ma']}
 
     def _process(self, data):
         rho, *vs, p = data.pris

--- a/pyfr/plugins/postproc/mu.py
+++ b/pyfr/plugins/postproc/mu.py
@@ -13,7 +13,7 @@ class MuPostProc(BasePostProcPlugin):
         return {}
 
     def _process(self, data):
-        cfg = data.cfg
+        cfg = data.soln.config
         mu_ref = cfg.getfloat('constants', 'mu')
 
         if cfg.get('solver', 'viscosity-correction', 'none') == 'sutherland':

--- a/pyfr/plugins/postproc/mu.py
+++ b/pyfr/plugins/postproc/mu.py
@@ -9,9 +9,6 @@ class MuPostProc(BasePostProcPlugin):
     dimensions = '2|3'
     export_types = '.*'
 
-    def fields(self):
-        return {}
-
     def _process(self, data):
         cfg = data.soln.config
         mu_ref = cfg.getfloat('constants', 'mu')

--- a/pyfr/plugins/postproc/tau_wall.py
+++ b/pyfr/plugins/postproc/tau_wall.py
@@ -11,9 +11,6 @@ class TauWallPostProc(BasePostProcPlugin):
     needs_grads = True
     deps = ['_mu']
 
-    def fields(self):
-        return {}
-
     def _process(self, data):
         normals = data.normals
         mu = data.fields['_mu']

--- a/pyfr/plugins/postproc/vorticity.py
+++ b/pyfr/plugins/postproc/vorticity.py
@@ -10,6 +10,7 @@ class VorticityPostProc(BasePostProcPlugin):
     export_types = '.*'
     needs_grads = True
 
+    @property
     def fields(self):
         if self.ndims == 3:
             return {'vorticity': ['omega_x', 'omega_y', 'omega_z']}

--- a/pyfr/plugins/postproc/yplus.py
+++ b/pyfr/plugins/postproc/yplus.py
@@ -9,9 +9,7 @@ class YPlusPostProc(BasePostProcPlugin):
     dimensions = '3'
     export_types = 'boundary'
     deps = ['_tau_wall', '_mu']
-
-    def fields(self):
-        return {'yplus': ['y+']}
+    fields = {'yplus': ['y+']}
 
     def _process(self, data):
         rho_wall = data.pris[0]

--- a/pyfr/writers/vtk/base.py
+++ b/pyfr/writers/vtk/base.py
@@ -425,7 +425,7 @@ class BaseVTKWriter(BaseWriter):
         self.pp_plugins = get_pp_plugins(self._pp_plugin_names,
                                          self.ndims, cfg, self.type)
         for pp in self.pp_plugins:
-            for fname, varnames in pp.fields().items():
+            for fname, varnames in pp.fields.items():
                 meta = FieldMeta('point', len(varnames), np.dtype(self.dtype))
                 self._extra_fields[fname] = meta
 

--- a/pyfr/writers/vtk/boundary.py
+++ b/pyfr/writers/vtk/boundary.py
@@ -176,7 +176,7 @@ class VTKBoundaryWriter(BaseVTKWriter):
             soln_t = face_vsoln.transpose(1, 0, 2)
             ploc = face_vpts.transpose(2, 0, 1)
 
-            adapter = BoundaryPostProcData(self.cfg, self.soln, soln_t, ploc,
+            adapter = BoundaryPostProcData(self.soln, soln_t, ploc,
                                            self.elementscls, spts, finfo)
             for pp in self.pp_plugins:
                 pp.run(adapter)

--- a/pyfr/writers/vtk/stl.py
+++ b/pyfr/writers/vtk/stl.py
@@ -178,7 +178,7 @@ class VTKSTLWriter(BaseVTKWriter):
             svars = self._pre_proc_fields(samps[:nsoln].astype(self.dtype))
 
             # Run postproc plugins at welded sample points
-            adapter = PostProcData(self.cfg, self.soln, svars, spts.T)
+            adapter = PostProcData(self.soln, svars, spts.T)
             for pp in self.pp_plugins:
                 pp.run(adapter)
 

--- a/pyfr/writers/vtk/volume.py
+++ b/pyfr/writers/vtk/volume.py
@@ -64,24 +64,23 @@ class VTKVolumeWriter(BaseVTKWriter):
         # Calculate node locations of VTU elements
         vpts = interpolate_pts(mesh_vtu_op, spts)
 
-        # Append dummy z dimension for points in 2D
-        if self.ndims == 2:
-            vpts = np.pad(vpts, [(0, 0), (0, 0), (0, 1)], 'constant')
-
         # Pre-process the solution at upts
         soln = self._pre_proc_fields(soln).swapaxes(0, 1)
 
         # Interpolate the solution to the vis points
         vsoln = interpolate_pts(soln_vtu_op, soln)
 
-        # Run postproc plugins at svpts (views into vsoln)
-        adapter = PostProcData(self.cfg, self.soln,
-                               vsoln.transpose(1, 0, 2),
+        # Run postproc plugins at svpts (views into vsoln/vpts)
+        adapter = PostProcData(self.soln, vsoln.transpose(1, 0, 2),
                                vpts.transpose(2, 0, 1))
         for pp in self.pp_plugins:
             pp.run(adapter)
         for fname, arr in adapter.fields.items():
             pointf[fname] = arr
+
+        # Append dummy z dimension for points in 2D (post-pp)
+        if self.ndims == 2:
+            vpts = np.pad(vpts, [(0, 0), (0, 0), (0, 1)], 'constant')
 
         # Extract extra fields
         nupts = soln.shape[0]


### PR DESCRIPTION
Move vtk point padding to after postproc runs so true ndims are computed and plugins behave intuitively w.r.t ndims. Also clear up confusing multiple cfg definitions between plugins and data adapters.

Now access to the simulation's cfg is through the adapter's soln.cfg and the (possibly extra) CLI cfg is accessed through the plugin's cfg attr. 