### PR TITLE
guard post proc runner for incompatable file types

### DIFF
--- a/pyfr/plugins/postproc/runner.py
+++ b/pyfr/plugins/postproc/runner.py
@@ -28,6 +28,9 @@ class PostProcRunner:
                 if not (public_only and n.startswith('_'))}
 
     def run_samples(self, cfg, samples, *, boundary=None, public_only=False):
+        if not self.plugins:
+            return {}
+
         from pyfr.solvers.base import BaseSystem
         sname = cfg.get('solver', 'system')
         elementscls = subclass_where(BaseSystem, name=sname).elementscls


### PR DESCRIPTION
Don't populate runner on tavg data prefixes. 