### PR TITLE
Add optional parallel HIP GiMMiK compilation

### DIFF
--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -34,10 +34,6 @@ class HIPGiMMiKKernels(HIPKernelProvider):
         arr = a.get()
         nnz, nuq = np.count_nonzero(arr), len(np.unique(np.abs(arr)))
 
-        # Check that A is suitable
-        if nuq > 128 and nnz / arr.size > 0.15:
-            raise NotSuitableError('Matrix inappropriate GiMMiK')
-
         # Dimensions
         n = b.ncol
         ldb, ldc = b.leaddim, out.leaddim

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -4,8 +4,7 @@ from gimmik import HIPMatMul
 import numpy as np
 
 from pyfr.backends.base import NotSuitableError
-from pyfr.backends.hip.provider import (HIPKernel, HIPKernelProvider,
-                                        get_grid_for_block)
+from pyfr.backends.hip.provider import HIPKernel, HIPKernelProvider
 
 
 class HIPGiMMiKKernels(HIPKernelProvider):
@@ -49,7 +48,7 @@ class HIPGiMMiKKernels(HIPKernelProvider):
 
         # Check the kernel cache
         try:
-            kern, block, width, dt = self._mul_kerns[ckey]
+            kern, block, width, grid_y, ncols, dt = self._mul_kerns[ckey]
         except KeyError:
             ifac = self.backend.autotune_ifac
             kname = f'gimmik_mm_{arr.shape[0]}x{arr.shape[1]}'
@@ -71,8 +70,10 @@ class HIPGiMMiKKernels(HIPKernelProvider):
                     kern = self._build_kernel(kname, src, 'iPiPi')
 
                     width = meta.get('width', 1)
