### PR TITLE
Allow PTX compilation bypass

### DIFF
--- a/pyfr/backends/cuda/compiler.py
+++ b/pyfr/backends/cuda/compiler.py
@@ -127,30 +127,34 @@ class CUDACompiler:
 class CUDACompilerModule:
     def __init__(self, backend, src):
         with backend.region('compile'):
-            # Prepare the source code
-            src = f'extern "C"\n{{\n{src}\n}}'
+            # PTX sources can be loaded directly by the driver without NVRTC
+            if src.lstrip().startswith('.'):
+                self.mod = backend.cuda.load_module(src.encode())
+            else:
+                # Prepare the source code
+                src = f'extern "C"\n{{\n{src}\n}}'
 
-            # Obtain the compute capability for our device
-            cmajor, cminor = backend.cuda.compute_capability()
+                # Obtain the compute capability for our device
+                cmajor, cminor = backend.cuda.compute_capability()
 
-            # Determine the family suffix
-            cfam = 'a' if cmajor >= 9 else ''
+                # Determine the family suffix
+                cfam = 'a' if cmajor >= 9 else ''
 
-            # Compiler flags
-            flags = [
-                f'--gpu-architecture=sm_{cmajor}{cminor}{cfam}',
-                '--ftz=true',
-                '--fmad=true'
-            ]
+                # Compiler flags
+                flags = [
+                    f'--gpu-architecture=sm_{cmajor}{cminor}{cfam}',
+                    '--ftz=true',
+                    '--fmad=true'
+                ]
 
-            cflags = backend.cfg.get('backend-cuda', 'cflags', '')
-            flags += shlex.split(cflags)
+                cflags = backend.cfg.get('backend-cuda', 'cflags', '')
+                flags += shlex.split(cflags)
 
-            # Compile to CUDA code
-            cucode = backend.compiler.build('kernel', src, flags)
+                # Compile to CUDA code
+                cucode = backend.compiler.build('kernel', src, flags)
 
-            # Load it as a module
-            self.mod = backend.cuda.load_module(cucode)
+                # Load it as a module
+                self.mod = backend.cuda.load_module(cucode)
 
     def get_function(self, name, argtypes):
         argtypes = [npdtype_to_ctypestype(arg) for arg in argtypes]


### PR DESCRIPTION
PXT files don't need to go through all the compilation steps that a `.cu` file needs, so this bypasses those steps. As all ptx files start with a `.`, this seems like the simplest filter. 