### PR TITLE
Initial Riemann invariant pressure for the pressure controller

### DIFF
--- a/doc/src/boundary-initial-conditions/soln-bcs.rst
+++ b/doc/src/boundary-initial-conditions/soln-bcs.rst
@@ -123,7 +123,12 @@ dependent, boundary condition labelled *name* in the .pyfrm file with
            *float* | *string*
 
         - ``pressure`` --- target area-averaged static pressure on the
-          boundary. Also used as the initial Riemann invariant pressure.
+          boundary.
+
+           *float* | *string*
+
+        - ``p`` --- initial Riemann invariant pressure (optional), which the
+          controller will vary to target ``pressure``.
 
            *float* | *string*
 

--- a/doc/src/boundary-initial-conditions/soln-bcs.rst
+++ b/doc/src/boundary-initial-conditions/soln-bcs.rst
@@ -55,8 +55,8 @@ dependent, boundary condition labelled *name* in the .pyfrm file with
 
            *float* | *string*
 
-        - ``p`` --- initial static pressure, the controller will vary this to
-          target a mass flow rate.
+        - ``init-pressure`` --- initial Riemann invariant pressure, which the 
+          controller will vary to target a mass flow rate.
 
            *float* | *string*
 

--- a/doc/src/boundary-initial-conditions/soln-bcs.rst
+++ b/doc/src/boundary-initial-conditions/soln-bcs.rst
@@ -127,8 +127,8 @@ dependent, boundary condition labelled *name* in the .pyfrm file with
 
            *float* | *string*
 
-        - ``p`` --- initial Riemann invariant pressure (optional), which the
-          controller will vary to target ``pressure``.
+        - ``init-pressure`` --- initial Riemann invariant pressure (optional),
+          which the controller will vary to target ``pressure``.
 
            *float* | *string*
 

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -280,7 +280,7 @@ class PressureBCMixin(ControlledBCMixin):
         self.area = scal_coll(self.bccomm.Allreduce, area, op=mpi.SUM)
 
     def _default_interp_c(self):
-        return self.target
+        return self._eval_opts(['p'], self.target)[0]
 
     def _measure(self, solns):
         p_num = 0.0

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -280,7 +280,10 @@ class PressureBCMixin(ControlledBCMixin):
         self.area = scal_coll(self.bccomm.Allreduce, area, op=mpi.SUM)
 
     def _default_interp_c(self):
-        return self._eval_opts(['init-pressure'], self.target)[0]
+        if self.cfg.hasopt(self.cfgsect, 'init-pressure'):
+            return self._eval_opts(['init-pressure'])[0]
+        else:
+            return self.target
 
     def _measure(self, solns):
         p_num = 0.0

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -280,7 +280,7 @@ class PressureBCMixin(ControlledBCMixin):
         self.area = scal_coll(self.bccomm.Allreduce, area, op=mpi.SUM)
 
     def _default_interp_c(self):
-        return self._eval_opts(['p'], self.target)[0]
+        return self._eval_opts(['init-pressure'], self.target)[0]
 
     def _measure(self, solns):
         p_num = 0.0

--- a/pyfr/solvers/euler/inters.py
+++ b/pyfr/solvers/euler/inters.py
@@ -243,7 +243,7 @@ class MassFlowBCMixin(ControlledBCMixin):
             self._qwts_norms.append(norms*qwts[:, None])
 
     def _default_interp_c(self):
-        return self._eval_opts(['p'])[0]
+        return self._eval_opts(['init-pressure'])[0]
 
     def _measure(self, solns):
         mf = 0.0


### PR DESCRIPTION
This lets the starting pressure for the pressure controller to be specified rather than always setting it to the target pressure. Without this you can't restart a sim with a different config file with the Riemann invariant pressure that the previous run found (e.g. if you change the polynomial order).