### PR TITLE
Heal diverged Newton for retry.

### DIFF
--- a/pyfr/integrators/implicit/base.py
+++ b/pyfr/integrators/implicit/base.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 
 from pyfr.integrators.base import (BaseIntegrator, _common_plugin_prop,
@@ -137,6 +139,9 @@ class BaseImplicitIntegrator(BaseIntegrator):
         # If we are adaptive then recompute eps
         if self._fd_eps_adapt:
             unorm = self._norm2(u_reg)
+            if not math.isfinite(unorm):
+                unorm = 0
+
             self._fd_eps = ((1 + unorm)*self.backend.fpdtype_eps)**0.5
 
     @property

--- a/pyfr/integrators/implicit/base.py
+++ b/pyfr/integrators/implicit/base.py
@@ -1,5 +1,3 @@
-import math
-
 import numpy as np
 
 from pyfr.integrators.base import (BaseIntegrator, _common_plugin_prop,
@@ -139,9 +137,6 @@ class BaseImplicitIntegrator(BaseIntegrator):
         # If we are adaptive then recompute eps
         if self._fd_eps_adapt:
             unorm = self._norm2(u_reg)
-            if not math.isfinite(unorm):
-                unorm = 0
-
             self._fd_eps = ((1 + unorm)*self.backend.fpdtype_eps)**0.5
 
     @property

--- a/pyfr/integrators/implicit/nonlinear/anderson.py
+++ b/pyfr/integrators/implicit/nonlinear/anderson.py
@@ -39,12 +39,10 @@ class AndersonSolver(BaseNonlinearSolver):
         def precond(in_reg, out_reg):
             self._apply_precond(in_reg, out_reg, out_scale=self._inv_scales)
 
-        initial_guess_fn(u_reg)
+        rnorm = rnorm0 = initial_guess_fn(u_reg)
         self._compute_fd_eps(u_reg)
 
-        nrhs = nprec = 0
-        rnorm = rnorm0 = self._residual_norm(t, u_reg, f_reg, residual_fn)
-        nrhs += 1
+        nrhs, nprec = 1, 0
         tol = max(rnorm*self._nl_rtol, self._nl_atol)
 
         # Build the block preconditioner once and freeze it over the stage

--- a/pyfr/integrators/implicit/nonlinear/anderson.py
+++ b/pyfr/integrators/implicit/nonlinear/anderson.py
@@ -39,8 +39,8 @@ class AndersonSolver(BaseNonlinearSolver):
         def precond(in_reg, out_reg):
             self._apply_precond(in_reg, out_reg, out_scale=self._inv_scales)
 
-        self._compute_fd_eps(u_reg)
         initial_guess_fn(u_reg)
+        self._compute_fd_eps(u_reg)
 
         nrhs = nprec = 0
         rnorm = rnorm0 = self._residual_norm(t, u_reg, f_reg, residual_fn)

--- a/pyfr/integrators/implicit/nonlinear/anderson.py
+++ b/pyfr/integrators/implicit/nonlinear/anderson.py
@@ -40,6 +40,9 @@ class AndersonSolver(BaseNonlinearSolver):
             self._apply_precond(in_reg, out_reg, out_scale=self._inv_scales)
 
         rnorm = rnorm0 = initial_guess_fn(u_reg)
+        if not math.isfinite(rnorm):
+            raise NonlinearDivergenceError('Non-finite residual')
+
         self._compute_fd_eps(u_reg)
 
         nrhs, nprec = 1, 0

--- a/pyfr/integrators/implicit/nonlinear/base.py
+++ b/pyfr/integrators/implicit/nonlinear/base.py
@@ -75,8 +75,8 @@ class BaseNonlinearSolver(BaseImplicitIntegrator):
         return self._calc_rnorm(self._nl_resid)
 
     def _line_search(self, t, u_reg, f_reg, delta_reg, residual_fn, rnorm_old):
-        alpha = 1.0
-        alpha_best = rnorm_best = None
+        alpha = alpha_best = 1.0
+        rnorm_best = math.inf
 
         for _ in range(self._linesearch_maxiter):
             self._add(0, self._nl_temp, 1, u_reg, alpha, delta_reg,
@@ -86,9 +86,8 @@ class BaseNonlinearSolver(BaseImplicitIntegrator):
             residual_fn(self._nl_temp, f_reg, self._nl_resid)
             rnorm_new = self._calc_rnorm(self._nl_resid)
 
-            # Note the best finite trial step seen so far
-            if math.isfinite(rnorm_new) and (rnorm_best is None or
-                                             rnorm_new < rnorm_best):
+            # Note the best trial step; false for non-finite norms
+            if rnorm_new < rnorm_best:
                 alpha_best, rnorm_best = alpha, rnorm_new
 
             if rnorm_new <= (1 - self._linesearch_c1*alpha)*rnorm_old:
@@ -97,7 +96,7 @@ class BaseNonlinearSolver(BaseImplicitIntegrator):
             alpha *= self._linesearch_fact
         # Failed to satisfy the Armijo condition; take the best finite step
         else:
-            if alpha_best is None:
+            if math.isinf(rnorm_best):
                 raise NonlinearDivergenceError('Non-finite residual in line '
                                                'search')
 

--- a/pyfr/integrators/implicit/nonlinear/base.py
+++ b/pyfr/integrators/implicit/nonlinear/base.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import math
 
 from pyfr.integrators.implicit.base import BaseImplicitIntegrator
 from pyfr.integrators.registers import DynamicScalarRegister, ScalarRegister
@@ -75,6 +76,7 @@ class BaseNonlinearSolver(BaseImplicitIntegrator):
 
     def _line_search(self, t, u_reg, f_reg, delta_reg, residual_fn, rnorm_old):
         alpha = 1.0
+        alpha_best = rnorm_best = None
 
         for _ in range(self._linesearch_maxiter):
             self._add(0, self._nl_temp, 1, u_reg, alpha, delta_reg,
@@ -84,10 +86,22 @@ class BaseNonlinearSolver(BaseImplicitIntegrator):
             residual_fn(self._nl_temp, f_reg, self._nl_resid)
             rnorm_new = self._calc_rnorm(self._nl_resid)
 
+            # Note the best finite trial step seen so far
+            if math.isfinite(rnorm_new) and (rnorm_best is None or
+                                             rnorm_new < rnorm_best):
+                alpha_best, rnorm_best = alpha, rnorm_new
+
             if rnorm_new <= (1 - self._linesearch_c1*alpha)*rnorm_old:
                 break
 
             alpha *= self._linesearch_fact
+        # Failed to satisfy the Armijo condition; take the best finite step
+        else:
+            if alpha_best is None:
+                raise NonlinearDivergenceError('Non-finite residual in line '
+                                               'search')
+
+            alpha = alpha_best
 
         # Apply the update
         self._add(1, u_reg, alpha, delta_reg, in_scale=self._scales,

--- a/pyfr/integrators/implicit/nonlinear/newton.py
+++ b/pyfr/integrators/implicit/nonlinear/newton.py
@@ -31,9 +31,6 @@ class NewtonSolver(BaseNonlinearSolver):
         # Pick an initial starting guess
         rnorm = initial_guess_fn(u_reg)
 
-        # Choose a suitable finite difference perturbation
-        self._compute_fd_eps(u_reg)
-
         krylov_total = precond_total = 0
 
         for i in range(self._nl_maxiter):
@@ -55,6 +52,9 @@ class NewtonSolver(BaseNonlinearSolver):
             # After we've done at least one step check for converge
             elif rnorm < tol:
                 break
+
+            # Choose a suitable finite difference perturbation
+            self._compute_fd_eps(u_reg)
 
             # Compute the preconditioner
             self._compute_precond(t, u_reg, gamma_dt, self._rhs, f_reg,

--- a/pyfr/integrators/implicit/nonlinear/newton.py
+++ b/pyfr/integrators/implicit/nonlinear/newton.py
@@ -30,9 +30,17 @@ class NewtonSolver(BaseNonlinearSolver):
 
         # Pick an initial starting guess
         initial_guess_fn(u_reg)
+        rnorm = self._residual_norm(t, u_reg, f_reg, residual_fn)
+
+        # If the predictor has left the state space use the trivial guess
+        if not math.isfinite(rnorm):
+            initial_guess_fn(u_reg, trivial=True)
+            rnorm = None
+
+        # Choose a suitable finite difference perturbation
+        self._compute_fd_eps(u_reg)
 
         krylov_total = precond_total = 0
-        rnorm = None
 
         for i in range(self._nl_maxiter):
             # Ensure we have a valid (scaled) residual norm
@@ -96,9 +104,6 @@ class NewtonSolver(BaseNonlinearSolver):
                                     out_scale=self._inv_scales)
         else:
             precond = None
-
-        # Choose a suitable finite difference perturbation
-        self._compute_fd_eps(u_reg)
 
         for i in range(self._tol_controller.max_retries + 1):
             pc_built_before_retry = self._precond_computed

--- a/pyfr/integrators/implicit/nonlinear/newton.py
+++ b/pyfr/integrators/implicit/nonlinear/newton.py
@@ -29,13 +29,7 @@ class NewtonSolver(BaseNonlinearSolver):
                               v, result)
 
         # Pick an initial starting guess
-        initial_guess_fn(u_reg)
-        rnorm = self._residual_norm(t, u_reg, f_reg, residual_fn)
-
-        # If the predictor has left the state space use the trivial guess
-        if not math.isfinite(rnorm):
-            initial_guess_fn(u_reg, trivial=True)
-            rnorm = None
+        rnorm = initial_guess_fn(u_reg)
 
         # Choose a suitable finite difference perturbation
         self._compute_fd_eps(u_reg)

--- a/pyfr/integrators/implicit/steppers.py
+++ b/pyfr/integrators/implicit/steppers.py
@@ -114,8 +114,13 @@ class BaseSDIRKStepper(BaseImplicitStepper):
                 def residual_fn(u, f, result, un=r_un, fprev=f_prev):
                     self._compute_stage_residual(un, fprev, u, f, dt, result)
 
-                def initial_guess_fn(u, stage=i, un=r_un, fprev=f_prev):
-                    self._compute_stage_initial_guess(stage, un, fprev, dt, u)
+                def initial_guess_fn(u, trivial=False, stage=i, un=r_un,
+                                     fprev=f_prev):
+                    if trivial:
+                        self._add(0, u, 1, un)
+                    else:
+                        self._compute_stage_initial_guess(stage, un, fprev,
+                                                          dt, u)
 
                 stats = self._stage_solve(
                     t_i, r_ui, f_reg, residual_fn, initial_guess_fn,

--- a/pyfr/integrators/implicit/steppers.py
+++ b/pyfr/integrators/implicit/steppers.py
@@ -37,15 +37,8 @@ class BaseSDIRKStepper(BaseImplicitStepper):
         # Precompute interpolation weights for initial guesses
         self._guess_weights = self._compute_guess_weights()
 
-        # Predictor levels to attempt for each stage, most accurate first
-        self._guess_levels = []
-        for cw in self._guess_weights:
-            if cw is None:
-                self._guess_levels.append(None)
-            elif cw[1] is None or len(cw[1]) == 1:
-                self._guess_levels.append((1, 0))
-            else:
-                self._guess_levels.append((2, 1, 0))
+        # Per-step cache of norms used to damp the predictors
+        self._guess_norms = {}
 
         self._fsal = self.A[0][0] == 0 and self.A[-1] == self.b
         self._fsal_valid = False
@@ -61,17 +54,20 @@ class BaseSDIRKStepper(BaseImplicitStepper):
         weights = []
 
         for i, Ai in enumerate(self.A):
-            # Explicit stage; no interpolation needed
+            # Explicit stage; no initial guess is required
             if Ai[i] == 0:
                 weights.append(None)
             # No prior stages, linearly extrapolate from previous time step
             elif i == 0:
-                weights.append((self.c[i], None))
-            # Prior stages; smoothly extrapolate from prior stages
+                weights.append((self.c[i], [None]))
+            # One prior stage; first-order through its derivative
+            elif i == 1:
+                weights.append((self.c[i], [[1]]))
+            # Prior stages; smoothly extrapolate, then first-order fallback
             else:
                 w = [pfit(self.c[:i], np.arange(i) == j, i - 1)(self.c[i])
                      for j in range(i)]
-                weights.append((self.c[i], w))
+                weights.append((self.c[i], [w, [0]*(i - 1) + [1]]))
 
         return weights
 
@@ -82,37 +78,45 @@ class BaseSDIRKStepper(BaseImplicitStepper):
 
         self._addv_nz(result, pairs)
 
-    def _compute_stage_initial_guess(self, stage, u_n, f_prev_list, dt,
-                                     u_i_reg, level):
-        c_i, w = self._guess_weights[stage]
+    def _compute_stage_initial_guess(self, stage, t_i, u_n, f_prev_list,
+                                     f_reg, dt, u_i_reg, residual_fn):
+        c_i, wcands = self._guess_weights[stage]
+        norms = self._guess_norms
 
-        # Trivial guess; take the current state
-        if level == 0:
-            self._add(0, u_i_reg, 1, u_n)
-            return
-
-        # Reduce to a first-order predictor through the latest derivative
-        if level == 1 and w is not None:
-            w = [0]*(len(w) - 1) + [1]
+        # Reference norms for damping; these are constant over a step
+        f_ref = self._r_f[-1] if wcands[0] is None else f_prev_list[0]
+        for r in (f_ref, u_n):
+            if r not in norms:
+                norms[r] = self._norm2(r)
 
         # Damp dt to bound the predictor for large time steps
-        f_ref = self._r_f[-1] if w is None else f_prev_list[0]
-        inc = c_i*dt*self._norm2(f_ref)
-        u_norm = self._norm2(u_n)
+        inc = c_i*dt*norms[f_ref]
+        u_norm = norms[u_n]
         adt = dt*u_norm / (u_norm + inc) if u_norm + inc else dt
 
-        # If we don't have weights then use a forward Euler predictor
-        if w is None:
-            self._add(0, u_i_reg, 1, u_n, c_i*adt, self._r_f[-1])
-        # Lagrange interpolation: u = u_n + c_i * dt * sum_j(w_j * f_j)
-        else:
-            pairs = [(1, u_n)]
-            pairs += [(wj*c_i*adt, fj) for wj, fj in zip(w, f_prev_list)]
-            self._addv_nz(u_i_reg, pairs)
+        # Try each predictor in turn, ending with the trivial guess
+        for w in [*wcands, []]:
+            # If we don't have weights then use a forward Euler predictor
+            if w is None:
+                self._add(0, u_i_reg, 1, u_n, c_i*adt, self._r_f[-1])
+            # Lagrange interpolation: u = u_n + c_i * dt * sum_j(w_j * f_j)
+            else:
+                pairs = [(1, u_n)]
+                pairs += [(wj*c_i*adt, fj) for wj, fj in zip(w, f_prev_list)]
+                self._addv_nz(u_i_reg, pairs)
+
+            rnorm = self._residual_norm(t_i, u_i_reg, f_reg, residual_fn)
+            if math.isfinite(rnorm):
+                break
+
+        return rnorm
 
     def step(self, t, dt):
         r_f = self._r_f
         r_un, r_ui = self._r_u
+
+        # Invalidate the predictor damping norm cache
+        self._guess_norms.clear()
 
         # Ensure r_un references the bank containing u(t)
         if r_un != self.idxcurr:
@@ -137,17 +141,9 @@ class BaseSDIRKStepper(BaseImplicitStepper):
 
                 def initial_guess_fn(u, t_i=t_i, f_reg=f_reg, stage=i,
                                      un=r_un, fprev=f_prev):
-                    # Try progressively more conservative predictors
-                    for level in self._guess_levels[stage]:
-                        self._compute_stage_initial_guess(stage, un, fprev,
-                                                          dt, u, level)
-                        rnorm = self._residual_norm(t_i, u, f_reg,
-                                                    residual_fn)
-
-                        if math.isfinite(rnorm):
-                            break
-
-                    return rnorm
+                    return self._compute_stage_initial_guess(
+                        stage, t_i, un, fprev, f_reg, dt, u, residual_fn
+                    )
 
                 stats = self._stage_solve(
                     t_i, r_ui, f_reg, residual_fn, initial_guess_fn,

--- a/pyfr/integrators/implicit/steppers.py
+++ b/pyfr/integrators/implicit/steppers.py
@@ -37,6 +37,16 @@ class BaseSDIRKStepper(BaseImplicitStepper):
         # Precompute interpolation weights for initial guesses
         self._guess_weights = self._compute_guess_weights()
 
+        # Predictor levels to attempt for each stage, most accurate first
+        self._guess_levels = []
+        for cw in self._guess_weights:
+            if cw is None:
+                self._guess_levels.append(None)
+            elif cw[1] is None or len(cw[1]) == 1:
+                self._guess_levels.append((1, 0))
+            else:
+                self._guess_levels.append((2, 1, 0))
+
         self._fsal = self.A[0][0] == 0 and self.A[-1] == self.b
         self._fsal_valid = False
 
@@ -73,8 +83,17 @@ class BaseSDIRKStepper(BaseImplicitStepper):
         self._addv_nz(result, pairs)
 
     def _compute_stage_initial_guess(self, stage, u_n, f_prev_list, dt,
-                                     u_i_reg):
+                                     u_i_reg, level):
         c_i, w = self._guess_weights[stage]
+
+        # Trivial guess; take the current state
+        if level == 0:
+            self._add(0, u_i_reg, 1, u_n)
+            return
+
+        # Reduce to a first-order predictor through the latest derivative
+        if level == 1 and w is not None:
+            w = [0]*(len(w) - 1) + [1]
 
         # Damp dt to bound the predictor for large time steps
         f_ref = self._r_f[-1] if w is None else f_prev_list[0]
@@ -118,15 +137,15 @@ class BaseSDIRKStepper(BaseImplicitStepper):
 
                 def initial_guess_fn(u, t_i=t_i, f_reg=f_reg, stage=i,
                                      un=r_un, fprev=f_prev):
-                    self._compute_stage_initial_guess(stage, un, fprev, dt, u)
-                    rnorm = self._residual_norm(t_i, u, f_reg, residual_fn)
-
-                    # If the predictor has left the state space then fall
-                    # back to the trivial guess
-                    if not math.isfinite(rnorm):
-                        self._add(0, u, 1, un)
+                    # Try progressively more conservative predictors
+                    for level in self._guess_levels[stage]:
+                        self._compute_stage_initial_guess(stage, un, fprev,
+                                                          dt, u, level)
                         rnorm = self._residual_norm(t_i, u, f_reg,
                                                     residual_fn)
+
+                        if math.isfinite(rnorm):
+                            break
 
                     return rnorm
 

--- a/pyfr/integrators/implicit/steppers.py
+++ b/pyfr/integrators/implicit/steppers.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 
 from pyfr.integrators.implicit.base import BaseImplicitIntegrator
@@ -114,13 +116,19 @@ class BaseSDIRKStepper(BaseImplicitStepper):
                 def residual_fn(u, f, result, un=r_un, fprev=f_prev):
                     self._compute_stage_residual(un, fprev, u, f, dt, result)
 
-                def initial_guess_fn(u, trivial=False, stage=i, un=r_un,
-                                     fprev=f_prev):
-                    if trivial:
+                def initial_guess_fn(u, t_i=t_i, f_reg=f_reg, stage=i,
+                                     un=r_un, fprev=f_prev):
+                    self._compute_stage_initial_guess(stage, un, fprev, dt, u)
+                    rnorm = self._residual_norm(t_i, u, f_reg, residual_fn)
+
+                    # If the predictor has left the state space then fall
+                    # back to the trivial guess
+                    if not math.isfinite(rnorm):
                         self._add(0, u, 1, un)
-                    else:
-                        self._compute_stage_initial_guess(stage, un, fprev,
-                                                          dt, u)
+                        rnorm = self._residual_norm(t_i, u, f_reg,
+                                                    residual_fn)
+
+                    return rnorm
 
                 stats = self._stage_solve(
                     t_i, r_ui, f_reg, residual_fn, initial_guess_fn,


### PR DESCRIPTION
When a Newton solve diverges, `NonlinearDivergenceError` propagates up to the controller, which halves `dt` and retries the step. Three defects in the nonlinear machinery can turn one such divergence into an unrecoverable failure, or corrupt state that the retry then consumes:

**1. The line search applies non-finite steps.** The Armijo loop in `BaseNonlinearSolver._line_search` applies the final `alpha` unconditionally after the loop. Since every comparison against a NaN residual norm is false, the acceptance test can never break out of the loop, and the step applied on exhaustion is `fact**maxiter` — an alpha that was never actually evaluated. If every damped trial produced a non-finite residual, this writes a known-bad step into the solution register. The fix tracks the best finite trial: on exhaustion the best finite `alpha` is applied instead of an untested one, and if no trial was finite a `NonlinearDivergenceError` is raised with the solution register untouched.

**2. The stage predictor is unguarded.** The extrapolated initial guess in the SDIRK steppers can leave the physical state space on stiff problems (the norm-based `adt` damping is global and does not protect individual variables). A non-finite initial residual was instant divergence — before the line search or the Krylov solver ever ran — even though the trivial guess `u = u_n` is always available and frequently converges at the same `dt`. The fix evaluates the predictor's residual and falls back to the trivial guess when it is non-finite.

**3. `fd_eps` is computed from a stale register.** `NewtonSolver._solve` computed the adaptive JFNK perturbation from `u_reg` *before* the initial guess was set. On the first stage of a step this register holds data from a previous time step; after a rejected step it holds the failed — possibly non-finite — Newton iterate, in which case `fd_eps` becomes NaN and every subsequent matvec is NaN regardless of how far the controller reduces `dt`. This presents as an unfixable "Non-finite residual" loop until the failure limit aborts the run. The fix computes `fd_eps` after the initial guess is in place (per tolerance retry, so each retry uses its actual starting state), applies the same reordering in the Anderson solver, and adds a non-finite norm guard in `_compute_fd_eps` which falls back to the non-adaptive baseline `eps`.

The three changes are complementary: (1) stops divergence from corrupting the solution register, (2) removes a spurious divergence trigger, and (3) ensures that when a divergence does occur, the retry starts from clean inputs. Behavior on converging solves is unchanged — the residual evaluation count per stage is identical, and the line search applies the same `alpha` whenever the Armijo condition is met.