### PR TITLE
Merge aux_field across ranks so alltoall agrees on size

### DIFF
--- a/pyfr/plugins/soln/writer.py
+++ b/pyfr/plugins/soln/writer.py
@@ -35,11 +35,12 @@ class WriterPlugin(PostactionMixin, RegionMixin, BaseSolnPlugin):
         # Extract auxiliary field info and getters from elements
         self._aux_fields, self._aux_getters = {}, {}
         for etype, eles in emap.items():
-            if etype in erdata and eles.export_fields:
+            if eles.export_fields:
                 self._aux_fields[etype] = [(ef.name, ef.shape, ef.dtype)
                                            for ef in eles.export_fields]
-                self._aux_getters[etype] = [(ef.name, ef.getter)
-                                            for ef in eles.export_fields]
+                if etype in erdata:
+                    self._aux_getters[etype] = [(ef.name, ef.getter)
+                                                for ef in eles.export_fields]
 
         # Figure out the shape of each element type in our region
         ershapes = {etype: (self.nvars, emap[etype].nupts) for etype in erdata}

--- a/pyfr/writers/native.py
+++ b/pyfr/writers/native.py
@@ -139,6 +139,13 @@ class NativeWriter:
                          aux_fields=None, *, ndims=0):
         comm, _, _ = get_comm_rank_root()
 
+        # Merge aux_fields across ranks
+        if aux_fields is not None:
+            merged = {}
+            for r_aux in comm.allgather(aux_fields):
+                merged.update(r_aux)
+            aux_fields = merged
+
         # Prepare the element information
         self._einfo = {}
         self._futures = {}

--- a/pyfr/writers/native.py
+++ b/pyfr/writers/native.py
@@ -140,7 +140,8 @@ class NativeWriter:
         comm, _, _ = get_comm_rank_root()
 
         # Merge aux_fields across ranks
-        aux_fields = {k: v for a in comm.allgather(aux_fields or {})
+        aux_fields = {k: v
+                      for a in comm.allgather(aux_fields or {})
                       for k, v in a.items()}
 
         # Prepare the element information

--- a/pyfr/writers/native.py
+++ b/pyfr/writers/native.py
@@ -140,11 +140,8 @@ class NativeWriter:
         comm, _, _ = get_comm_rank_root()
 
         # Merge aux_fields across ranks
-        if aux_fields is not None:
-            merged = {}
-            for r_aux in comm.allgather(aux_fields):
-                merged.update(r_aux)
-            aux_fields = merged
+        aux_fields = {k: v for a in comm.allgather(aux_fields or {})
+                      for k, v in a.items()}
 
         # Prepare the element information
         self._einfo = {}
@@ -172,9 +169,8 @@ class NativeWriter:
                 upts = get_quadrule(etype, rname, shape[2]).pts
 
                 # Build nested compound dtype for this element type
-                aux = aux_fields.get(etype, []) if aux_fields else []
                 dtype = self._build_dtype(field_groups, shape[2], ndims,
-                                          aux)
+                                          aux_fields.get(etype, []))
 
                 ek = f'p{order}-{etype}'
                 self._einfo[ek] = (gatherer, subset, etype, dtype,


### PR DESCRIPTION
Merge aux_fields across ranks so the per-etype dtype is identical everywhere — otherwise the persistent Alltoallv buffers don't agree and we get MPI_ERR_TRUNCATE at wait time.