### PR TITLE
Boundary Groups

### DIFF
--- a/doc/src/boundary-initial-conditions/soln-bcs.rst
+++ b/doc/src/boundary-initial-conditions/soln-bcs.rst
@@ -3,7 +3,18 @@
 *****************
 
 Parameterises constant, or if available space (x, y, [z]) and time (t)
-dependent, boundary condition labelled *name* in the .pyfrm file with
+dependent, boundary condition labelled *name* in the .pyfrm file.  A
+single section may govern several boundaries through brace enumeration;
+as such ``[soln-bcs-{le, te, ps, ss}]`` applies one condition to the
+four boundaries ``le``, ``te``, ``ps``, and ``ss``, which are fused into
+a single surface.  Each boundary must be given a condition by exactly
+one section.  Fusion matters for conditions which act on the surface as
+a whole, such as ``char-riem-inv-mass-flow``: an enumerated section is
+driven by one regulator whose measured mass flow is integrated over
+every constituent boundary, so ``mass-flow-rate`` is the total through
+the surface.  Enumerating the boundaries into separate sections instead
+yields one independent regulator per boundary, each driving to the full
+target.  Parameterised with
 
 1. ``type`` --- type of boundary condition:
 

--- a/doc/src/plugins/soln-plugin-ascent.rst
+++ b/doc/src/plugins/soln-plugin-ascent.rst
@@ -39,7 +39,9 @@ on-the-fly.  The following parameters can then be set:
 
 #. ``surface-{name}`` --- attach a named surface source to the scene,
    sampling fields on the specified boundary.  The value is the
-   boundary name (with optional ``bc/`` prefix).  When at least one
+   boundary name (with optional ``bc/`` prefix); a brace enumeration
+   such as ``bc/{le, te}`` fuses several boundaries into one source.
+   When at least one
    ``surface-{name}`` is set, the volume source is omitted unless
    ``volume = true`` is also given.  Multiple surface sources can be
    defined and used in the same scene:

--- a/doc/src/plugins/soln-plugin-fluid-force.rst
+++ b/doc/src/plugins/soln-plugin-fluid-force.rst
@@ -6,7 +6,10 @@ Periodically integrates the pressure and viscous stress on the boundary
 labelled ``name`` and writes out the resulting force and moment (if
 requested) vectors to a CSV or HDF5 file.  When reference conditions are
 supplied the non-dimensional force coefficients are also written out.
-Parameterised with
+Here ``name`` may also be a brace enumeration of the form
+``{le, te, ps, ss}``, in which case the pressure and viscous stress are
+integrated over every named boundary as though they formed a single
+surface.  Parameterised with
 
 #. ``nsteps`` --- integrate every ``nsteps``:
 

--- a/doc/src/plugins/soln-plugin-fwh.rst
+++ b/doc/src/plugins/soln-plugin-fwh.rst
@@ -38,8 +38,9 @@ employed as an approximation.
     *boolean*
 
 #. ``surface`` --- a region the surface of which is sampled for the
-   FWH solver; either a boundary as ``bc/name`` or a combination of
-   the geometric shapes specified in :ref:`user_guide:regions`:
+   FWH solver; either a boundary as ``bc/name``, a brace enumeration
+   of boundaries as ``bc/{a, b}``, or a combination of the geometric
+   shapes specified in :ref:`user_guide:regions`:
 
    ``bc/name`` | ``shape(args, ...)``
 

--- a/doc/src/user_guide.rst
+++ b/doc/src/user_guide.rst
@@ -143,7 +143,10 @@ pyfr export
 
           pyfr export boundary mesh.pyfrm solution.pyfrs solution.vtu lower_wall upper_wall
 
-      Note that boundary export is only supported for 3D grids.
+      Each name may also be a brace enumeration such as
+      ``'{le, te, ps, ss}'``; note the quotes, which prevent the shell
+      from expanding the braces itself.  Boundary export is only
+      supported for 3D grids.
 
    pyfr export spanwise
       Exports a spanwise average of a 3D grid to a 2D VTK grid.
@@ -621,6 +624,11 @@ STL ``stl('name')``
   An STL region.  Note that the region *name* must have been already
   added to the mesh file with ``pyfr region add``.  Only valid in 3D.
   Additionally, region itself *must* be closed.
+
+Boundary ``bc/name``
+  The elements adjacent to the boundary *name*.  The name may also be a
+  brace enumeration ``bc/{le, te, ps, ss}``, which combines the
+  elements of every named boundary.
 
 All region also support rotation.  In 2D this is accomplished by passing
 a trailing `rot=angle` argument where `angle` is a rotation angle in

--- a/pyfr/fields.py
+++ b/pyfr/fields.py
@@ -295,8 +295,9 @@ class FieldRecovery:
                  for b in subclasses(scls.bbcinterscls, just_leaf=True)}
 
         info = []
+        bcsects = scls.bc_sections(self.cfg, self.mesh)
         for bc, con in self.mesh.bcon.items():
-            cfgsect = f'soln-bcs-{bc}'
+            cfgsect = bcsects[bc]
             bcls = bcmap[self.cfg.get(cfgsect, 'type')]
             if hasattr(bcls, 'common_pri_state'):
                 c = bcls.common_consts(self.cfg, cfgsect, self.ndims)

--- a/pyfr/fields.py
+++ b/pyfr/fields.py
@@ -295,7 +295,7 @@ class FieldRecovery:
                  for b in subclasses(scls.bbcinterscls, just_leaf=True)}
 
         info = []
