### PR TITLE
Add support for tracking per-peer MPI wait times

### DIFF
--- a/doc/src/backends/backend.rst
+++ b/doc/src/backends/backend.rst
@@ -18,6 +18,11 @@ Parameterises the backend with
 
     ``True`` | ``False``
 
+#. ``collect-wait-times-per-peer`` --- if to additionally attribute MPI
+   request wait times to individual peers. Requires ``collect-wait-times``:
+
+    ``True`` | ``False``
+
 #. ``collect-wait-times-len`` --- size of the wait time history buffer:
 
      *int*

--- a/doc/src/performance_tuning.rst
+++ b/doc/src/performance_tuning.rst
@@ -307,6 +307,16 @@ initiate MPI requests.  The average amount of time each rank spends
 waiting for MPI requests per right hand side evaluation can be obtained
 by vertically summing all of the ``-median`` fields together.
 
+Per-peer wait attribution can additionally be enabled with
+``collect-wait-times-per-peer = true``.  In this mode PyFR uses
+``MPI_Waitsome`` and attributes each blocking interval equally across the
+requests completed by that call.  The resulting sparse
+``rhs-graph-*-send-*`` and ``rhs-graph-*-recv-*`` fields contain
+``(rank, peer, value)`` triplets, where ``rank`` is the rank reporting the
+statistic.  Corresponding ``*-bytes`` fields give the static message sizes.
+This mode has additional measurement overhead and should only be enabled when
+per-peer information is required.
+
 There exists an inverse relationship between the amount of computational
 work a rank has to perform and the amount of time it spends waiting for
 MPI requests to complete.  Hence, ranks which spend comparatively less

--- a/pyfr/backends/base/types.py
+++ b/pyfr/backends/base/types.py
@@ -2,6 +2,7 @@ from bisect import insort
 from collections import defaultdict, deque
 from copy import copy
 import time
+import weakref
 
 import numpy as np
 
@@ -259,11 +260,25 @@ class TiledMatrix(_StorageBase):
 class XchgMatrix(Matrix):
     _base_tags = {'xchg'}
 
+    def _makereq(self, req, pid, send):
+        req = autofree(req)
+
+        if self.backend.cfg.getbool('backend', 'collect-wait-times-per-peer',
+                                    False):
+            if not hasattr(self.backend, 'mpi_req_info'):
+                self.backend.mpi_req_info = {}
+
+            rid = id(req)
+            self.backend.mpi_req_info[rid] = (pid, send, self.hdata.nbytes)
+            weakref.finalize(req, self.backend.mpi_req_info.pop, rid, None)
+
+        return req
+
     def recvreq(self, comm, pid, tag):
-        return autofree(comm.Recv_init(self.hdata, pid, tag))
+        return self._makereq(comm.Recv_init(self.hdata, pid, tag), pid, False)
 
     def sendreq(self, comm, pid, tag):
-        return autofree(comm.Send_init(self.hdata, pid, tag))
+        return self._makereq(comm.Send_init(self.hdata, pid, tag), pid, True)
 
 
 class View:
@@ -411,18 +426,27 @@ class Graph:
         # MPI wrappers
         self._startall = mpi.Prequest.Startall
 
-        if backend.cfg.getbool('backend', 'collect-wait-times', False):
+        collect_wait = backend.cfg.getbool('backend', 'collect-wait-times',
+                                           False)
+        per_peer = backend.cfg.getbool(
+            'backend', 'collect-wait-times-per-peer', False
+        )
+        if per_peer and not collect_wait:
+            raise ValueError('collect-wait-times-per-peer requires '
+                             'collect-wait-times')
+
+        self._wait_times = None
+        self._send_wait_times = self._recv_wait_times = None
+        if collect_wait:
             n = backend.cfg.getint('backend', 'collect-wait-times-len', 10000)
-            self._wait_times = wait_times = deque(maxlen=n)
+            self._wait_times = deque(maxlen=n)
 
-            # Wrap the wait all function with a timing variant
-            def waitall(reqs):
-                if reqs:
-                    t = time.perf_counter_ns()
-                    mpi.Prequest.Waitall(reqs)
-                    wait_times.append((time.perf_counter_ns() - t) / 1e9)
-
-            self._waitall = waitall
+            if per_peer:
+                self._send_wait_times = defaultdict(lambda: deque(maxlen=n))
+                self._recv_wait_times = defaultdict(lambda: deque(maxlen=n))
+                self._waitall = self._waitall_detailed
+            else:
+                self._waitall = self._waitall_timed
         else:
             self._waitall = mpi.Prequest.Waitall
 
@@ -586,5 +610,56 @@ class Graph:
     def run(self, *args):
         pass
 