+                    grid_y = meta.get('grid_y', 1)
+                    ncols = meta.get('ncols', meta['block'][0])
                     vn = -(-n // width)
-                    grid = get_grid_for_block(meta['block'], vn)
+                    grid = (-(-vn // ncols), grid_y, 1)
                     params = kern.make_params(grid, meta['block'])
                     params.set_args(n, b, ldb, out, ldc)
 
@@ -83,7 +84,7 @@ class HIPGiMMiKKernels(HIPKernelProvider):
                     )
 
                     if best_kern is None or dt < ifac*best_kern[-1]:
-                        best_kern = kern, meta['block'], width, dt
+                        best_kern = kern, meta['block'], width, grid_y, ncols, dt
 
                     kdata = {
                         'runtime': dt,
@@ -97,12 +98,14 @@ class HIPGiMMiKKernels(HIPKernelProvider):
             getattr(out, 'parent', out).set(out_np)
 
             # Update the cache
-            self._mul_kerns[ckey] = kern, block, width, dt = best_kern
+            self._mul_kerns[ckey] = (
+                kern, block, width, grid_y, ncols, dt
+            ) = best_kern
             finalize(a, lambda: self._mul_kerns.pop(ckey))
 
         # Set the parameters
         vn = -(-n // width)
-        grid = get_grid_for_block(block, vn)
+        grid = (-(-vn // ncols), grid_y, 1)
         params = kern.make_params(grid, block)
         params.set_args(n, b, ldb, out, ldc)
 

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -1,7 +1,6 @@
 from weakref import finalize
 
 from gimmik import HIPMatMul
-import numpy as np
 
 from pyfr.backends.base import NotSuitableError
 from pyfr.backends.hip.provider import HIPKernel, HIPKernelProvider
@@ -29,9 +28,8 @@ class HIPGiMMiKKernels(HIPKernelProvider):
         if 'const' not in a.tags:
             raise NotSuitableError('GiMMiK requires a constant a matrix')
 
-        # Fetch the matrix and tally up the number of non-zeros
+        # Fetch the matrix
         arr = a.get()
-        nnz, nuq = np.count_nonzero(arr), len(np.unique(np.abs(arr)))
 
         # Dimensions
         n = b.ncol
@@ -48,7 +46,7 @@ class HIPGiMMiKKernels(HIPKernelProvider):
 
         # Check the kernel cache
         try:
-            kern, block, width, grid_y, ncols, dt = self._mul_kerns[ckey]
+            kern, block, grid_y, ncolsv, dt = self._mul_kerns[ckey]
         except KeyError:
             ifac = self.backend.autotune_ifac
             kname = f'gimmik_mm_{arr.shape[0]}x{arr.shape[1]}'
@@ -69,11 +67,12 @@ class HIPGiMMiKKernels(HIPKernelProvider):
                     src, meta = kgen.send(kdata)
                     kern = self._build_kernel(kname, src, 'iPiPi')
 
-                    width = meta.get('width', 1)
                     grid_y = meta.get('grid_y', 1)
-                    ncols = meta.get('ncols', meta['block'][0])
-                    vn = -(-n // width)
-                    grid = (-(-vn // ncols), grid_y, 1)
+                    ncolsv = (
+                        meta.get('width', 1) *
+                        meta.get('ncols', meta['block'][0])
+                    )
+                    grid = (-(-n // ncolsv), grid_y, 1)
                     params = kern.make_params(grid, meta['block'])
                     params.set_args(n, b, ldb, out, ldc)
 
@@ -84,7 +83,7 @@ class HIPGiMMiKKernels(HIPKernelProvider):
                     )
 
                     if best_kern is None or dt < ifac*best_kern[-1]:
-                        best_kern = kern, meta['block'], width, grid_y, ncols, dt
+                        best_kern = kern, meta['block'], grid_y, ncolsv, dt
 
                     kdata = {
                         'runtime': dt,
@@ -99,13 +98,12 @@ class HIPGiMMiKKernels(HIPKernelProvider):
 
             # Update the cache
             self._mul_kerns[ckey] = (
-                kern, block, width, grid_y, ncols, dt
+                kern, block, grid_y, ncolsv, dt
             ) = best_kern
             finalize(a, lambda: self._mul_kerns.pop(ckey))
 
         # Set the parameters
-        vn = -(-n // width)
-        grid = (-(-vn // ncols), grid_y, 1)
+        grid = (-(-n // ncolsv), grid_y, 1)
         params = kern.make_params(grid, block)
         params.set_args(n, b, ldb, out, ldc)
 

--- a/pyfr/backends/hip/gimmik.py
+++ b/pyfr/backends/hip/gimmik.py
@@ -1,9 +1,66 @@
+from concurrent.futures import ProcessPoolExecutor
+import multiprocessing as mp
 from weakref import finalize
 
 from gimmik import HIPMatMul
 
 from pyfr.backends.base import NotSuitableError
+from pyfr.backends.hip.compiler import HIPRTC
 from pyfr.backends.hip.provider import HIPKernel, HIPKernelProvider
+from pyfr.cache import ObjectCache
+from pyfr.util import digest
+
+
+_worker_cache = None
+_worker_hiprtc = None
+
+
+def _kernel_cache_entry(src, gcn_arch, compiler_version):
+    src = f'extern "C"\n{{\n{src}\n}}'
+    flags = [f'--gpu-architecture={gcn_arch}', '-munsafe-fp-atomics']
+    ckey = digest(compiler_version, 'kernel', src, flags)
+
+    return ckey, src, flags
+
+
+def _warm_kernel_cache(src, gcn_arch, compiler_version):
+    global _worker_cache, _worker_hiprtc
+
+    if _worker_cache is None:
+        _worker_cache = ObjectCache('hip')
+    if _worker_hiprtc is None:
+        _worker_hiprtc = HIPRTC()
+
+    ckey, src, flags = _kernel_cache_entry(src, gcn_arch, compiler_version)
+
+    if _worker_cache.get_bytes(ckey) is None:
+        code = _worker_hiprtc.compile('kernel', src, flags)
+        _worker_cache.set_with_bytes(ckey, code)
+
+
+def _warmup_worker(_):
+    global _worker_cache, _worker_hiprtc
+
+    if _worker_cache is None:
+        _worker_cache = ObjectCache('hip')
+    if _worker_hiprtc is None:
+        _worker_hiprtc = HIPRTC()
+
+    return True
+
+
+def _render_compile_candidate(args):
+    (idx, arr, dtype, alpha, beta, aligne, kname, gcn_arch, warp_size,
+     compiler_version) = args
+
+    mm = HIPMatMul(alpha*arr, beta=beta, aligne=aligne)
+    src, meta = mm.render_candidate(idx, dtype, kname=kname,
+                                    gcn_arch=gcn_arch,
+                                    warp_size=warp_size)
+
+    _warm_kernel_cache(src, gcn_arch, compiler_version)
+
+    return src, meta
 
 
 class HIPGiMMiKKernels(HIPKernelProvider):
@@ -11,13 +68,41 @@ class HIPGiMMiKKernels(HIPKernelProvider):
         super().__init__(backend)
 
         # Maximum number of kernels to consider
-        self.nkerns = backend.cfg.getint('backend-hip', 'gimmik-nkerns', 8)
+        self.nkerns = backend.cfg.getint('backend-hip', 'gimmik-nkerns', 20)
 
         # Number of benchmarking runs
         self.nbench = backend.cfg.getint('backend-hip', 'gimmik-nbench', 5)
 
+        # Parallel source rendering and compiler-cache warmup
+        self.parallel_compile = backend.cfg.getbool(
+            'backend-hip', 'gimmik-parallel-compile', False
+        )
+        self.parallel_compile_workers = backend.cfg.getint(
+            'backend-hip', 'gimmik-parallel-compile-workers', self.nkerns
+        )
+        self.parallel_compile_pool = None
+
+        if self.parallel_compile:
+            workers = max(1, self.parallel_compile_workers)
+            mpctx = mp.get_context('spawn')
+            self.parallel_compile_pool = ProcessPoolExecutor(
+                max_workers=workers, mp_context=mpctx
+            )
+
+            # Spawn workers eagerly so the first autotune does not pay for
+            # process creation and HIPRTC initialization.
+            list(self.parallel_compile_pool.map(_warmup_worker,
+                                                range(workers)))
+
         # Kernel cache
         self._mul_kerns = {}
+
+    def __del__(self):
+        try:
+            if self.parallel_compile_pool is not None:
+                self.parallel_compile_pool.shutdown()
+        except AttributeError:
+            pass
 
     def mul(self, a, b, out, alpha=1.0, beta=0.0):
         # Ensure the matrices are compatible
@@ -56,42 +141,81 @@ class HIPGiMMiKKernels(HIPKernelProvider):
             # Save a copy of the contents of the output matrix
             out_np = getattr(out, 'parent', out).get()
 
+            def benchmark_candidate(src, meta):
+                kern = self._build_kernel(kname, src, 'iPiPi')
+
+                grid_y = meta.get('grid_y', 1)
+                ncolsv = (
+                    meta.get('width', 1) *
+                    meta.get('ncols', meta['block'][0])
+                )
+                grid = (-(-n // ncolsv), grid_y, 1)
+                params = kern.make_params(grid, meta['block'])
+                params.set_args(n, b, ldb, out, ldc)
+
+                # Obtain the runtime
+                dt = self._benchmark(
+                    lambda stream: kern.exec_async(stream, params),
+                    nbench=self.nbench
+                )
+
+                kdata = {
+                    'runtime': dt,
+                    'registers': kern.nreg,
+                    'local_mem': kern.local_mem
+                }
+
+                return kern, meta['block'], grid_y, ncolsv, dt, kdata
+
+            def update_best(bench):
+                nonlocal best_kern
+
+                if best_kern is None or bench[4] < ifac*best_kern[4]:
+                    best_kern = bench[:-1]
+
             mm = HIPMatMul(alpha*arr, beta=beta, aligne=aligne)
-            kgen = mm.kernels(a.dtype, kname=kname,
-                              gcn_arch=self.backend.props['gcn_arch_name'],
-                              warp_size=self.backend.props['warp_size'])
 
-            # Benchmark the sequence of kernels generated by GiMMiK
-            try:
-                for i in range(self.nkerns):
-                    src, meta = kgen.send(kdata)
-                    kern = self._build_kernel(kname, src, 'iPiPi')
-
-                    grid_y = meta.get('grid_y', 1)
-                    ncolsv = (
-                        meta.get('width', 1) *
-                        meta.get('ncols', meta['block'][0])
+            if self.parallel_compile:
+                gcn_arch = self.backend.props['gcn_arch_name']
+                warp_size = self.backend.props['warp_size']
+                count = min(
+                    self.nkerns,
+                    mm.candidate_count(a.dtype, gcn_arch=gcn_arch,
+                                       warp_size=warp_size)
+                )
+                args = [
+                    (
+                        idx, arr, a.dtype, alpha, beta, aligne, kname,
+                        gcn_arch, warp_size, self.backend.compiler.version
                     )
-                    grid = (-(-n // ncolsv), grid_y, 1)
-                    params = kern.make_params(grid, meta['block'])
-                    params.set_args(n, b, ldb, out, ldc)
+                    for idx in range(count)
+                ]
 
-                    # Obtain the runtime
-                    dt = self._benchmark(
-                        lambda stream: kern.exec_async(stream, params),
-                        nbench=self.nbench
+                candidates = list(
+                    self.parallel_compile_pool.map(
+                        _render_compile_candidate, args
                     )
+                ) if args else []
 
-                    if best_kern is None or dt < ifac*best_kern[-1]:
-                        best_kern = kern, meta['block'], grid_y, ncolsv, dt
+                for src, meta in candidates:
+                    update_best(benchmark_candidate(src, meta))
+            else:
+                kgen = mm.kernels(
+                    a.dtype, kname=kname,
+                    gcn_arch=self.backend.props['gcn_arch_name'],
+                    warp_size=self.backend.props['warp_size']
+                )
 
-                    kdata = {
-                        'runtime': dt,
-                        'registers': kern.nreg,
-                        'local_mem': kern.local_mem
-                    }
-            except StopIteration:
-                pass
+                # Benchmark the sequence of kernels generated by GiMMiK
+                try:
+                    for i in range(self.nkerns):
+                        src, meta = kgen.send(kdata)
+
+                        bench = benchmark_candidate(src, meta)
+                        update_best(bench)
+                        kdata = bench[-1]
+                except StopIteration:
+                    pass
 
             # Restore the output matrix
             getattr(out, 'parent', out).set(out_np)


### PR DESCRIPTION
## Summary

This PR adds an opt-in PyFR-side parallel compile path for HIP GiMMiK autotuning.

When `backend-hip.gimmik-parallel-compile = true`, GiMMiK candidate source generation and HIPRTC compilation/cache warmup are dispatched to multiple workers. The main process then benchmarks candidates through the normal kernel build path, which should hit the warmed HIP object cache.

The default path is unchanged.

This follows the HIP MFMA dense GiMMiK work in PyFR/GiMMiK#20 and uses the indexed candidate rendering support from PyFR/GiMMiK#21. It is also the PyFR-side follow-up to PyFR/PyFR#570.

## Validation

Tested on MI300X with 1000 selected dense cases.

| Metric | Value |
|---|---:|
| Cases | 1000 |
| Worst-case MFMA / rocBLAS BW | 95% |
| Geomean MFMA / rocBLAS BW | 102% |
| rocBLAS autotuning total | 3940.1 s |
| MFMA sequential autotuning total | 1137.0 s |
| MFMA parallel compile autotuning total | 416.2 s |
| rocBLAS -> MFMA sequential speedup | 3.47x |
| rocBLAS -> MFMA parallel compile speedup | 9.47x |

Autotuning time also improves significantly. With backend-hip.gimmik-parallel-compile = true, MFMA tuning time drops further to 416.2s, making MFMA with parallel compile 9.47x faster to tune than rocBLAS on these cases.

Attached CSV files:

synthetic_1000_summary.csv: aggregate bandwidth and autotuning summary.
synthetic_1000_details.csv: per-case results for the selected 1000 shapes.

[synthetic_1000_details.csv](https://github.com/user-attachments/files/30109166/synthetic_1000_details.csv)
[synthetic_1000_summary.csv](https://github.com/user-attachments/files/30109169/synthetic_1000_summary.csv)