-        bcsects = scls.bc_sections(self.cfg, self.mesh)
+        bcsects = self.mesh.bc_sections(self.cfg)
         for bc, con in self.mesh.bcon.items():
             cfgsect = bcsects[bc]
             bcls = bcmap[self.cfg.get(cfgsect, 'type')]

--- a/pyfr/plugins/soln/ascent.py
+++ b/pyfr/plugins/soln/ascent.py
@@ -9,6 +9,7 @@ from pyfr.ctypesutil import LibWrapper
 from pyfr.exprs import npeval
 from pyfr.fields import CleanToGrid
 from pyfr.inifile import process_expr
+from pyfr.readers.native import Connectivity
 from pyfr.mpiutil import get_comm_rank_root, mpi
 from pyfr.plugins.common import region_data
 from pyfr.plugins.postproc.adapters import (BoundaryPostProcData, FaceInfo,
@@ -17,7 +18,8 @@ from pyfr.plugins.postproc import get_source
 from pyfr.plugins.soln.base import BaseSolnPlugin
 from pyfr.shapes import BaseShape, proj_pts
 from pyfr.subdiv import get_subdiv
-from pyfr.util import file_path_gen, first, paren_depths, subclass_where
+from pyfr.util import (expand_braces, file_path_gen, first, paren_depths,
+                       subclass_where)
 
 
 def con_psolns_pgrads(elementscls, scfg, csolns, cgrads):
@@ -348,15 +350,18 @@ class _BoundaryAscentOutput(_VolumeAscentOutput):
         self.renderer = renderer
         self.sname = sname
 
-        # Accept bc/foo or foo to match mesh.bcon keys
-        bcname = region.removeprefix('bc/')
-        comm, _, _ = get_comm_rank_root()
-        if not comm.allreduce(bcname in renderer.mesh.bcon, op=mpi.LOR):
-            raise ValueError(f'Boundary {bcname} does not exist')
+        # Accept bc/foo or foo or bc/{foo,bar}
+        mesh = renderer.mesh
+        bcnames = expand_braces(region.removeprefix('bc/'))
+        if missing := [b for b in bcnames if f'bc/{b}' not in mesh.codec]:
+            raise ValueError(f'Boundaries do not exist: {missing}')
+
+        # Fuse the boundaries into a single surface
+        conn = Connectivity.fuse(mesh.bcon.get(b) for b in bcnames)
 
         # Per-itype patches, each a flat (eidxs, etype, mop, sop, fidx, svpts)
         self.patches = patches = defaultdict(list)
-        if (conn := renderer.mesh.bcon.get(bcname)) is not None:
+        if conn is not None:
             for etype, fidx, eidxs in conn.items():
                 itype, mop, sop, svpts = renderer.adapter.face_soln_op_vpts(
                     etype, fidx, renderer.divisor

--- a/pyfr/plugins/soln/ascent.py
+++ b/pyfr/plugins/soln/ascent.py
@@ -9,7 +9,6 @@ from pyfr.ctypesutil import LibWrapper
 from pyfr.exprs import npeval
 from pyfr.fields import CleanToGrid
 from pyfr.inifile import process_expr
-from pyfr.readers.native import Connectivity
 from pyfr.mpiutil import get_comm_rank_root, mpi
 from pyfr.plugins.common import region_data
 from pyfr.plugins.postproc.adapters import (BoundaryPostProcData, FaceInfo,
@@ -18,7 +17,7 @@ from pyfr.plugins.postproc import get_source
 from pyfr.plugins.soln.base import BaseSolnPlugin
 from pyfr.shapes import BaseShape, proj_pts
 from pyfr.subdiv import get_subdiv
-from pyfr.util import (expand_braces, file_path_gen, first, paren_depths,
+from pyfr.util import (file_path_gen, first, paren_depths,
                        subclass_where)
 
 
@@ -350,14 +349,8 @@ class _BoundaryAscentOutput(_VolumeAscentOutput):
         self.renderer = renderer
         self.sname = sname
 
-        # Accept bc/foo or foo or bc/{foo,bar}
-        mesh = renderer.mesh
-        bcnames = expand_braces(region.removeprefix('bc/'))
-        if missing := [b for b in bcnames if f'bc/{b}' not in mesh.codec]:
-            raise ValueError(f'Boundaries do not exist: {missing}')
-
-        # Fuse the boundaries into a single surface
-        conn = Connectivity.fuse(mesh.bcon.get(b) for b in bcnames)
+        # Accept bc/foo or foo or bc/{foo, bar}
+        conn = renderer.mesh.bcon_for(region.removeprefix('bc/'))
 
         # Per-itype patches, each a flat (eidxs, etype, mop, sop, fidx, svpts)
         self.patches = patches = defaultdict(list)

--- a/pyfr/plugins/soln/ascent.py
+++ b/pyfr/plugins/soln/ascent.py
@@ -349,7 +349,10 @@ class _BoundaryAscentOutput(_VolumeAscentOutput):
         self.renderer = renderer
         self.sname = sname
 
-        # Accept bc/foo or foo or bc/{foo, bar}
+        # Boundary surface sources take the form bc/<name>
+        if not region.startswith('bc/'):
+            raise ValueError(f'Invalid surface source: {region}')
+
         conn = renderer.mesh.bcon_for(region.removeprefix('bc/'))
 
         # Per-itype patches, each a flat (eidxs, etype, mop, sop, fidx, svpts)

--- a/pyfr/plugins/soln/fluidforce.py
+++ b/pyfr/plugins/soln/fluidforce.py
@@ -2,14 +2,18 @@ import numpy as np
 
 from pyfr.cache import memoize
 from pyfr.mpiutil import get_comm_rank_root, mpi
+from pyfr.readers.native import Connectivity
 from pyfr.plugins.mixins import BackendMixin, PublishMixin, SeriesWriterMixin
 from pyfr.plugins.soln.base import BaseSolnPlugin
 from pyfr.quadrules.surface import SurfaceIntegrator
+from pyfr.util import expand_braces
 
 
 class FluidForceIntegrator(SurfaceIntegrator):
     def __init__(self, cfg, cfgsect, system, bcname, morigin):
-        con = system.mesh.bcon.get(bcname)
+        # Fuse the boundaries in any brace enumeration into one surface
+        bcon = system.mesh.bcon
+        con = Connectivity.fuse(bcon.get(b) for b in expand_braces(bcname))
 
         super().__init__(cfg, cfgsect, system.ele_map, con, flags='s')
 
@@ -74,14 +78,15 @@ class FluidForcePlugin(PublishMixin, SeriesWriterMixin, BackendMixin,
                 self._mcnames = ['cmr', 'cmp', 'cmy']
                 self._mcdirs = [drag, side, lift]
 
-        # See which ranks have the boundary
-        bcranks = comm.gather(suffix in intg.system.mesh.bcon, root=root)
+        # Ensure the boundaries exist; the codec is global, so this
+        # check is consistent across all ranks
+        codec = intg.system.mesh.codec
+        if missing := [b for b in expand_braces(suffix)
+                       if f'bc/{b}' not in codec]:
+            raise RuntimeError(f'Boundaries do not exist: {missing}')
 
         # The root rank needs to open the output file
         if rank == root:
-            if not any(bcranks):
-                raise RuntimeError(f'Boundary {suffix} does not exist')
-
             self._init_series(intg, self._fields)
 
         # Set interpolation matrices and quadrature weights

--- a/pyfr/plugins/soln/fluidforce.py
+++ b/pyfr/plugins/soln/fluidforce.py
@@ -2,18 +2,15 @@ import numpy as np
 
 from pyfr.cache import memoize
 from pyfr.mpiutil import get_comm_rank_root, mpi
-from pyfr.readers.native import Connectivity
 from pyfr.plugins.mixins import BackendMixin, PublishMixin, SeriesWriterMixin
 from pyfr.plugins.soln.base import BaseSolnPlugin
 from pyfr.quadrules.surface import SurfaceIntegrator
-from pyfr.util import expand_braces
 
 
 class FluidForceIntegrator(SurfaceIntegrator):
     def __init__(self, cfg, cfgsect, system, bcname, morigin):
         # Fuse the boundaries in any brace enumeration into one surface
-        bcon = system.mesh.bcon
-        con = Connectivity.fuse(bcon.get(b) for b in expand_braces(bcname))
+        con = system.mesh.bcon_for(bcname)
 
         super().__init__(cfg, cfgsect, system.ele_map, con, flags='s')
 
@@ -78,20 +75,14 @@ class FluidForcePlugin(PublishMixin, SeriesWriterMixin, BackendMixin,
                 self._mcnames = ['cmr', 'cmp', 'cmy']
                 self._mcdirs = [drag, side, lift]
 
-        # Ensure the boundaries exist; the codec is global, so this
-        # check is consistent across all ranks
-        codec = intg.system.mesh.codec
-        if missing := [b for b in expand_braces(suffix)
-                       if f'bc/{b}' not in codec]:
-            raise RuntimeError(f'Boundaries do not exist: {missing}')
+        # Set interpolation matrices and quadrature weights; this also
+        # validates the boundaries against the codec on every rank
+        self.ff_int = FluidForceIntegrator(self.cfg, cfgsect, intg.system,
+                                           suffix, morigin)
 
         # The root rank needs to open the output file
         if rank == root:
             self._init_series(intg, self._fields)
-
-        # Set interpolation matrices and quadrature weights
-        self.ff_int = FluidForceIntegrator(self.cfg, cfgsect, intg.system,
-                                           suffix, morigin)
 
         # Initialise backend infrastructure
         self._init_backend(intg)

--- a/pyfr/plugins/soln/fwh.py
+++ b/pyfr/plugins/soln/fwh.py
@@ -116,7 +116,7 @@ class FWHPlugin(SeriesWriterMixin, SurfaceRegionMixin, BaseSolnPlugin):
         # Solid boundary surfaces require the wall boundary treatment
         sname = self.cfg.get(cfgsect, 'surface')
         if sname.startswith('bc/'):
-            bcsects = intg.system.bc_sections(self.cfg, intg.system.mesh)
+            bcsects = intg.system.mesh.bc_sections(self.cfg)
             bctypes = {self.cfg.get(bcsects[b], 'type')
                        for b in expand_braces(sname[3:])}
 

--- a/pyfr/plugins/soln/fwh.py
+++ b/pyfr/plugins/soln/fwh.py
@@ -7,7 +7,7 @@ from pyfr.exprs import npeval
 from pyfr.plugins.mixins import SeriesWriterMixin, SurfaceRegionMixin
 from pyfr.plugins.soln.base import BaseSolnPlugin
 from pyfr.quadrules.surface import SurfaceIntegrator
-from pyfr.util import first
+from pyfr.util import expand_braces, first
 
 
 FWHSurfParams = namedtuple(
@@ -116,7 +116,16 @@ class FWHPlugin(SeriesWriterMixin, SurfaceRegionMixin, BaseSolnPlugin):
         # Solid boundary surfaces require the wall boundary treatment
         sname = self.cfg.get(cfgsect, 'surface')
         if sname.startswith('bc/'):
-            self.bctype = self.cfg.get(f'soln-bcs-{sname[3:]}', 'type')
+            bcsects = intg.system.bc_sections(self.cfg, intg.system.mesh)
+            bctypes = {self.cfg.get(bcsects[b], 'type')
+                       for b in expand_braces(sname[3:])}
+
+            # Check for malformed boundary groups
+            if len(bctypes) > 1:
+                raise ValueError(f'Surface {sname} spans mixed boundary '
+                                 f'types: {sorted(bctypes)}')
+
+            self.bctype = first(bctypes)
         else:
             self.bctype = None
 

--- a/pyfr/readers/native.py
+++ b/pyfr/readers/native.py
@@ -95,6 +95,23 @@ class Connectivity:
 
         return Connectivity(self.cidxs[mask], new[mask], self.cidxmap)
 
+    @classmethod
+    def fuse(cls, cons):
+        # Fuse several connectivities, which must share a cidxmap, into one
+        cons = [c for c in cons if c is not None and len(c)]
+        if not cons:
+            return None
+        elif len(cons) == 1:
+            return cons[0]
+
+        cidxs = np.concatenate([c.cidxs for c in cons])
+        eidxs = np.concatenate([c.eidxs for c in cons])
+
+        # Order by (cidx, eidx) so the result does not depend on fuse order
+        sidx = np.lexsort((eidxs, cidxs))
+
+        return cls(cidxs[sidx], eidxs[sidx], first(cons).cidxmap)
+
 
 class NativeReader:
     def __init__(self, fname, pname=None, *, construct_con=True):

--- a/pyfr/readers/native.py
+++ b/pyfr/readers/native.py
@@ -47,7 +47,11 @@ class Mesh:
 
     def bcon_for(self, spec):
         # Boundaries in any brace enumeration, fused into one connectivity
-        names = expand_braces(spec)
+        names = list(expand_braces(spec))
+
+        # Catch double counted boundaries
+        if len(set(names)) != len(names):
+            raise ValueError(f'Duplicate boundaries in {spec}')
 
         # The codec is global, so this check is consistent across all ranks
         if missing := [b for b in names if f'bc/{b}' not in self.codec]:

--- a/pyfr/readers/native.py
+++ b/pyfr/readers/native.py
@@ -50,14 +50,42 @@ class Mesh:
         names = list(expand_braces(spec))
 
         # Catch double counted boundaries
-        if len(set(names)) != len(names):
-            raise ValueError(f'Duplicate boundaries in {spec}')
+        if dup := sorted(n for n in set(names) if names.count(n) > 1):
+            raise ValueError(f'Duplicate boundaries in {spec}: {dup}')
 
         # The codec is global, so this check is consistent across all ranks
         if missing := [b for b in names if f'bc/{b}' not in self.codec]:
             raise ValueError(f'Boundaries do not exist: {missing}')
 
-        return Connectivity.fuse(self.bcon.get(b) for b in names)
+        cons = [c for b in names if (c := self.bcon.get(b))]
+
+        return Connectivity.fuse(cons)
+
+    def bc_sections(self, cfg, prefix='soln-bcs-'):
+        # Map each boundary onto the section which parameterises it
+        bcs = {c.removeprefix('bc/') for c in self.codec
+               if c.startswith('bc/')}
+
+        sects = {}
+        for sect in cfg.sections():
+            if not sect.startswith(prefix):
+                continue
+
+            names = set(expand_braces(sect.removeprefix(prefix)))
+
+            # Enumerated sections must name valid boundaries
+            if len(names) > 1 and (missing := names - bcs):
+                raise ValueError(f'Boundaries in [{sect}] do not exist: '
+                                 f'{sorted(missing)}')
+
+            # A boundary may be parameterised by at most one section
+            if dup := min(names & sects.keys(), default=None):
+                raise ValueError(f'Boundary {dup} is parameterised by both '
+                                 f'[{sects[dup]}] and [{sect}]')
+
+            sects |= dict.fromkeys(names & bcs, sect)
+
+        return sects
 
 
 @dataclass
@@ -112,19 +140,18 @@ class Connectivity:
     @classmethod
     def fuse(cls, cons):
         # Fuse several connectivities, which must share a cidxmap, into one
-        cons = [c for c in cons if c is not None and len(c)]
+        cons = list(cons)
         if not cons:
             return None
         elif len(cons) == 1:
             return cons[0]
+        else:
+            cidxs = np.concatenate([c.cidxs for c in cons])
+            eidxs = np.concatenate([c.eidxs for c in cons])
 
-        cidxs = np.concatenate([c.cidxs for c in cons])
-        eidxs = np.concatenate([c.eidxs for c in cons])
+            sidx = np.lexsort((eidxs, cidxs))
 
-        # Order by (cidx, eidx) so the result does not depend on fuse order
-        sidx = np.lexsort((eidxs, cidxs))
-
-        return cls(cidxs[sidx], eidxs[sidx], first(cons).cidxmap)
+            return cls(cidxs[sidx], eidxs[sidx], first(cons).cidxmap)
 
 
 class NativeReader:

--- a/pyfr/readers/native.py
+++ b/pyfr/readers/native.py
@@ -9,7 +9,7 @@ from pyfr.inifile import Inifile
 from pyfr.mpiutil import (Scatterer, SparseScatterer, autofree,
                           get_comm_rank_root)
 from pyfr.readers.shared_nodes import SharedNodesFinder
-from pyfr.util import first
+from pyfr.util import expand_braces, first
 
 
 @dataclass
@@ -44,6 +44,16 @@ class Mesh:
     node_idxs: np.ndarray = None
     node_valency: np.ndarray = None
     shared_nodes: object = None
+
+    def bcon_for(self, spec):
+        # Boundaries in any brace enumeration, fused into one connectivity
+        names = expand_braces(spec)
+
+        # The codec is global, so this check is consistent across all ranks
+        if missing := [b for b in names if f'bc/{b}' not in self.codec]:
+            raise ValueError(f'Boundaries do not exist: {missing}')
+
+        return Connectivity.fuse(self.bcon.get(b) for b in names)
 
 
 @dataclass

--- a/pyfr/regions.py
+++ b/pyfr/regions.py
@@ -6,7 +6,7 @@ from boostree import RTree
 import numpy as np
 
 from pyfr.mpiutil import get_comm_rank_root, mpi
-from pyfr.util import match_paired_paren, subclass_where
+from pyfr.util import expand_braces, match_paired_paren, subclass_where
 
 
 def parse_region_expr(expr, rdata=None):
@@ -198,24 +198,23 @@ class TagRegion(BaseRegion):
 
 class BoundaryRegion(BaseRegion):
     def __init__(self, bcname):
-        self.bcname = bcname
+        self.bcnames = expand_braces(bcname)
 
     def region_eles(self, mesh):
-        comm, rank, root = get_comm_rank_root()
-
         eset = defaultdict(list)
 
-        # Ensure the boundary exists
-        bcranks = comm.gather(self.bcname in mesh.bcon, root=root)
-        if rank == root and not any(bcranks):
-            raise ValueError(f'Boundary {self.bcname} does not exist')
+        # Ensure the boundaries exist across all ranks
+        if missing := [b for b in self.bcnames
+                       if f'bc/{b}' not in mesh.codec]:
+            raise ValueError(f'Boundaries do not exist: {missing}')
 
         # Determine which of our elements are directly on the boundary
-        if self.bcname in mesh.bcon:
-            for etype, fidx, eidxs in mesh.bcon[self.bcname].items():
-                eset[etype].extend(eidxs.tolist())
+        for b in self.bcnames:
+            if b in mesh.bcon:
+                for etype, fidx, eidxs in mesh.bcon[b].items():
+                    eset[etype].extend(eidxs.tolist())
 
-        return {k: sorted(v) for k, v in eset.items()}
+        return {k: sorted(set(v)) for k, v in eset.items()}
 
 
 class BaseGeometricRegion(BaseRegion):

--- a/pyfr/regions.py
+++ b/pyfr/regions.py
@@ -6,7 +6,7 @@ from boostree import RTree
 import numpy as np
 
 from pyfr.mpiutil import get_comm_rank_root, mpi
-from pyfr.util import expand_braces, match_paired_paren, subclass_where
+from pyfr.util import match_paired_paren, subclass_where
 
 
 def parse_region_expr(expr, rdata=None):
@@ -198,21 +198,15 @@ class TagRegion(BaseRegion):
 
 class BoundaryRegion(BaseRegion):
     def __init__(self, bcname):
-        self.bcnames = expand_braces(bcname)
+        self.bcname = bcname
 
     def region_eles(self, mesh):
         eset = defaultdict(list)
 
-        # Ensure the boundaries exist across all ranks
-        if missing := [b for b in self.bcnames
-                       if f'bc/{b}' not in mesh.codec]:
-            raise ValueError(f'Boundaries do not exist: {missing}')
-
         # Determine which of our elements are directly on the boundary
-        for b in self.bcnames:
-            if b in mesh.bcon:
-                for etype, fidx, eidxs in mesh.bcon[b].items():
-                    eset[etype].extend(eidxs.tolist())
+        if (con := mesh.bcon_for(self.bcname)) is not None:
+            for etype, fidx, eidxs in con.items():
+                eset[etype].extend(eidxs.tolist())
 
         return {k: sorted(set(v)) for k, v in eset.items()}
 

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -280,11 +280,11 @@ class BaseSystem:
             if not c.startswith('bc/'):
                 continue
 
+            # Unclaimed boundaries fall back to their nominal section,
+            # with the resulting error coming from the config lookup
             bname = c.removeprefix('bc/')
-            if bname not in bcsects:
-                raise ValueError(f'No boundary condition for {bname}')
-
-            if (sect := bcsects[bname]) not in sects:
+            sect = bcsects.get(bname, f'soln-bcs-{bname}')
+            if sect not in sects:
                 sects.append(sect)
 
         # Iterate over the boundary conditions

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -275,7 +275,7 @@ class BaseSystem:
         bcsects = mesh.bc_sections(self.cfg)
 
         # Determine the active sections, in codec order
-        sects = {}
+        sects = []
         for c in mesh.codec:
             if not c.startswith('bc/'):
                 continue
@@ -284,12 +284,17 @@ class BaseSystem:
             if bname not in bcsects:
                 raise ValueError(f'No boundary condition for {bname}')
 
-            sects[bcsects[bname]] = None
+            if (sect := bcsects[bname]) not in sects:
+                sects.append(sect)
 
         # Iterate over the boundary conditions
         for cfgsect in sects:
             # Fuse the constituent boundaries
-            con = mesh.bcon_for(cfgsect.removeprefix('soln-bcs-'))
+            # Serialisation and kernel tags follow the section suffix
+            sname = cfgsect.removeprefix('soln-bcs-')
+
+            # Fuse the constituent boundaries
+            con = mesh.bcon_for(sname)
 
             # Construct an MPI communicator for this BC
             localbc = con is not None
@@ -298,8 +303,6 @@ class BaseSystem:
             # Get the class
             bcclass = bcmap[self.cfg.get(cfgsect, 'type')]
 
-            # Serialisation and kernel tags follow the section suffix
-            sname = cfgsect.removeprefix('soln-bcs-')
             sdata = initsoln.state.get(f'bcs/{sname}') if initsoln else None
 
             # If we have this boundary then create an instance

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -9,7 +9,7 @@ from pyfr.backends.base import NullKernel
 from pyfr.cache import memoize
 from pyfr.mpiutil import autofree, get_comm_rank_root, mpi
 from pyfr.shapes import BaseShape
-from pyfr.util import expand_braces, subclasses
+from pyfr.util import subclasses
 
 
 class BaseSystem:
@@ -262,33 +262,6 @@ class BaseSystem:
 
         return mpi_inters
 
-    @staticmethod
-    def bc_sections(cfg, mesh, prefix='soln-bcs-'):
-        # Map each boundary onto the section which parameterises it
-        bcs = {c.removeprefix('bc/') for c in mesh.codec
-               if c.startswith('bc/')}
-
-        sects = {}
-        for sect in cfg.sections():
-            if not sect.startswith(prefix):
-                continue
-
-            names = set(expand_braces(sect.removeprefix(prefix)))
-
-            # Enumerated sections must name valid boundaries
-            if len(names) > 1 and (missing := names - bcs):
-                raise ValueError(f'Boundaries in [{sect}] do not exist: '
-                                 f'{sorted(missing)}')
-
-            # A boundary may be parameterised by at most one section
-            if dup := min(names & sects.keys(), default=None):
-                raise ValueError(f'Boundary {dup} is parameterised by both '
-                                 f'[{sects[dup]}] and [{sect}]')
-
-            sects |= dict.fromkeys(names & bcs, sect)
-
-        return sects
-
     def _load_bc_inters(self, mesh, elemap, initsoln, serialiser):
         comm, rank, root = get_comm_rank_root()
 
@@ -299,7 +272,7 @@ class BaseSystem:
         prevcfg = initsoln.config if initsoln else None
 
         # Map each boundary onto its governing section
-        bcsects = self.bc_sections(self.cfg, mesh)
+        bcsects = mesh.bc_sections(self.cfg)
 
         # Determine the active sections, in codec order
         sects = {}

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -289,11 +289,10 @@ class BaseSystem:
 
         # Iterate over the boundary conditions
         for cfgsect in sects:
-            # Fuse the constituent boundaries
-            # Serialisation and kernel tags follow the section suffix
+            # Name the constituent boundaries
             sname = cfgsect.removeprefix('soln-bcs-')
 
-            # Fuse the constituent boundaries
+            # Fuse the boundaries
             con = mesh.bcon_for(sname)
 
             # Construct an MPI communicator for this BC
@@ -303,6 +302,7 @@ class BaseSystem:
             # Get the class
             bcclass = bcmap[self.cfg.get(cfgsect, 'type')]
 
+            # Serialised state and kernel tags follow suffix
             sdata = initsoln.state.get(f'bcs/{sname}') if initsoln else None
 
             # If we have this boundary then create an instance

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -8,8 +8,9 @@ import numpy as np
 from pyfr.backends.base import NullKernel
 from pyfr.cache import memoize
 from pyfr.mpiutil import autofree, get_comm_rank_root, mpi
+from pyfr.readers.native import Connectivity
 from pyfr.shapes import BaseShape
-from pyfr.util import subclasses
+from pyfr.util import expand_braces, subclasses
 
 
 class BaseSystem:
@@ -262,6 +263,35 @@ class BaseSystem:
 
         return mpi_inters
 
+    @staticmethod
+    def bc_sections(cfg, mesh, prefix='soln-bcs-'):
+        # Map each boundary onto the section which parameterises it
+        bcs = {c.removeprefix('bc/') for c in mesh.codec
+               if c.startswith('bc/')}
+
+        sects = {}
+        for sect in cfg.sections():
+            if not sect.startswith(prefix):
+                continue
+
+            names = expand_braces(sect.removeprefix(prefix))
+
+            # Enumerated sections must name valid boundaries
+            if len(names) > 1:
+                if missing := [b for b in names if b not in bcs]:
+                    raise ValueError(f'Boundaries in [{sect}] do not exist: '
+                                     f'{missing}')
+
+            for b in names:
+                if b in bcs:
+                    if b in sects:
+                        raise ValueError(f'Boundary {b} is parameterised by '
+                                         f'both [{sects[b]}] and [{sect}]')
+
+                    sects[b] = sect
+
+        return sects
+
     def _load_bc_inters(self, mesh, elemap, initsoln, serialiser):
         comm, rank, root = get_comm_rank_root()
 
@@ -271,27 +301,41 @@ class BaseSystem:
 
         prevcfg = initsoln.config if initsoln else None
 
-        # Iterate over all boundaries in the mesh
+        # Map each boundary onto its governing section
+        bcsects = self.bc_sections(self.cfg, mesh)
+
+        # Group the boundaries in the mesh by their section
+        sects = {}
         for c in mesh.codec:
             if not c.startswith('bc/'):
                 continue
 
-            # Construct an MPI communicator for this boundary
             bname = c.removeprefix('bc/')
-            localbc = bname in mesh.bcon
+            if bname not in bcsects:
+                raise ValueError(f'No boundary condition for {bname}')
+
+            sects.setdefault(bcsects[bname], []).append(bname)
+
+        # Iterate over the boundary conditions
+        for cfgsect, bnames in sects.items():
+            # Fuse the constituent boundaries
+            con = Connectivity.fuse(mesh.bcon.get(b) for b in bnames)
+
+            # Construct an MPI communicator for this BC
+            localbc = con is not None
             bccomm = autofree(comm.Split(1 if localbc else mpi.UNDEFINED))
 
             # Get the class
-            cfgsect = f'soln-bcs-{bname}'
             bcclass = bcmap[self.cfg.get(cfgsect, 'type')]
 
-            # Check if there is serialised data for this boundary in initsoln
-            sdata = initsoln.state.get(f'bcs/{bname}') if initsoln else None
+            # Serialisation and kernel tags follow the section suffix
+            sname = cfgsect.removeprefix('soln-bcs-')
+            sdata = initsoln.state.get(f'bcs/{sname}') if initsoln else None
 
             # If we have this boundary then create an instance
             if localbc:
-                bciface = bcclass(self.backend, mesh.bcon[bname], elemap,
-                                  cfgsect, self.cfg, bccomm)
+                bciface = bcclass(self.backend, con, elemap, cfgsect,
+                                  self.cfg, bccomm)
                 bciface.setup(sdata, prevcfg)
                 bc_inters.append(bciface)
             else:
@@ -299,9 +343,9 @@ class BaseSystem:
 
             # Allow the boundary to return a preparation callback
             if (pfn := bcclass.preparefn(bciface, mesh, elemap)):
-                bc_prefns[bname] = pfn
+                bc_prefns[sname] = pfn
 
-            bcclass.serialisefn(bciface, f'bcs/{bname}', serialiser)
+            bcclass.serialisefn(bciface, f'bcs/{sname}', serialiser)
 
         return bc_inters, bc_prefns
 

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -8,7 +8,6 @@ import numpy as np
 from pyfr.backends.base import NullKernel
 from pyfr.cache import memoize
 from pyfr.mpiutil import autofree, get_comm_rank_root, mpi
-from pyfr.readers.native import Connectivity
 from pyfr.shapes import BaseShape
 from pyfr.util import expand_braces, subclasses
 
@@ -274,21 +273,19 @@ class BaseSystem:
             if not sect.startswith(prefix):
                 continue
 
-            names = expand_braces(sect.removeprefix(prefix))
+            names = set(expand_braces(sect.removeprefix(prefix)))
 
             # Enumerated sections must name valid boundaries
-            if len(names) > 1:
-                if missing := [b for b in names if b not in bcs]:
-                    raise ValueError(f'Boundaries in [{sect}] do not exist: '
-                                     f'{missing}')
+            if len(names) > 1 and (missing := names - bcs):
+                raise ValueError(f'Boundaries in [{sect}] do not exist: '
+                                 f'{sorted(missing)}')
 
-            for b in names:
-                if b in bcs:
-                    if b in sects:
-                        raise ValueError(f'Boundary {b} is parameterised by '
-                                         f'both [{sects[b]}] and [{sect}]')
+            # A boundary may be parameterised by at most one section
+            if dup := min(names & sects.keys(), default=None):
+                raise ValueError(f'Boundary {dup} is parameterised by both '
+                                 f'[{sects[dup]}] and [{sect}]')
 
-                    sects[b] = sect
+            sects |= dict.fromkeys(names & bcs, sect)
 
         return sects
 
@@ -304,7 +301,7 @@ class BaseSystem:
         # Map each boundary onto its governing section
         bcsects = self.bc_sections(self.cfg, mesh)
 
-        # Group the boundaries in the mesh by their section
+        # Determine the active sections, in codec order
         sects = {}
         for c in mesh.codec:
             if not c.startswith('bc/'):
@@ -314,12 +311,12 @@ class BaseSystem:
             if bname not in bcsects:
                 raise ValueError(f'No boundary condition for {bname}')
 
-            sects.setdefault(bcsects[bname], []).append(bname)
+            sects[bcsects[bname]] = None
 
         # Iterate over the boundary conditions
-        for cfgsect, bnames in sects.items():
+        for cfgsect in sects:
             # Fuse the constituent boundaries
-            con = Connectivity.fuse(mesh.bcon.get(b) for b in bnames)
+            con = mesh.bcon_for(cfgsect.removeprefix('soln-bcs-'))
 
             # Construct an MPI communicator for this BC
             localbc = con is not None

--- a/pyfr/stats/provider.py
+++ b/pyfr/stats/provider.py
@@ -4,6 +4,7 @@ from importlib.resources import files
 import re
 
 from pyfr.exprs import subst_expr_vars
+from pyfr.util import expand_braces
 
 
 KEYWORDS = ('field', 'derived', 'derived-hidden', 'set')
@@ -16,10 +17,7 @@ def parse_stats(spec):
     pkgs, npats = [], 0
     for m in re.finditer(pat, spec):
         npats += 1
-        if m[2] is None:
-            pkgs.append(m[1])
-        else:
-            pkgs.extend(f'{m[1]}{a.strip()}{m[3]}' for a in m[2].split(','))
+        pkgs.extend(expand_braces(m[0]))
 
     # The specification must be exactly these patterns, comma separated
     rem = re.sub(r'\s', '', re.sub(pat, '', spec))

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -207,20 +207,17 @@ def strip_parens(s):
 
 
 def expand_braces(spec):
-    # Expand a brace enumeration pre{a, b}post onto [preapost, prebpost]
-    if (m := re.fullmatch(r'(.*?)\{(.*?)\}(.*)', spec)):
-        parts = [p.strip() for p in m[2].split(',')]
-        if not all(parts):
-            raise ValueError(f'Invalid brace enumeration: {spec}')
+    # Expand brace enumerations
+    if not (m := re.search(r'\{([^{}]*)\}', spec)):
+        yield spec
+        return
 
-        names = [f'{m[1]}{p}{m[3]}' for p in parts]
+    parts = [p.strip() for p in m[1].split(',')]
+    if not all(parts) or len(set(parts)) != len(parts):
+        raise ValueError(f'Invalid brace enumeration: {spec}')
 
-        if len(set(names)) != len(names):
-            raise ValueError(f'Duplicate names in enumeration: {spec}')
-
-        return names
-    else:
-        return [spec]
+    for part in parts:
+        yield from expand_braces(spec[:m.start()] + part + spec[m.end():])
 
 
 class CSVStream:

--- a/pyfr/util.py
+++ b/pyfr/util.py
@@ -206,6 +206,23 @@ def strip_parens(s):
                    if d == 0 and c not in ')}')
 
 
+def expand_braces(spec):
+    # Expand a brace enumeration pre{a, b}post onto [preapost, prebpost]
+    if (m := re.fullmatch(r'(.*?)\{(.*?)\}(.*)', spec)):
+        parts = [p.strip() for p in m[2].split(',')]
+        if not all(parts):
+            raise ValueError(f'Invalid brace enumeration: {spec}')
+
+        names = [f'{m[1]}{p}{m[3]}' for p in parts]
+
+        if len(set(names)) != len(names):
+            raise ValueError(f'Duplicate names in enumeration: {spec}')
+
+        return names
+    else:
+        return [spec]
+
+
 class CSVStream:
     def __init__(self, fname, *, header=None, nflush=100, reset=False):
         # Append the '.csv' extension

--- a/pyfr/writers/vtk/boundary.py
+++ b/pyfr/writers/vtk/boundary.py
@@ -7,7 +7,7 @@ from pyfr.plugins.postproc.adapters import FaceInfo
 from pyfr.polys import get_polybasis
 from pyfr.shapes import BaseShape, interp_pts, proj_pts
 from pyfr.subdiv import get_subdiv
-from pyfr.util import subclass_where
+from pyfr.util import expand_braces, subclass_where
 from pyfr.writers.vtk.base import BaseVTKWriter
 
 
@@ -32,7 +32,12 @@ class VTKBoundaryWriter(BaseVTKWriter):
         self._surface_info = defaultdict(list)
 
         rmesh, smesh = self.reader.mesh, self.mesh
-        for b in self.boundaries:
+
+        # Expand any brace enumerations, dropping duplicate boundaries
+        bnames = dict.fromkeys(b for n in self.boundaries
+                               for b in expand_braces(n))
+
+        for b in bnames:
             if f'bc/{b}' not in smesh.codec:
                 raise ValueError(f'Unknown boundary {b!r}')
 


### PR DESCRIPTION
For complex geometries, it is convenient to split boundaries at mesh-gen into several discrete entities. However, these entities may all share a single boundary condition. In other cases, some post processing operations are best done as individual boundaries, while others are nice to aggregate. Consider a aerofoil with a LE, TE, PS, SS surfaces. Some data is nice to have individually, while something like lift or a surface integral would be best to group these surfaces. This PR introduces brace expansion everywhere boundaries are specified:

**Boundary conditions**

[soln-bcs-{le, te, ps, ss}]
type = no-slp-adia-wall

The four boundaries become one interface, one kernel set, one serialisation key. Each boundary must get its condition from exactly one section — a boundary claimed twice (its own section plus an enumeration, or two enumerations) is an error naming both. This is semantic, not just shorthand: for controlled BCs,


[soln-bcs-{inlet-upper, inlet-lower}]
type = char-riem-inv-mass-flow
mass-flow-rate = 9.0        ; total through BOTH boundaries
...

gives one regulator measuring the combined flow, separate sections would give two independent regulators, each chasing the full 9.0.

**Force integration plugin**

[soln-plugin-fluidforce-{le, te, ps, ss}]
nsteps = 10
file = airfoil-forces.csv
morigin = (0.25, 0.0, 0.0)

Forces and moments integrated over the fused surface in one pass — equals the sum of four single-boundary plugins to round-off.

**Regions and surfaces**

[soln-plugin-writer]
region = bc/{le, te, ps, ss}        ; region-restricted output

[soln-plugin-fwh]
surface = bc/{shield, shoulder}     ; members must share one BC type

[soln-plugin-ascent]
surface-wing = bc/{le, te, ps, ss}  ; one render source spanning all four

**Export**

pyfr export boundary mesh.pyfrm soln.pyfrs wing.vtu '{le, te, ps, ss}'

Quotes required (the shell expands bare braces itself). Byte-identical to listing the names separately; mixing works too: '{le, te}' ps ss.

Rules
Members must exist in the mesh; unknown names error listing the offenders, identically on every rank.
{a,}, {a,a}, {} are rejected.
Plain names are untouched, so configs without braces behave bit-identically to before.