### PR TITLE
fix ldg state for ns slip wall bc

### DIFF
--- a/pyfr/solvers/navstokes/kernels/bcs/slp-adia-wall.mako
+++ b/pyfr/solvers/navstokes/kernels/bcs/slp-adia-wall.mako
@@ -27,4 +27,11 @@
 % endfor
 </%pyfr:macro>
 
-<%pyfr:alias name='bc_ldg_state' func='bc_rsolve_state'/>
+<%pyfr:macro name='bc_ldg_state' params='ul, nl, ur'>
+    fpdtype_t nor = ${' + '.join(f'ul[{i + 1}]*nl[{i}]' for i in range(ndims))};
+    ur[0] = ul[0];
+% for i in range(ndims):
+    ur[${i + 1}] = ul[${i + 1}] - nor*nl[${i}];
+% endfor
+    ur[${nvars - 1}] = ul[${nvars - 1}] - (0.5/ul[0])*nor*nor;
+</%pyfr:macro>


### PR DESCRIPTION
This PR deals with a potential problem with slip wall. Currently slip wall uses ldg state as the same as rsolve state, which only flips the sign of the momentum and preserves the energy. However, I think ldg state should remove energy/momentum contribution from wall normal velocity and use that to do the gradient correction. A simple test case is conducted with a cylinder (r = 1) with freestream u = 0.1 (test case mesh and config are attached). 

First figure shows the comparison of the wall normal velocity: the new implementation can reduce quite a lot of the amplitude of the wall normal velocity.
<img width="1920" height="1440" alt="wall_normal_velocity_comparison_s" src="https://github.com/user-attachments/assets/9c1fd4c9-acde-4c4e-bdc9-d978af7c2c23" />


The second figure shows ux (wall normal) along a line (y = 0) from upstream to the wall location (x = -1), the new implementation can reduce the oscillation in the first wall element.
<img width="2400" height="1800" alt="ux_comparison_s" src="https://github.com/user-attachments/assets/65abc86a-8c36-4fe3-a5ec-c0d1442210a6" />


[slip_wall.zip](https://github.com/user-attachments/files/28163675/slip_wall.zip)





