### PR TITLE
Fixing OpenCL bugs

### DIFF
--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -519,6 +519,7 @@ class Graph:
             # Insert MPI sends whose deps are now satisfied
             for req, deps in mpi_at.get(i, []):
                 self._add_mpi_req(req, deps)
+                self.depk.update(deps)
 
         # Replay groups (after all kernels are added)
         for kerns, subs in self._pgroups:

--- a/pyfr/backends/opencl/types.py
+++ b/pyfr/backends/opencl/types.py
@@ -87,7 +87,7 @@ class OpenCLGraph(base.Graph):
             evtidxs[k] = i
 
             # Resolve the event indices of kernels we depend on
-            wait_evts = [evtidxs[dep] for dep in self._alldeps(k)] or None
+            wait_evts = [evtidxs[dep] for dep in self.kdeps.get(k, [])] or None
 
             klist.append((k, wait_evts, k in self.depk))
 

--- a/pyfr/backends/opencl/types.py
+++ b/pyfr/backends/opencl/types.py
@@ -87,7 +87,8 @@ class OpenCLGraph(base.Graph):
             evtidxs[k] = i
 
             # Resolve the event indices of kernels we depend on
-            wait_evts = [evtidxs[dep] for dep in self.kdeps.get(k, [])] or None
+            wait_evts = [evtidxs[dep] for dep in self._alldeps(k)
+                         if dep in evtidxs] or None
 
             klist.append((k, wait_evts, k in self.depk))
 


### PR DESCRIPTION
The first issue was the `self.depk` (set of kernels that are depended on by something) was only being updated for kernels, not MPI dependencies. This means the OpenCL backend didn't generate events for kernels that are only depended on by a MPI request, so when the MPI request called `wait_for_events` we got an error. Only the OpenCL backend uses `self.depk`, so the other backends don't trigger this bug.

The second issue is that when the OpenCL backend was getting the events that kernels depend on, it was including the pdeps as well as the hard dependencies which lead to errors due to the way the event indices were being generated generated. Right now with this the OpenCL backend does not try to enforce the pdeps where possible like OpenMP and Metal, do we want to do that on this backend or only on CUDA/HIP which have the vendor graphs?