### PR TITLE
Enable block-jacobi at p=0

### DIFF
--- a/pyfr/backends/base/generator.py
+++ b/pyfr/backends/base/generator.py
@@ -130,7 +130,7 @@ class BaseKernelGenerator:
                         argt.append([np.uintp, np.uintp])
                     case 2, _:
                         argt.append([np.uintp, np.uintp, self.ixdtype])
-                    case _, 2:
+                    case _, 2 if va.cdims[0] > 1:
                         argt.append([np.uintp]*3)
                     case _:
                         argt.append([np.uintp]*2)
@@ -180,6 +180,9 @@ class BaseKernelGenerator:
             return f'{n}_v[{vix}]'
         elif arg.ncdim == 1:
             return fr'{n}_v[{vix} + SOA_SZ*(\1)]'
+        # Views with a unit row dimension do not require a stride
+        elif arg.cdims[0] == 1:
+            return fr'{n}_v[{vix} + SOA_SZ*(\2)]'
         else:
             return fr'{n}_v[{vix} + {vs}[X_IDX]*(\1) + SOA_SZ*(\2)]'
 

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -344,7 +344,7 @@ class View:
         self.mapping = backend.const_matrix(mapping, dtype=ixdtype, tags=tags)
 
         # Row strides
-        if len(vshape) == 2:
+        if self.nvrow > 1:
             rstrides = (rstridemap*leaddim)[None, :]
             self.rstrides_val = int(rstrides.flat[0])
             self.rstrides = backend.const_matrix(rstrides, dtype=ixdtype,

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -344,7 +344,7 @@ class View:
         self.mapping = backend.const_matrix(mapping, dtype=ixdtype, tags=tags)
 
         # Row strides
-        if self.nvrow > 1:
+        if len(vshape) == 2:
             rstrides = (rstridemap*leaddim)[None, :]
             self.rstrides_val = int(rstrides.flat[0])
             self.rstrides = backend.const_matrix(rstrides, dtype=ixdtype,

--- a/pyfr/backends/cuda/generator.py
+++ b/pyfr/backends/cuda/generator.py
@@ -31,7 +31,7 @@ class CUDAKernelGenerator(BaseGPUKernelGenerator):
 
                 if self.ndim == 2 and not va.isbroadcastc:
                     kargs.append(f'ixdtype_t {va.name}_vrstri')
-                elif va.ncdim == 2:
+                elif va.ncdim == 2 and va.cdims[0] > 1:
                     kargs.append(f'const ixdtype_t* {res} {va.name}_vrstri')
             # Arrays
             elif self.needs_ldim(va):

--- a/pyfr/backends/hip/generator.py
+++ b/pyfr/backends/hip/generator.py
@@ -31,7 +31,7 @@ class HIPKernelGenerator(BaseGPUKernelGenerator):
 
                 if self.ndim == 2 and not va.isbroadcastc:
                     kargs.append(f'ixdtype_t {va.name}_vrstri')
-                elif va.ncdim == 2:
+                elif va.ncdim == 2 and va.cdims[0] > 1:
                     kargs.append(f'const ixdtype_t* {res} {va.name}_vrstri')
             # Arrays
             elif self.needs_ldim(va):

--- a/pyfr/backends/metal/generator.py
+++ b/pyfr/backends/metal/generator.py
@@ -29,7 +29,7 @@ class MetalKernelGenerator(BaseGPUKernelGenerator):
 
                 if self.ndim == 2 and not va.isbroadcastc:
                     kargs.append(f'constant ixdtype_t& {va.name}_vrstri')
-                elif va.ncdim == 2:
+                elif va.ncdim == 2 and va.cdims[0] > 1:
                     kargs.append(f'device const ixdtype_t* {va.name}_vrstri')
             # Arrays
             elif self.needs_ldim(va):

--- a/pyfr/backends/opencl/generator.py
+++ b/pyfr/backends/opencl/generator.py
@@ -29,7 +29,7 @@ class OpenCLKernelGenerator(BaseGPUKernelGenerator):
 
                 if self.ndim == 2 and not va.isbroadcastc:
                     kargs.append(f'ixdtype_t {va.name}_vrstri')
-                elif va.ncdim == 2:
+                elif va.ncdim == 2 and va.cdims[0] > 1:
                     kargs.append(f'{g} {c} ixdtype_t* {r} {va.name}_vrstri')
             # Arrays
             elif self.needs_ldim(va):

--- a/pyfr/backends/openmp/generator.py
+++ b/pyfr/backends/openmp/generator.py
@@ -233,7 +233,7 @@ class OpenMPKernelGenerator(BaseKernelGenerator):
                 if self.ndim == 2 and not va.isbroadcastc:
                     kargs.append(('ixdtype_t', f'{va.name}_vrstri', None,
                                   None))
-                elif va.ncdim == 2:
+                elif va.ncdim == 2 and va.cdims[0] > 1:
                     kargs.append(('const ixdtype_t*', f'{va.name}_vrstri',
                                   '_ib*BLK_SZ', None))
 


### PR DESCRIPTION
Update the view shape check. Block-Jacobi at p = 0 dies at kernel instantiation because the generated signature expects a stride pointer the view never built.