+    def _waitall_timed(self, reqs):
+        if reqs:
+            t = time.perf_counter_ns()
+            mpi.Prequest.Waitall(reqs)
+            self._wait_times.append((time.perf_counter_ns() - t) / 1e9)
+
+    def _waitall_detailed(self, reqs):
+        if not reqs:
+            return
+
+        reqinfo = self.backend.mpi_req_info
+        lreqs = list(reqs)
+        wait_ns = 0
+
+        while True:
+            t0 = time.perf_counter_ns()
+            idxs = mpi.Prequest.Waitsome(lreqs)
+            t1 = time.perf_counter_ns()
+
+            if idxs is None:
+                break
+
+            dt_ns = t1 - t0
+            wait_ns += dt_ns
+            share = dt_ns / (1e9*max(len(idxs), 1))
+
+            for i in idxs:
+                peer, send, _ = reqinfo[id(lreqs[i])]
+                times = (self._send_wait_times if send
+                         else self._recv_wait_times)
+                times[peer].append(share)
+                lreqs[i] = mpi.REQUEST_NULL
+
+        self._wait_times.append(wait_ns / 1e9)
+
     def get_wait_times(self):
-        return list(self._wait_times)
+        return list(self._wait_times or ())
+
+    def get_wait_times_by_peer(self):
+        def asdict(times):
+            return {p: list(t) for p, t in (times or {}).items()}
+
+        return asdict(self._send_wait_times), asdict(self._recv_wait_times)
+
+    def get_mpi_bytes(self):
+        send, recv = defaultdict(int), defaultdict(int)
+        reqinfo = getattr(self.backend, 'mpi_req_info', {})
+
+        for req in self.mpi_reqs:
+            peer, is_send, nbytes = reqinfo[id(req)]
+            (send if is_send else recv)[peer] += nbytes
+
+        return dict(send), dict(recv)

--- a/pyfr/integrators/base.py
+++ b/pyfr/integrators/base.py
@@ -385,6 +385,34 @@ class BaseIntegrator(metaclass=RegisterMeta):
                     stats.set('backend-wait-times', f'rhs-graph-{i}-{k}',
                               ','.join(f'{v[j]:.3g}' for v in ms))
 
+            if self.cfg.getbool('backend', 'collect-wait-times-per-peer',
+                                False):
+                peer_times = comm.allgather(
+                    self.system.rhs_wait_times_by_peer()
+                )
+                for i, gs in enumerate(zip(*peer_times)):
+                    for d, di in [('send', 0), ('recv', 1)]:
+                        for j, k in enumerate(['mean', 'stdev', 'median']):
+                            vals = []
+                            for rank, g in enumerate(gs):
+                                for peer, v in sorted(g[di].items()):
+                                    vals.append(f'({rank},{peer},{v[j]:.3g})')
+
+                            stats.set('backend-wait-times',
+                                      f'rhs-graph-{i}-{d}-{k}',
+                                      ','.join(vals))
+
+                mpi_bytes = comm.allgather(self.system.rhs_mpi_bytes())
+                for i, gs in enumerate(zip(*mpi_bytes)):
+                    for d, di in [('send', 0), ('recv', 1)]:
+                        vals = []
+                        for rank, g in enumerate(gs):
+                            for peer, v in sorted(g[di].items()):
+                                vals.append(f'({rank},{peer},{v})')
+
+                        stats.set('backend-wait-times',
+                                  f'rhs-graph-{i}-{d}-bytes', ','.join(vals))
+
         # Backend memory
         comm, _, _ = get_comm_rank_root()
         mem_info = comm.allgather(self.backend.memory_info())

--- a/pyfr/solvers/base/system.py
+++ b/pyfr/solvers/base/system.py
@@ -486,6 +486,48 @@ class BaseSystem:
 
         return stats
 
+    def rhs_wait_times_by_peer(self):
+        times = defaultdict(lambda: [defaultdict(list), defaultdict(list)])
+
+        # Group together timings for graphs which are semantically equivalent
+        for u, f in self._rhs_uin_fout:
+            for i, g in enumerate(self._rhs_graphs(u, f)):
+                for ptimes, samples in zip(times[i],
+                                           g.get_wait_times_by_peer()):
+                    for peer, vals in samples.items():
+                        ptimes[peer].extend(vals)
+
+        # Compute statistics for each graph, direction, and peer
+        stats = []
+        for i in range(max(times, default=-1) + 1):
+            gstats = []
+            for ptimes in times[i]:
+                pstats = {}
+                for peer, vals in ptimes.items():
+                    mean = statistics.mean(vals) if vals else 0
+                    stdev = (statistics.stdev(vals, mean)
+                             if len(vals) >= 2 else 0)
+                    median = statistics.median(vals) if vals else 0
+                    pstats[peer] = mean, stdev, median
+
+                gstats.append(pstats)
+            stats.append(tuple(gstats))
+
+        return stats
+
+    def rhs_mpi_bytes(self):
+        nbytes = {}
+
+        for u, f in self._rhs_uin_fout:
+            for i, g in enumerate(self._rhs_graphs(u, f)):
+                gb = g.get_mpi_bytes()
+                if i in nbytes and nbytes[i] != gb:
+                    raise RuntimeError('Inconsistent MPI request sizes across '
+                                       'equivalent RHS graphs')
+                nbytes[i] = gb
+
+        return [nbytes[i] for i in range(max(nbytes, default=-1) + 1)]
+
     def _compute_grads_graph(self, uinbank):
         raise NotImplementedError(f'Solver {self.name!r} does not compute '
                                   'corrected gradients of the solution')

--- a/pyfr/tests/test_mpi_wait_times.py
+++ b/pyfr/tests/test_mpi_wait_times.py
@@ -1,0 +1,193 @@
+import gc
+from types import SimpleNamespace
+
+import pytest
+
+import pyfr.backends.base.types as btypes
+from pyfr.backends.base.types import Graph, XchgMatrix
+from pyfr.solvers.base.system import BaseSystem
+
+
+class _Cfg:
+    def __init__(self, collect=True, per_peer=True, n=100):
+        self.collect = collect
+        self.per_peer = per_peer
+        self.n = n
+
+    def getbool(self, section, option, default=False):
+        return {
+            'collect-wait-times': self.collect,
+            'collect-wait-times-per-peer': self.per_peer,
+        }.get(option, default)
+
+    def getint(self, section, option, default=None):
+        return self.n if option == 'collect-wait-times-len' else default
+
+
+class _Req:
+    pass
+
+
+def test_xchg_matrix_records_request_metadata(monkeypatch):
+    backend = SimpleNamespace(cfg=_Cfg())
+    mat = XchgMatrix.__new__(XchgMatrix)
+    mat.backend = backend
+    mat.hdata = SimpleNamespace(nbytes=128)
+
+    class Comm:
+        def Recv_init(self, data, pid, tag):
+            return _Req()
+
+        def Send_init(self, data, pid, tag):
+            return _Req()
+
+    monkeypatch.setattr(btypes, 'autofree', lambda req: req)
+
+    recv = mat.recvreq(Comm(), 2, 10)
+    send = mat.sendreq(Comm(), 3, 11)
+
+    rid_recv, rid_send = id(recv), id(send)
+    assert backend.mpi_req_info[rid_recv] == (2, False, 128)
+    assert backend.mpi_req_info[rid_send] == (3, True, 128)
+
+    del recv, send
+    gc.collect()
+    assert rid_recv not in backend.mpi_req_info
+    assert rid_send not in backend.mpi_req_info
+
+
+def test_per_peer_tracking_requires_wait_tracking():
+    backend = SimpleNamespace(cfg=_Cfg(collect=False, per_peer=True))
+    with pytest.raises(ValueError, match='requires collect-wait-times'):
+        Graph(backend)
+
+
+def test_detailed_wait_attribution_conserves_time(monkeypatch):
+    reqs = [_Req() for _ in range(4)]
+    backend = SimpleNamespace(
+        cfg=_Cfg(),
+        mpi_req_info={
+            id(reqs[0]): (1, True, 10),
+            id(reqs[1]): (2, False, 20),
+            id(reqs[2]): (3, False, 30),
+            id(reqs[3]): (2, True, 40),
+        },
+    )
+    batches = iter([[0, 2], [1], [3], None])
+
+    class Prequest:
+        Startall = staticmethod(lambda reqs: None)
+        Waitall = staticmethod(lambda reqs: None)
+        Waitsome = staticmethod(lambda reqs: next(batches))
+
+    fake_mpi = SimpleNamespace(Prequest=Prequest, REQUEST_NULL=object())
+    ticks = iter([0, 100, 100, 400, 400, 450, 450, 450])
+    monkeypatch.setattr(btypes, 'mpi', fake_mpi)
+    monkeypatch.setattr(btypes.time, 'perf_counter_ns', lambda: next(ticks))
+
+    graph = Graph(backend)
+    graph.mpi_reqs = reqs
+    graph._waitall(reqs)
+
+    send, recv = graph.get_wait_times_by_peer()
+
+    assert graph.get_wait_times() == pytest.approx([450e-9])
+    assert send[1] == pytest.approx([50e-9])
+    assert send[2] == pytest.approx([50e-9])
+    assert recv[2] == pytest.approx([300e-9])
+    assert recv[3] == pytest.approx([50e-9])
+
+    attributed = sum(map(sum, send.values())) + sum(map(sum, recv.values()))
+    assert attributed == pytest.approx(graph.get_wait_times()[0])
+    assert graph.get_mpi_bytes() == ({1: 10, 2: 40}, {2: 20, 3: 30})
+
+
+class _FakeGraph:
+    def __init__(self, send=None, recv=None, nbytes=None):
+        self._send = send or {}
+        self._recv = recv or {}
+        self._nbytes = nbytes or ({}, {})
+
+    def get_wait_times_by_peer(self):
+        return self._send, self._recv
+
+    def get_mpi_bytes(self):
+        return self._nbytes
+
+
+class _FakeSystem:
+    _rhs_uin_fout = {(0, 1), (2, 2)}
+
+    def __init__(self, graphs):
+        self.graphs = graphs
+
+    def _rhs_graphs(self, uinbank, foutbank):
+        return self.graphs[uinbank, foutbank]
+
+
+def test_rhs_peer_stats_pool_equivalent_graphs():
+    nb0 = ({1: 64}, {1: 64})
+    nb1 = ({2: 96}, {2: 96})
+    graphs = {
+        (0, 1): (
+            _FakeGraph({1: [1.0, 3.0]}, {2: [2.0]}, nb0),
+            _FakeGraph({2: [4.0]}, {3: [8.0]}, nb1),
+            _FakeGraph(),
+        ),
+        (2, 2): (
+            _FakeGraph({1: [5.0]}, {2: [4.0]}, nb0),
+            _FakeGraph({2: [6.0]}, {3: [10.0]}, nb1),
+            _FakeGraph(),
+        ),
+    }
+    system = _FakeSystem(graphs)
+
+    stats = BaseSystem.rhs_wait_times_by_peer(system)
+    assert len(stats) == 3
+
+    send0, recv0 = stats[0]
+    assert send0[1] == pytest.approx((3.0, 2.0, 3.0))
+    assert recv0[2][0] == pytest.approx(3.0)
+    assert recv0[2][2] == pytest.approx(3.0)
+
+    send1, recv1 = stats[1]
+    assert send1[2][0] == pytest.approx(5.0)
+    assert send1[2][2] == pytest.approx(5.0)
+    assert recv1[3][0] == pytest.approx(9.0)
+    assert recv1[3][2] == pytest.approx(9.0)
+
+    assert stats[2] == ({}, {})
+    assert BaseSystem.rhs_mpi_bytes(system) == [nb0, nb1, ({}, {})]
+
+
+def test_rhs_mpi_bytes_reject_inconsistent_graph_variants():
+    graphs = {
+        (0, 1): (_FakeGraph(nbytes=({1: 64}, {1: 64})),),
+        (2, 2): (_FakeGraph(nbytes=({1: 128}, {1: 64})),),
+    }
+    system = _FakeSystem(graphs)
+
+    with pytest.raises(RuntimeError, match='Inconsistent MPI request sizes'):
+        BaseSystem.rhs_mpi_bytes(system)
+
+
+def test_regular_wait_tracking_uses_waitall(monkeypatch):
+    backend = SimpleNamespace(cfg=_Cfg(collect=True, per_peer=False))
+    calls = []
+
+    class Prequest:
+        Startall = staticmethod(lambda reqs: None)
+        Waitall = staticmethod(lambda reqs: calls.append(list(reqs)))
+
+    fake_mpi = SimpleNamespace(Prequest=Prequest)
+    ticks = iter([10, 60])
+    monkeypatch.setattr(btypes, 'mpi', fake_mpi)
+    monkeypatch.setattr(btypes.time, 'perf_counter_ns', lambda: next(ticks))
+
+    reqs = [_Req(), _Req()]
+    graph = Graph(backend)
+    graph._waitall(reqs)
+
+    assert calls == [reqs]
+    assert graph.get_wait_times() == pytest.approx([50e-9])
+    assert graph.get_wait_times_by_peer() == ({}, {})


### PR DESCRIPTION
This extends the existing MPI wait-time instrumentation with optional per-peer attribution.

When `collect-wait-times-per-peer = true`, PyFR uses `MPI_Waitsome` and attributes each blocking interval equally across the requests completed by that call. Send and receive statistics are retained separately for every RHS graph, with static per-peer message byte counts. Equivalent graph instances from different RHS register-bank pairs are pooled by graph index, matching the existing `rhs_wait_times()` semantics.

The existing `collect-wait-times = true` path is unchanged and continues to use `MPI_Waitall`; the more expensive per-peer attribution is explicitly opt-in.

The output remains graph-indexed rather than selecting a particular RHS graph. This is important because the number and role of communication-bearing graphs are system dependent; consumers can combine graph medians as appropriate.

Validation performed:
- focused tests for request metadata, metadata lifetime cleanup, legacy `Waitall` behaviour, equal-share attribution/conservation, graph/bank aggregation, and static byte consistency;
- two-rank OpenMP MPI runs for Euler and Navier-Stokes, confirming the expected active/dormant graph structure, reciprocal send/receive byte accounting, and finite final solution fields.
